### PR TITLE
use header modem to generate random header symbols

### DIFF
--- a/src/framing/src/ofdmflexframegen.c
+++ b/src/framing/src/ofdmflexframegen.c
@@ -620,8 +620,8 @@ void ofdmflexframegen_write_header(ofdmflexframegen _q,
             } else {
                 //printf("  random header symbol\n");
                 // load random symbol
-                unsigned int sym = modem_gen_rand_sym(_q->mod_payload);
-                modem_modulate(_q->mod_payload, sym, &_q->X[i]);
+                unsigned int sym = modem_gen_rand_sym(_q->mod_header);
+                modem_modulate(_q->mod_header, sym, &_q->X[i]);
             }
         } else {
             // ignore subcarrier (ofdmframegen handles nulls and pilots)


### PR DESCRIPTION
i don't think i quite understand why we need randomness at this point but in my testing, using the payload modem here sometimes caused strange results. i suspect that as we are in the header, we should use the header modem.