### PR TITLE
Fix LDFLAGS in makefile.in to respect environment variables

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -67,7 +67,7 @@ INCLUDE_CFLAGS	= $(addprefix -I ,$(include_dirs))
 CONFIG_CFLAGS	= @CFLAGS@ @DEBUG_OPTION@ @ARCH_OPTION@
 # -g : debugging info
 CFLAGS		+= $(INCLUDE_CFLAGS) -Wall -fPIC $(CONFIG_CFLAGS)
-LDFLAGS		+= @LIBS@
+LDFLAGS		+= @LDFLAGS@ @LIBS@
 ARFLAGS		= r
 PATHSEP		= /
 


### PR DESCRIPTION
```LDPATHS="-L/opt/local/lib" ./configure``` had no effect, this patch fixes this.