### PR TITLE
Fixed array allocators in IIR Filter creator.

### DIFF
--- a/src/filter/src/iirfilt.c
+++ b/src/filter/src/iirfilt.c
@@ -98,8 +98,8 @@ IIRFILT() IIRFILT(_create)(TC *         _b,
     q->type = IIRFILT_TYPE_NORM;
 
     // allocate memory for numerator, denominator
-    q->b = (TC *) malloc((q->na)*sizeof(TC));
-    q->a = (TC *) malloc((q->nb)*sizeof(TC));
+    q->a = (TC *) malloc((q->na)*sizeof(TC));
+    q->b = (TC *) malloc((q->nb)*sizeof(TC));
 
     // normalize coefficients to _a[0]
     TC a0 = _a[0];


### PR DESCRIPTION
The array allocators for IIR Filter create were using the wrong bounds.