### PR TITLE
constify all payload paths

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -1029,7 +1029,7 @@ fec_scheme   packetizer_get_fec1       (packetizer _p);
 //  _msg    :   input message (uncoded bytes)
 //  _pkt    :   encoded output message
 void packetizer_encode(packetizer _p,
-                       unsigned char * _msg,
+                       const unsigned char * _msg,
                        unsigned char * _pkt);
 
 // packetizer_decode()
@@ -3436,7 +3436,7 @@ unsigned int qpacketmodem_get_modscheme(qpacketmodem _q);
 //  _payload    :   unencoded payload bytes
 //  _syms       :   encoded but un-modulated payload symbol indices
 void qpacketmodem_encode_syms(qpacketmodem    _q,
-                              unsigned char * _payload,
+                              const unsigned char * _payload,
                               unsigned char * _syms);
 
 // decode packet from demodulated frame symbol indices (hard-decision decoding)
@@ -3460,7 +3460,7 @@ int qpacketmodem_decode_bits(qpacketmodem    _q,
 //  _payload    :   unencoded payload bytes
 //  _frame      :   encoded/modulated payload symbols
 void qpacketmodem_encode(qpacketmodem           _q,
-                         unsigned char *        _payload,
+                         const unsigned char *        _payload,
                          liquid_float_complex * _frame);
 
 // decode packet from modulated frame samples, returning flag if CRC passed

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3768,8 +3768,8 @@ int  gmskframegen_is_assembled(gmskframegen _fg);
 void gmskframegen_print(gmskframegen _fg);
 void gmskframegen_reset(gmskframegen _fg);
 void gmskframegen_assemble(gmskframegen    _fg,
-                           unsigned char * _header,
-                           unsigned char * _payload,
+                           const unsigned char * _header,
+                           const unsigned char * _payload,
                            unsigned int    _payload_len,
                            crc_scheme      _check,
                            fec_scheme      _fec0,

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3764,6 +3764,7 @@ typedef struct gmskframegen_s * gmskframegen;
 // create GMSK frame generator
 gmskframegen gmskframegen_create();
 void gmskframegen_destroy(gmskframegen _fg);
+int  gmskframegen_is_assembled(gmskframegen _fg);
 void gmskframegen_print(gmskframegen _fg);
 void gmskframegen_reset(gmskframegen _fg);
 void gmskframegen_assemble(gmskframegen    _fg,

--- a/src/fec/src/packetizer.c
+++ b/src/fec/src/packetizer.c
@@ -245,7 +245,7 @@ fec_scheme packetizer_get_fec1(packetizer _p)
 //  _msg    :   input message (uncoded bytes)
 //  _pkt    :   encoded output message
 void packetizer_encode(packetizer _p,
-                       unsigned char * _msg,
+                       const unsigned char * _msg,
                        unsigned char * _pkt)
 {
     unsigned int i;

--- a/src/framing/src/gmskframegen.c
+++ b/src/framing/src/gmskframegen.c
@@ -36,7 +36,7 @@
 #define DEBUG_GMSKFRAMEGEN    0
 
 // gmskframegen
-void gmskframegen_encode_header( gmskframegen _q, unsigned char * _header);
+void gmskframegen_encode_header( gmskframegen _q, const unsigned char * _header);
 void gmskframegen_write_preamble(gmskframegen _q, float complex * _y);
 void gmskframegen_write_header(  gmskframegen _q, float complex * _y);
 void gmskframegen_write_payload( gmskframegen _q, float complex * _y);
@@ -316,7 +316,7 @@ int gmskframegen_write_samples(gmskframegen _q,
 //
 
 void gmskframegen_encode_header(gmskframegen    _q,
-                                unsigned char * _header)
+                                const unsigned char * _header)
 {
     // first 'n' bytes user data
     memmove(_q->header_dec, _header, GMSKFRAME_H_USER);

--- a/src/framing/src/gmskframegen.c
+++ b/src/framing/src/gmskframegen.c
@@ -175,6 +175,12 @@ void gmskframegen_reset(gmskframegen _q)
     _q->symbol_counter  = 0;
 }
 
+// is frame assembled?
+int gmskframegen_is_assembled(gmskframegen _q)
+{
+    return _q->frame_assembled;
+}
+
 // print gmskframegen object internals
 void gmskframegen_print(gmskframegen _q)
 {

--- a/src/framing/src/gmskframegen.c
+++ b/src/framing/src/gmskframegen.c
@@ -211,8 +211,8 @@ void gmskframegen_print(gmskframegen _q)
 //  _fec0           :   inner forward error correction
 //  _fec1           :   outer forward error correction
 void gmskframegen_assemble(gmskframegen    _q,
-                           unsigned char * _header,
-                           unsigned char * _payload,
+                           const unsigned char * _header,
+                           const unsigned char * _payload,
                            unsigned int    _payload_len,
                            crc_scheme      _check,
                            fec_scheme      _fec0,

--- a/src/framing/src/qpacketmodem.c
+++ b/src/framing/src/qpacketmodem.c
@@ -193,7 +193,7 @@ unsigned int qpacketmodem_get_modscheme(qpacketmodem _q)
 //  _payload    :   unencoded payload bytes
 //  _syms       :   encoded but un-modulated payload symbol indices
 void qpacketmodem_encode_syms(qpacketmodem    _q,
-                              unsigned char * _payload,
+                              const unsigned char * _payload,
                               unsigned char * _syms)
 {
     // encode payload
@@ -249,7 +249,7 @@ int qpacketmodem_decode_bits(qpacketmodem    _q,
 //  _payload    :   unencoded payload bytes
 //  _frame      :   encoded/modulated payload symbols
 void qpacketmodem_encode(qpacketmodem    _q,
-                         unsigned char * _payload,
+                         const unsigned char * _payload,
                          float complex * _frame)
 {
     // encode payload symbols into internal buffer


### PR DESCRIPTION
(builds on top of gmsk_improvements)

this constifies all user payload paths, silencing related const warnings