### PR TITLE
const correctness for framegen

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3613,8 +3613,8 @@ unsigned int flexframegen_getframelen(flexframegen _q);
 //  _payload        :   payload data [size: _payload_len x 1]
 //  _payload_len    :   payload data length
 void flexframegen_assemble(flexframegen    _q,
-                           unsigned char * _header,
-                           unsigned char * _payload,
+                           const unsigned char * _header,
+                           const unsigned char * _payload,
                            unsigned int    _payload_len);
 
 // write samples of assembled frame, two samples at a time, returning
@@ -3861,8 +3861,8 @@ unsigned int ofdmflexframegen_getframelen(ofdmflexframegen _q);
 //  _payload        :   payload data [size: _payload_len x 1]
 //  _payload_len    :   payload data length
 void ofdmflexframegen_assemble(ofdmflexframegen _q,
-                               unsigned char * _header,
-                               unsigned char * _payload,
+                               const unsigned char * _header,
+                               const unsigned char * _payload,
                                unsigned int    _payload_len);
 
 // write symbols of assembled frame

--- a/src/framing/src/flexframegen.c
+++ b/src/framing/src/flexframegen.c
@@ -286,8 +286,8 @@ unsigned int flexframegen_getframelen(flexframegen _q)
 //  _payload        :   variable payload buffer (configured by setprops method)
 //  _payload_dec_len:   length of payload
 void flexframegen_assemble(flexframegen    _q,
-                           unsigned char * _header,
-                           unsigned char * _payload,
+                           const unsigned char * _header,
+                           const unsigned char * _payload,
                            unsigned int    _payload_dec_len)
 {
     // reset object

--- a/src/framing/src/ofdmflexframegen.c
+++ b/src/framing/src/ofdmflexframegen.c
@@ -351,8 +351,8 @@ unsigned int ofdmflexframegen_getframelen(ofdmflexframegen _q)
 //  _payload        :   payload data [size: _payload_len x 1]
 //  _payload_len    :   payload data length
 void ofdmflexframegen_assemble(ofdmflexframegen _q,
-                               unsigned char *  _header,
-                               unsigned char *  _payload,
+                               const unsigned char *  _header,
+                               const unsigned char *  _payload,
                                unsigned int     _payload_len)
 {
     // check payload length and reconfigure if necessary


### PR DESCRIPTION
it's common for code which takes user data for the incoming data to be
declared const very early on. in order to maintain const correctness, it
has to remain const through every call from there on.