### PR TITLE
output-limited resampler execute mode

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -2997,6 +2997,27 @@ void RESAMP(_execute_block)(RESAMP()       _q,                  \
                             unsigned int   _nx,                 \
                             TO *           _y,                  \
                             unsigned int * _ny);                \
+                                                                \
+/* execute arbitrary resampler into specified output size   */  \
+/* will fill up to but not more than requested size _ny     */  \
+/* returns true if more samples can be fetched without      */  \
+/*    more inputs                                           */  \
+/* false otherwise                                          */  \
+/*  _q              :   resamp object                       */  \
+/*  _x              :   input buffer [size: _nx x 1]        */  \
+/*  _nx             :   input buffer size                   */  \
+/*  _ux             :   number of input samples read        */  \
+/*  _y              :   output sample array                 */  \
+/*  _ny             :   capacity of output sample array     */  \
+/*  _uy             :   number of output samples written    */  \
+int RESAMP(_execute_output_block)(RESAMP() _q,                  \
+                                  TI * _x,                      \
+                                  unsigned int _nx,             \
+                                  unsigned int * _ux,           \
+                                  TO * _y,                      \
+                                  unsigned int _ny,             \
+                                  unsigned int * _uy);          \
+
 
 LIQUID_RESAMP_DEFINE_API(RESAMP_MANGLE_RRRF,
                          float,


### PR DESCRIPTION
often if we want to talk to devices they might have a fixed buffer size
that they will accept. limiting to this size makes it easier to work
with them