### PR TITLE
Enable build and install in one step

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -1251,7 +1251,7 @@ help:
 ## TARGET : install   - installs the libraries and header files in the host system
 ##
 
-install:
+install: all
 	@echo "installing..."
 	@echo ""
 	mkdir -p $(DESTDIR)$(exec_prefix)$(libdir)


### PR DESCRIPTION
Running `make install` should now also build the library. Currently
`make install` fails if the library wasn't built before - e.g. after
initial checkout.

Fixes #52.