### PR TITLE
WIP: Fix bugs & warnings found with static analysis

### DIFF
--- a/src/filter/src/ellip.c
+++ b/src/filter/src/ellip.c
@@ -312,8 +312,8 @@ void ellip_azpkf(unsigned int _n,
 #endif
 
     float Nexact = (K1p/K1)/(Kp/K); // 4.69604063
-    float N = ceilf(Nexact);        // 5
-    N = _n;
+    float N = ceilf(Nexact);        // 5 TODO: dead initialization,
+    N = _n;                         //         which one is correct?
 #if LIQUID_DEBUG_ELLIP_PRINT
     printf("N (exact)   : %12.8f\n", Nexact);
     printf("N           : %12.8f\n", N);

--- a/src/filter/src/iirdes.c
+++ b/src/filter/src/iirdes.c
@@ -380,9 +380,6 @@ void iirdes_dzpk2sosf(float complex * _zd,
 
     // add remaining zero/pole pair if order is odd
     if (r) {
-        p0 = -pp[_n-1];
-        z0 = -zp[_n-1];
-        
         _A[3*i+0] =  1.0;
         _A[3*i+1] = -pp[_n-1];
         _A[3*i+2] =  0.0;
@@ -620,8 +617,10 @@ void liquid_iirdes(liquid_iirdes_filtertype _ftype,
         memmove(pd, pd1, 2*_n*sizeof(float complex));
 
         // update paramters : n -> 2*n
+#if LIQUID_IIRDES_DEBUG_PRINT
         r = 0;
         L = _n;
+#endif
         _n = 2*_n;
     }
 

--- a/src/filter/src/rkaiser.c
+++ b/src/filter/src/rkaiser.c
@@ -166,32 +166,33 @@ float rkaiser_approximate_rho(unsigned int _m,
     // compute bandwidth adjustment estimate
     float c0=0.0f, c1=0.0f, c2=0.0f;
     switch (_m) {
-    case 1:     c0=0.75749731;  c1=0.06134303;  c2=-0.08729663;
-    case 2:     c0=0.81151861;  c1=0.07437658;  c2=-0.01427088;
-    case 3:     c0=0.84249538;  c1=0.07684185;  c2=-0.00536879;
-    case 4:     c0=0.86140782;  c1=0.07144126;  c2=-0.00558652;
-    case 5:     c0=0.87457740;  c1=0.06578694;  c2=-0.00650447;
-    case 6:     c0=0.88438797;  c1=0.06074265;  c2=-0.00736405;
-    case 7:     c0=0.89216620;  c1=0.05669236;  c2=-0.00791222;
-    case 8:     c0=0.89874983;  c1=0.05361696;  c2=-0.00815301;
-    case 9:     c0=0.90460032;  c1=0.05167952;  c2=-0.00807893;
-    case 10:    c0=0.91034430;  c1=0.05130753;  c2=-0.00746192;
-    case 11:    c0=0.91587675;  c1=0.05180436;  c2=-0.00670711;
-    case 12:    c0=0.92121875;  c1=0.05273801;  c2=-0.00588351;
-    case 13:    c0=0.92638195;  c1=0.05400764;  c2=-0.00508452;
-    case 14:    c0=0.93123555;  c1=0.05516163;  c2=-0.00437306;
-    case 15:    c0=0.93564993;  c1=0.05596561;  c2=-0.00388152;
-    case 16:    c0=0.93976742;  c1=0.05662274;  c2=-0.00348280;
-    case 17:    c0=0.94351703;  c1=0.05694120;  c2=-0.00318821;
-    case 18:    c0=0.94557273;  c1=0.05227591;  c2=-0.00400676;
-    case 19:    c0=0.95001614;  c1=0.05681641;  c2=-0.00300628;
-    case 20:    c0=0.95281708;  c1=0.05637607;  c2=-0.00304790;
-    case 21:    c0=0.95536256;  c1=0.05575880;  c2=-0.00312988;
-    case 22:    c0=0.95754206;  c1=0.05426060;  c2=-0.00385945;
+    case 1:     c0=0.75749731;  c1=0.06134303;  c2=-0.08729663; break;
+    case 2:     c0=0.81151861;  c1=0.07437658;  c2=-0.01427088; break;
+    case 3:     c0=0.84249538;  c1=0.07684185;  c2=-0.00536879; break;
+    case 4:     c0=0.86140782;  c1=0.07144126;  c2=-0.00558652; break;
+    case 5:     c0=0.87457740;  c1=0.06578694;  c2=-0.00650447; break;
+    case 6:     c0=0.88438797;  c1=0.06074265;  c2=-0.00736405; break;
+    case 7:     c0=0.89216620;  c1=0.05669236;  c2=-0.00791222; break;
+    case 8:     c0=0.89874983;  c1=0.05361696;  c2=-0.00815301; break;
+    case 9:     c0=0.90460032;  c1=0.05167952;  c2=-0.00807893; break;
+    case 10:    c0=0.91034430;  c1=0.05130753;  c2=-0.00746192; break;
+    case 11:    c0=0.91587675;  c1=0.05180436;  c2=-0.00670711; break;
+    case 12:    c0=0.92121875;  c1=0.05273801;  c2=-0.00588351; break;
+    case 13:    c0=0.92638195;  c1=0.05400764;  c2=-0.00508452; break;
+    case 14:    c0=0.93123555;  c1=0.05516163;  c2=-0.00437306; break;
+    case 15:    c0=0.93564993;  c1=0.05596561;  c2=-0.00388152; break;
+    case 16:    c0=0.93976742;  c1=0.05662274;  c2=-0.00348280; break;
+    case 17:    c0=0.94351703;  c1=0.05694120;  c2=-0.00318821; break;
+    case 18:    c0=0.94557273;  c1=0.05227591;  c2=-0.00400676; break;
+    case 19:    c0=0.95001614;  c1=0.05681641;  c2=-0.00300628; break;
+    case 20:    c0=0.95281708;  c1=0.05637607;  c2=-0.00304790; break;
+    case 21:    c0=0.95536256;  c1=0.05575880;  c2=-0.00312988; break;
+    case 22:    c0=0.95754206;  c1=0.05426060;  c2=-0.00385945; break;
     default:
         c0 =  0.056873*logf(_m+1e-3f) + 0.781388;
         c1 =  0.05426f;
         c2 = -0.00386f;
+        break;
     }
 
     float b = logf(_beta);
@@ -291,13 +292,13 @@ void liquid_firdes_rkaiser_bisection(unsigned int _k,
 
         // find the minimum of [ya,y1,yb], update bounds
         if (y1 < ya && y1 < yb) {
-            x0 = xa;    y0 = ya;
-            x2 = xb;    y2 = yb;
+            x0 = xa;
+            x2 = xb;
         } else if (ya < yb) {
-            x2 = x1;    y2 = y1;
+            x2 = x1;
             x1 = xa;    y1 = ya;
         } else {
-            x0 = x1;    y0 = y1;
+            x0 = x1;
             x1 = xb;    y1 = yb;
         }
 
@@ -383,7 +384,6 @@ void liquid_firdes_rkaiser_quadratic(unsigned int _k,
     // run parabolic search to find bandwidth adjustment x_hat which
     // minimizes the inter-symbol interference of the filter
     unsigned int p, pmax=14;
-    float x_hat = rho_hat;
     float dx  = 0.2f;       // bounding size
     float del = 0.0f;       // computed step size
     float tol = 1e-6f;      // tolerance
@@ -434,7 +434,7 @@ void liquid_firdes_rkaiser_quadratic(unsigned int _k,
                     y2*(x0 - x1);
 
         // update estimate
-        x_hat = 0.5f * ta / tb;
+        float x_hat = 0.5f * ta / tb;
 
         // ensure x_hat is within boundary (this will fail if y1 > y0 || y1 > y2)
         if (x_hat < x0 || x_hat > x2) {

--- a/src/framing/src/bpacketgen.c
+++ b/src/framing/src/bpacketgen.c
@@ -101,7 +101,7 @@ bpacketgen bpacketgen_create(unsigned int _m,
     bpacketgen_compute_packet_len(q);
 
     // arrays
-    q->pnsequence = (unsigned char*) malloc((q->pnsequence_len)*sizeof(unsigned char*));
+    q->pnsequence = malloc((q->pnsequence_len)*sizeof(unsigned char));
 
     // create m-sequence generator
     // TODO : configure sequence from generator polynomial
@@ -157,7 +157,7 @@ bpacketgen bpacketgen_recreate(bpacketgen _q,
     // arrays
     _q->g = 0;
     _q->pnsequence_len = 8;
-    _q->pnsequence = (unsigned char*) realloc(_q->pnsequence, (_q->pnsequence_len)*sizeof(unsigned char*));
+    _q->pnsequence = realloc(_q->pnsequence, (_q->pnsequence_len)*sizeof(unsigned char));
 
     // re-create m-sequence generator
     // TODO : configure sequence from generator polynomial

--- a/src/framing/src/bpacketsync.c
+++ b/src/framing/src/bpacketsync.c
@@ -122,9 +122,9 @@ bpacketsync bpacketsync_create(unsigned int _m,
     q->header_len = packetizer_compute_enc_msg_len(6, LIQUID_CRC_16, LIQUID_FEC_NONE, LIQUID_FEC_HAMMING128);
 
     // arrays
-    q->pnsequence  = (unsigned char*) malloc((q->pnsequence_len)*sizeof(unsigned char*));
-    q->payload_enc = (unsigned char*) malloc((q->enc_msg_len)*sizeof(unsigned char*));
-    q->payload_dec = (unsigned char*) malloc((q->dec_msg_len)*sizeof(unsigned char*));
+    q->pnsequence  = malloc((q->pnsequence_len)*sizeof(unsigned char));
+    q->payload_enc = malloc((q->enc_msg_len)*sizeof(unsigned char));
+    q->payload_dec = malloc((q->dec_msg_len)*sizeof(unsigned char));
 
     // create m-sequence generator
     // TODO : configure sequence from generator polynomial

--- a/src/framing/src/qdetector_cccf.c
+++ b/src/framing/src/qdetector_cccf.c
@@ -554,7 +554,6 @@ void qdetector_cccf_execute_align(qdetector_cccf _q,
     float        vpos = cabsf(_q->buf_freq_0[ipos]);
     a            =  0.5f*(vpos + vneg) - v0;
     b            =  0.5f*(vpos - vneg);
-    c            =  v0;
     float idx    = -b / (2.0f*a); //-0.5f*(vpos - vneg) / (vpos + vneg - 2*v0);
     float index  = (float)i0 + idx;
     _q->dphi_hat = (i0 > _q->nfft/2 ? index-(float)_q->nfft : index) * 2*M_PI / (float)(_q->nfft);

--- a/src/modem/src/fskdem.c
+++ b/src/modem/src/fskdem.c
@@ -224,7 +224,7 @@ unsigned int fskdem_demodulate(fskdem          _q,
 float fskdem_get_frequency_error(fskdem _q)
 {
     // get index of peak bin
-    unsigned int index = _q->buf_freq[ _q->s_demod ];
+    unsigned int index = _q->buf_freq[ _q->s_demod ]; // TODO: Dead initiliaztion, is this for not yet implemented functionality?
 
     // extract peak value of previous, post FFT index
     float vm = cabsf( (_q->s_demod + _q->K - 1) % _q->K );  // previous


### PR DESCRIPTION
Building liquid with clang's static analysis tool `scan-build` emits about 85 warnings. Many are from missing `break`s in `rkaiser.c`. The rest are either dead assignments, dead initializations, and 'allocator sizeof operand mismatch'.

This PR is labeled WIP because in some cases I'm not sure what the fix is. In those cases, I added a comment without changing any code. Please let me know if I deleted anything that should have been kept in the code.