### PR TITLE
allow use of kissfft

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,13 +106,15 @@ then
 fi
 
 # Check for optional header files, libraries, programs
-AC_CHECK_HEADERS(fec.h fftw3.h)
+AC_CHECK_HEADERS(fec.h fftw3.h kiss_fft.h)
 AC_CHECK_LIB([fftw3f], [fftwf_plan_dft_1d], [],
              [AC_MSG_WARN(fftw3 library useful but not required)],
              [])
 AC_CHECK_LIB([fec], [create_viterbi27], [],
              [AC_MSG_WARN(fec library useful but not required)],
              [])
+AC_CHECK_LIB([kissfft], [kiss_fft_alloc], [],
+             [], [])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE

--- a/makefile.in
+++ b/makefile.in
@@ -324,6 +324,7 @@ fft_objects :=							\
 	src/fft/src/spgramcf.o					\
 	src/fft/src/spgramf.o					\
 	src/fft/src/fft_utilities.o				\
+	src/fft/src/kiss.o						\
 
 # explicit targets and dependencies
 fft_includes :=							\
@@ -350,6 +351,8 @@ src/fft/src/mdct.o : %.o : %.c $(include_headers)
 src/fft/src/spgramcf.o : %.o : %.c $(include_headers) src/fft/src/asgram.c src/fft/src/spgram.c
 
 src/fft/src/spgramf.o : %.o : %.c $(include_headers) src/fft/src/asgram.c src/fft/src/spgram.c
+
+src/fft/src/kiss.o : %.o : %.c $(include_headers)
 
 # fft autotest scripts
 fft_autotests :=						\

--- a/src/fft/src/kiss.c
+++ b/src/fft/src/kiss.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2007 - 2015 Joseph Gaeddert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+//
+// kiss.c : wrapper for kiss fft lib
+//
+#include <stdio.h>
+#include <stdlib.h>
+#include "liquid.internal.h"
+#ifdef HAVE_LIBKISSFFT
+
+#define KISS_FFT(name)           LIQUID_CONCAT(kiss_fft,name)
+
+#define T                   float           /* primitive type */
+#define TC                  float complex   /* primitive type (complex) */
+
+typedef union {
+    kiss_fft_cpx * cpx;
+    TC * c;
+} foo;
+
+struct KISS_FFT(_plan_s)
+{
+    // common data
+    kiss_fft_cfg kiss_cfg;
+    foo x;             // input array pointer
+    foo y;             // output array pointer
+};
+
+
+// create KISS_FFT plan, regular complex one-dimensional transform
+//  _nfft   :   FFT size
+//  _x      :   input array [size: _nfft x 1]
+//  _y      :   output array [size: _nfft x 1]
+//  _dir    :   fft direction: {KISS_FFT_FORWARD, KISS_FFT_BACKWARD}
+//  _flags  :   fft method (not used)
+KISS_FFT(_plan) KISS_FFT(_create_plan)(unsigned int _nfft,
+                                       TC *         _x,
+                                       TC *         _y,
+                                       int          _dir,
+                                       int          _flags)
+{
+    int is_inverse = (_dir == FFT_DIR_BACKWARD);
+    KISS_FFT(_plan) q = (KISS_FFT(_plan)) malloc(sizeof(struct KISS_FFT(_plan_s)));
+
+    q->kiss_cfg = kiss_fft_alloc(_nfft, is_inverse, NULL, NULL);
+
+    q->x.c = _x;
+    q->y.c = _y;
+
+    return q;
+}
+
+// destroy KISS_FFT plan
+void KISS_FFT(_destroy_plan)(KISS_FFT(_plan) _q)
+{
+    kiss_fft_free(_q->kiss_cfg);
+    free(_q);
+}
+
+void KISS_FFT(_execute)(KISS_FFT(_plan) _q)
+{
+    kiss_fft(_q->kiss_cfg, _q->x.cpx, _q->y.cpx);
+}
+#endif // HAVE_LIBKISSFFT

--- a/src/framing/src/qpilotsync.c
+++ b/src/framing/src/qpilotsync.c
@@ -49,7 +49,7 @@ struct qpilotsync_s {
     unsigned int    nfft;           // FFT size
     float complex * buf_time;       // FFT time buffer
     float complex * buf_freq;       // FFT freq buffer
-    fftplan         fft;            // transform object
+    FFT_PLAN         fft;            // transform object
 
     float           dphi_hat;       // carrier frequency offset estimate
     float           phi_hat;        // carrier phase offset estimate
@@ -104,7 +104,7 @@ qpilotsync qpilotsync_create(unsigned int _payload_len,
     q->nfft = 1 << liquid_nextpow2(q->num_pilots + (q->num_pilots>>1));
     q->buf_time = (float complex*) malloc(q->nfft*sizeof(float complex));
     q->buf_freq = (float complex*) malloc(q->nfft*sizeof(float complex));
-    q->fft      = fft_create_plan(q->nfft, q->buf_time, q->buf_freq, LIQUID_FFT_FORWARD, 0);
+    q->fft      = FFT_CREATE_PLAN(q->nfft, q->buf_time, q->buf_freq, LIQUID_FFT_FORWARD, 0);
 
     // reset and return pointer to main object
     qpilotsync_reset(q);
@@ -134,7 +134,7 @@ void qpilotsync_destroy(qpilotsync _q)
     free(_q->buf_freq);
 
     // destroy objects
-    fft_destroy_plan(_q->fft);
+    FFT_DESTROY_PLAN(_q->fft);
     
     // free main object memory
     free(_q);
@@ -196,7 +196,7 @@ void qpilotsync_execute(qpilotsync      _q,
     }
 
     // compute frequency offset by computing transform and finding peak
-    fft_execute(_q->fft);
+    FFT_EXECUTE(_q->fft);
     unsigned int i0 = 0;
     float        y0 = 0;
     for (i=0; i<_q->nfft; i++) {


### PR DESCRIPTION
In my particular strange example, running in emscripten, it appears that kissfft offers a slight performance advantage over the native fft and both have a distinct advantage over fftw, which plays poorly with emscripten's emulated host environment. kissfft very nearly offers the same signature as fftw so it is relatively easy to integrate it

this also changes some uses of the native fft to the compile-time determined fft, e.g. fft_execute -> FFT_EXECUTE