### PR TITLE
nice-to-haves for gmskframegen

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3768,8 +3768,8 @@ int  gmskframegen_is_assembled(gmskframegen _fg);
 void gmskframegen_print(gmskframegen _fg);
 void gmskframegen_reset(gmskframegen _fg);
 void gmskframegen_assemble(gmskframegen    _fg,
-                           unsigned char * _header,
-                           unsigned char * _payload,
+                           const unsigned char * _header,
+                           const unsigned char * _payload,
                            unsigned int    _payload_len,
                            crc_scheme      _check,
                            fec_scheme      _fec0,

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3764,6 +3764,7 @@ typedef struct gmskframegen_s * gmskframegen;
 // create GMSK frame generator
 gmskframegen gmskframegen_create();
 void gmskframegen_destroy(gmskframegen _fg);
+int  gmskframegen_is_assembled(gmskframegen _fg);
 void gmskframegen_print(gmskframegen _fg);
 void gmskframegen_reset(gmskframegen _fg);
 void gmskframegen_assemble(gmskframegen    _fg,

--- a/src/framing/src/gmskframegen.c
+++ b/src/framing/src/gmskframegen.c
@@ -175,6 +175,12 @@ void gmskframegen_reset(gmskframegen _q)
     _q->symbol_counter  = 0;
 }
 
+// is frame assembled?
+int gmskframegen_is_assembled(gmskframegen _q)
+{
+    return _q->frame_assembled;
+}
+
 // print gmskframegen object internals
 void gmskframegen_print(gmskframegen _q)
 {

--- a/src/framing/src/gmskframegen.c
+++ b/src/framing/src/gmskframegen.c
@@ -211,8 +211,8 @@ void gmskframegen_print(gmskframegen _q)
 //  _fec0           :   inner forward error correction
 //  _fec1           :   outer forward error correction
 void gmskframegen_assemble(gmskframegen    _q,
-                           unsigned char * _header,
-                           unsigned char * _payload,
+                           const unsigned char * _header,
+                           const unsigned char * _payload,
                            unsigned int    _payload_len,
                            crc_scheme      _check,
                            fec_scheme      _fec0,


### PR DESCRIPTION
* const correctness as with flexframegen/ofdmflexframegen
* _is_assembled