### PR TITLE
make liquid-dsp build under -Wpedantic

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -690,8 +690,8 @@ void EQLMS(_train)(EQLMS()      _q,                             \
                    T *          _d,                             \
                    unsigned int _n);                            \
 
-LIQUID_EQLMS_DEFINE_API(EQLMS_MANGLE_RRRF, float);
-LIQUID_EQLMS_DEFINE_API(EQLMS_MANGLE_CCCF, liquid_float_complex);
+LIQUID_EQLMS_DEFINE_API(EQLMS_MANGLE_RRRF, float)
+LIQUID_EQLMS_DEFINE_API(EQLMS_MANGLE_CCCF, liquid_float_complex)
 
 
 // recursive least-squares (RLS)
@@ -764,8 +764,8 @@ void EQRLS(_train)(EQRLS()      _q,                             \
                    T *          _d,                             \
                    unsigned int _n);
 
-LIQUID_EQRLS_DEFINE_API(EQRLS_MANGLE_RRRF, float);
-LIQUID_EQRLS_DEFINE_API(EQRLS_MANGLE_CCCF, liquid_float_complex);
+LIQUID_EQRLS_DEFINE_API(EQRLS_MANGLE_RRRF, float)
+LIQUID_EQRLS_DEFINE_API(EQRLS_MANGLE_CCCF, liquid_float_complex)
 
 
 
@@ -6692,8 +6692,8 @@ void VECTOR(_normalize)(T *          _x,                        \
                         unsigned int _n,                        \
                         T *          _y);                       \
 
-LIQUID_VECTOR_DEFINE_API(VECTOR_MANGLE_RF, float,                float);
-LIQUID_VECTOR_DEFINE_API(VECTOR_MANGLE_CF, liquid_float_complex, float);
+LIQUID_VECTOR_DEFINE_API(VECTOR_MANGLE_RF, float,                float)
+LIQUID_VECTOR_DEFINE_API(VECTOR_MANGLE_CF, liquid_float_complex, float)
 
 // 
 // mixed types

--- a/makefile.in
+++ b/makefile.in
@@ -66,7 +66,7 @@ RANLIB		:= ranlib
 INCLUDE_CFLAGS	= $(addprefix -I ,$(include_dirs))
 CONFIG_CFLAGS	= @CFLAGS@ @DEBUG_OPTION@ @ARCH_OPTION@
 # -g : debugging info
-CFLAGS		+= $(INCLUDE_CFLAGS) -Wall -fPIC $(CONFIG_CFLAGS)
+CFLAGS		+= $(INCLUDE_CFLAGS) -Wall -Wpedantic -fPIC $(CONFIG_CFLAGS)
 LDFLAGS		+= @LDFLAGS@ @LIBS@
 ARFLAGS		= r
 PATHSEP		= /

--- a/src/framing/src/msource.c
+++ b/src/framing/src/msource.c
@@ -235,7 +235,7 @@ void MSOURCE(_remove)(MSOURCE() _q,
     _q->num_sources--;
 
     // shift sources down
-    for (i; i<_q->num_sources; i++)
+    for (; i<_q->num_sources; i++)
         _q->sources[i] = _q->sources[i+1];
 }
 

--- a/src/modem/src/fskdem.c
+++ b/src/modem/src/fskdem.c
@@ -223,13 +223,11 @@ unsigned int fskdem_demodulate(fskdem          _q,
 // get demodulator frequency error
 float fskdem_get_frequency_error(fskdem _q)
 {
-    // get index of peak bin
-    unsigned int index = _q->buf_freq[ _q->s_demod ];
 
     // extract peak value of previous, post FFT index
-    float vm = cabsf( (_q->s_demod + _q->K - 1) % _q->K );  // previous
-    float v0 = cabsf(  _q->s_demod                      );  // peak
-    float vp = cabsf( (_q->s_demod +         1) % _q->K );  // post
+    float vm = (_q->s_demod + _q->K - 1) % _q->K ;  // previous
+    float v0 =  _q->s_demod                      ;  // peak
+    float vp = (_q->s_demod +         1) % _q->K ;  // post
 
     // compute derivative
     // TODO: compensate for bin spacing


### PR DESCRIPTION
I love this project! I'm eager to try it out soon.

The changes to fskdem.c in this are not necessarily helpful. The warning message says all of the arguments in that call to `abs` are unsigned values. The `index` var was unused by anything.