### PR TITLE
configure.ac: use AC_CONFIG_MACRO_DIR

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,7 +27,7 @@
 #
 
 rm -f config.cache aclocal.m4
-aclocal -I./scripts
+aclocal
 autoconf
 autoheader
 #automake --foreign --add-missing

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@
 
 AC_INIT([liquid-dsp],[1.2.0],[support@liquidsdr.org])
 AC_CONFIG_SRCDIR([src/libliquid.c])
+AC_CONFIG_MACRO_DIR([scripts])
 
 # permit auxiliary scripts directory (e.g. config.sub, config.guess, install-sh)
 AC_CONFIG_AUX_DIR(scripts/)


### PR DESCRIPTION
Instead of having to explicitly pass -I./scripts when running aclocal,
use the AC_CONFIG_MACRO_DIR() macro in configure.ac. This allows to
use "autoreconf" normally, without any hacks.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>