### PR TITLE
Fix issues with undefined behavior and compiler warnings

### DIFF
--- a/autotest/autotest.h
+++ b/autotest/autotest.h
@@ -179,6 +179,20 @@ void liquid_autotest_print_array(unsigned char * _x,
 #define CONTEND_DELTA_FL(F,L,X,Y,D)       TEST_DELTA(F,L,#X,(X),#Y,(Y),#D,(D))
 #define CONTEND_DELTA(X,Y,D)              CONTEND_DELTA_FL(__FILE__,__LINE__,X,Y,D)
 
+// CONTEND_DELTA_COMPLEX
+#define TEST_DELTA_COMPLEX(F,L,EX,X,EY,Y,ED,D)                      \
+{                                                                   \
+    if (cabs((X)-(Y))>(D))                                          \
+    {                                                               \
+        liquid_autotest_failed_expr(F,L,"abs(" #X "-" #Y ")",       \
+                                    cabs(X-Y),"<",ED,D);            \
+    } else {                                                        \
+        liquid_autotest_passed();                                   \
+    }                                                               \
+}
+#define CONTEND_DELTA_COMPLEX_FL(F,L,X,Y,D)       TEST_DELTA_COMPLEX(F,L,#X,(X),#Y,(Y),#D,(D))
+#define CONTEND_DELTA_COMPLEX(X,Y,D)              CONTEND_DELTA_COMPLEX_FL(__FILE__,__LINE__,X,Y,D)
+
 // CONTEND_EXPRESSION
 #define TEST_EXPRESSION(F,L,EX,X)                                   \
 {                                                                   \

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -1027,9 +1027,9 @@ void fec_decode_soft(fec _q,
 //  _fec0   :   inner forward error-correction code
 //  _fec1   :   outer forward error-correction code
 unsigned int packetizer_compute_enc_msg_len(unsigned int _n,
-                                            int _crc,
-                                            int _fec0,
-                                            int _fec1);
+                                            crc_scheme _crc,
+                                            fec_scheme _fec0,
+                                            fec_scheme _fec1);
 
 // computes the number of decoded bytes before packetizing
 //
@@ -1038,9 +1038,9 @@ unsigned int packetizer_compute_enc_msg_len(unsigned int _n,
 //  _fec0   :   inner forward error-correction code
 //  _fec1   :   outer forward error-correction code
 unsigned int packetizer_compute_dec_msg_len(unsigned int _k,
-                                            int _crc,
-                                            int _fec0,
-                                            int _fec1);
+                                            crc_scheme _crc,
+                                            fec_scheme _fec0,
+                                            fec_scheme _fec1);
 
 typedef struct packetizer_s * packetizer;
 
@@ -1051,9 +1051,9 @@ typedef struct packetizer_s * packetizer;
 //  _fec0   :   inner forward error-correction code
 //  _fec1   :   outer forward error-correction code
 packetizer packetizer_create(unsigned int _dec_msg_len,
-                             int _crc,
-                             int _fec0,
-                             int _fec1);
+                             crc_scheme _crc,
+                             fec_scheme _fec0,
+                             fec_scheme _fec1);
 
 // re-create packetizer object
 //
@@ -1064,9 +1064,9 @@ packetizer packetizer_create(unsigned int _dec_msg_len,
 //  _fec1   :   outer forward error-correction code
 packetizer packetizer_recreate(packetizer _p,
                                unsigned int _dec_msg_len,
-                               int _crc,
-                               int _fec0,
-                               int _fec1);
+                               crc_scheme _crc,
+                               fec_scheme _fec0,
+                               fec_scheme _fec1);
 
 // destroy packetizer object
 void packetizer_destroy(packetizer _p);
@@ -3774,9 +3774,9 @@ typedef struct bpacketgen_s * bpacketgen;
 //  _fec1           :   outer forward error-correction code scheme
 bpacketgen bpacketgen_create(unsigned int _m,
                              unsigned int _dec_msg_len,
-                             int _crc,
-                             int _fec0,
-                             int _fec1);
+                             crc_scheme _crc,
+                             fec_scheme _fec0,
+                             fec_scheme _fec1);
 
 // re-create bpacketgen object from old object
 //  _q              :   old bpacketgen object
@@ -3788,9 +3788,9 @@ bpacketgen bpacketgen_create(unsigned int _m,
 bpacketgen bpacketgen_recreate(bpacketgen _q,
                                unsigned int _m,
                                unsigned int _dec_msg_len,
-                               int _crc,
-                               int _fec0,
-                               int _fec1);
+                               crc_scheme _crc,
+                               fec_scheme _fec0,
+                               fec_scheme _fec1);
 
 // destroy bpacketgen object, freeing all internally-allocated memory
 void bpacketgen_destroy(bpacketgen _q);

--- a/scripts/autoscript.c
+++ b/scripts/autoscript.c
@@ -307,7 +307,7 @@ void autoscript_parsefile(autoscript _q,
     char basename[1024];    // base script name
     char * cptr = NULL;     // readline return value
     char * sptr = NULL;     // tag string pointer
-    int cterm;              // terminating character
+    unsigned int cterm;     // terminating character
     unsigned int n=0;       // line number
     do {
         // increment line number

--- a/src/dotprod/tests/dotprod_cccf_autotest.c
+++ b/src/dotprod/tests/dotprod_cccf_autotest.c
@@ -134,7 +134,7 @@ void autotest_dotprod_cccf_struct_lengths()
     // n = 32
     dp = dotprod_cccf_create(h,32);
     dotprod_cccf_execute(dp, x, &y);
-    CONTEND_DELTA(y, v32, tol);
+    CONTEND_DELTA_COMPLEX(y, v32, tol);
     dotprod_cccf_destroy(dp);
     if (liquid_autotest_verbose) {
         printf("  dotprod-cccf-32 : %12.8f + j%12.8f (expected %12.8f + j%12.8f)\n",
@@ -144,7 +144,7 @@ void autotest_dotprod_cccf_struct_lengths()
     // n = 33
     dp = dotprod_cccf_create(h,33);
     dotprod_cccf_execute(dp, x, &y);
-    CONTEND_DELTA(y, v33, tol);
+    CONTEND_DELTA_COMPLEX(y, v33, tol);
     dotprod_cccf_destroy(dp);
     if (liquid_autotest_verbose) {
         printf("  dotprod-cccf-33 : %12.8f + j%12.8f (expected %12.8f + j%12.8f)\n",
@@ -154,7 +154,7 @@ void autotest_dotprod_cccf_struct_lengths()
     // n = 34
     dp = dotprod_cccf_create(h,34);
     dotprod_cccf_execute(dp, x, &y);
-    CONTEND_DELTA(y, v34, tol);
+    CONTEND_DELTA_COMPLEX(y, v34, tol);
     dotprod_cccf_destroy(dp);
     if (liquid_autotest_verbose) {
         printf("  dotprod-cccf-34 : %12.8f + j%12.8f (expected %12.8f + j%12.8f)\n",
@@ -164,7 +164,7 @@ void autotest_dotprod_cccf_struct_lengths()
     // n = 35
     dp = dotprod_cccf_create(h,35);
     dotprod_cccf_execute(dp, x, &y);
-    CONTEND_DELTA(y, v35, tol);
+    CONTEND_DELTA_COMPLEX(y, v35, tol);
     dotprod_cccf_destroy(dp);
     if (liquid_autotest_verbose) {
         printf("  dotprod-cccf-35 : %12.8f + j%12.8f (expected %12.8f + j%12.8f)\n",

--- a/src/fec/src/fec.c
+++ b/src/fec/src/fec.c
@@ -642,6 +642,8 @@ void fec_decode_soft(fec _q,
     } else {
         // pack bytes and use hard-decision decoding
         unsigned enc_msg_len = fec_get_enc_msg_length(_q->scheme, _dec_msg_len);
+        if (enc_msg_len == 0)
+            return;
         unsigned char msg_enc_hard[enc_msg_len];
         unsigned int i;
         for (i=0; i<enc_msg_len; i++) {

--- a/src/fec/src/fec_hamming3126.c
+++ b/src/fec/src/fec_hamming3126.c
@@ -103,7 +103,7 @@ unsigned int fec_hamming3126_encode_symbol(unsigned int _sym_dec)
 unsigned int fec_hamming3126_decode_symbol(unsigned int _sym_enc)
 {
     // validate input
-    if (_sym_enc >= (1<<31)) {
+    if (_sym_enc >= (1u<<31)) {
         fprintf(stderr,"error, fec_hamming_decode(), input symbol too large\n");
         exit(1);
     }

--- a/src/fec/src/packetizer.c
+++ b/src/fec/src/packetizer.c
@@ -40,9 +40,9 @@ void packetizer_realloc_buffers(packetizer _p, unsigned int _len);
 //  _fec0   :   inner forward error-correction code
 //  _fec1   :   outer forward error-correction code
 unsigned int packetizer_compute_enc_msg_len(unsigned int _n,
-                                            int _crc,
-                                            int _fec0,
-                                            int _fec1)
+                                            crc_scheme _crc,
+                                            fec_scheme _fec0,
+                                            fec_scheme _fec1)
 {
     unsigned int k = _n + crc_get_length(_crc);
     unsigned int n0 = fec_get_enc_msg_length(_fec0, k);
@@ -58,9 +58,9 @@ unsigned int packetizer_compute_enc_msg_len(unsigned int _n,
 //  _fec0   :   inner forward error-correction code
 //  _fec1   :   outer forward error-correction code
 unsigned int packetizer_compute_dec_msg_len(unsigned int _k,
-                                            int _crc,
-                                            int _fec0,
-                                            int _fec1)
+                                            crc_scheme _crc,
+                                            fec_scheme _fec0,
+                                            fec_scheme _fec1)
 {
     unsigned int n_hat = 0;
     unsigned int k_hat = 0;
@@ -91,9 +91,9 @@ unsigned int packetizer_compute_dec_msg_len(unsigned int _k,
 //  _fec0   :   inner forward error-correction code
 //  _fec1   :   outer forward error-correction code
 packetizer packetizer_create(unsigned int _n,
-                             int _crc,
-                             int _fec0,
-                             int _fec1)
+                             crc_scheme _crc,
+                             fec_scheme _fec0,
+                             fec_scheme _fec1)
 {
     packetizer p = (packetizer) malloc(sizeof(struct packetizer_s));
 
@@ -148,9 +148,9 @@ packetizer packetizer_create(unsigned int _n,
 //  _fec1   :   outer forward error-correction code
 packetizer packetizer_recreate(packetizer _p,
                                unsigned int _n,
-                               int _crc,
-                               int _fec0,
-                               int _fec1)
+                               crc_scheme _crc,
+                               fec_scheme _fec0,
+                               fec_scheme _fec1)
 {
     if (_p == NULL) {
         // packetizer was never created
@@ -389,7 +389,7 @@ int packetizer_decode_soft(packetizer            _p,
                                 key);
 }
 
-void packetizer_set_scheme(packetizer _p, int _fec0, int _fec1)
+void packetizer_set_scheme(packetizer _p, fec_scheme _fec0, fec_scheme _fec1)
 {
     //
 }

--- a/src/filter/src/firdes.c
+++ b/src/filter/src/firdes.c
@@ -422,16 +422,16 @@ float liquid_filter_autocorr(float *      _h,
                              int          _lag)
 {
     // auto-correlation is even symmetric
-    _lag = abs(_lag);
+    unsigned int _ulag = abs(_lag);
 
     // lag outside of filter length is zero
-    if (_lag >= _h_len) return 0.0f;
+    if (_ulag >= _h_len) return 0.0f;
 
     // compute auto-correlation
     float rxx=0.0f; // initialize auto-correlation to zero
     unsigned int i;
-    for (i=_lag; i<_h_len; i++)
-        rxx += _h[i] * _h[i-_lag];
+    for (i=_ulag; i<_h_len; i++)
+        rxx += _h[i] * _h[i-_ulag];
 
     return rxx;
 }
@@ -476,7 +476,7 @@ float liquid_filter_crosscorr(float *      _h,
     int n;
     if (_lag < 0)
         n = (int)_g_len + _lag;
-    else if (_lag < (_h_len-_g_len))
+    else if ((unsigned int)_lag < (_h_len-_g_len))
         n = _g_len;
     else
         n = _h_len - _lag;

--- a/src/filter/src/firdespm.c
+++ b/src/filter/src/firdespm.c
@@ -724,11 +724,11 @@ void firdespm_compute_taps(firdespm _q, float * _h)
     // TODO : flesh out computation for other filter types
     unsigned int j;
     if (_q->btype == LIQUID_FIRDESPM_BANDPASS) {
-        // odd filter length, even symmetry
+        // even/odd filter length, even symmetry
         for (i=0; i<_q->h_len; i++) {
             double v = G[0];
             double f = ((double)i - (double)(p-1) + 0.5*(1-_q->s)) / (double)(_q->h_len);
-            for (j=1; j<_q->r; j++)
+            for (j=1; j<p; j++)
                 v += 2.0 * G[j] * cos(2*M_PI*f*j);
             _h[i] = v / (double)(_q->h_len);
         }

--- a/src/filter/src/iirdes.c
+++ b/src/filter/src/iirdes.c
@@ -324,7 +324,7 @@ void iirdes_dzpk2sosf(float complex * _zd,
                       float * _B,
                       float * _A)
 {
-    int i;
+    unsigned int i;
     float tol=1e-6f; // tolerance for conjuate pair computation
 
     // find/group complex conjugate pairs (poles)

--- a/src/filter/src/resamp.c
+++ b/src/filter/src/resamp.c
@@ -55,7 +55,7 @@ struct RESAMP(_s) {
     // floating-point phase
     float tau;          // accumulated timing phase, 0 <= tau < 1
     float bf;           // soft filterbank index, bf = tau*npfb = b + mu
-    int b;              // base filterbank index, 0 <= b < npfb
+    unsigned int b;     // base filterbank index, 0 <= b < npfb
     float mu;           // fractional filterbank interpolation value, 0 <= mu < 1
     TO y0;              // filterbank output at index b
     TO y1;              // filterbank output at index b+1
@@ -358,7 +358,7 @@ void RESAMP(_update_timing_state)(RESAMP() _q)
     _q->bf  = _q->tau * (float)(_q->npfb);
 
     // split into integer filterbank index and fractional interpolation
-    _q->b   = (int)floorf(_q->bf);      // base index
+    _q->b   = (unsigned int)floorf(_q->bf);      // base index
     _q->mu  = _q->bf - (float)(_q->b);  // fractional index
 }
 

--- a/src/filter/src/symsync.c
+++ b/src/filter/src/symsync.c
@@ -88,7 +88,7 @@ struct SYMSYNC(_s) {
     float tau;                  // accumulated timing phase (0 <= tau <= 1)
     float tau_decim;            // timing phase, retained for get_tau() method
     float bf;                   // soft filterbank index
-    int   b;                    // filterbank index
+    unsigned int b;             // filterbank index
 
     // loop filter
     float q;                    // instantaneous timing error
@@ -504,7 +504,7 @@ void SYMSYNC(_step)(SYMSYNC()      _q,
         // update states
         _q->tau += _q->del;                     // instantaneous fractional offset
         _q->bf  = _q->tau * (float)(_q->npfb);  // filterbank index (soft)
-        _q->b   = (int)roundf(_q->bf);          // filterbank index
+        _q->b   = (unsigned int)roundf(_q->bf); // filterbank index
         n++;                                    // number of output samples
     }
 

--- a/src/filter/tests/filter_crosscorr_autotest.c
+++ b/src/filter/tests/filter_crosscorr_autotest.c
@@ -58,7 +58,7 @@ void autotest_filter_crosscorr_rrrf()
         printf("testing corr(x,y):\n");
 
     // corr(x,y)
-    int i;
+    unsigned int i;
     for (i=0; i<rxy_len; i++) {
         int lag = i - y_len + 1;
         rxy[i] = liquid_filter_crosscorr(x,x_len, y,y_len, lag);

--- a/src/framing/src/bpacketgen.c
+++ b/src/framing/src/bpacketgen.c
@@ -75,9 +75,9 @@ struct bpacketgen_s {
 //  _fec1           :   outer forward error-correction code scheme
 bpacketgen bpacketgen_create(unsigned int _m,
                              unsigned int _dec_msg_len,
-                             int _crc,
-                             int _fec0,
-                             int _fec1)
+                             crc_scheme _crc,
+                             fec_scheme _fec0,
+                             fec_scheme _fec1)
 {
     // validate input
 
@@ -134,9 +134,9 @@ bpacketgen bpacketgen_create(unsigned int _m,
 bpacketgen bpacketgen_recreate(bpacketgen _q,
                                unsigned int _m,
                                unsigned int _dec_msg_len,
-                               int _crc,
-                               int _fec0,
-                               int _fec1)
+                               crc_scheme _crc,
+                               fec_scheme _fec0,
+                               fec_scheme _fec1)
 {
     // validate input
 

--- a/src/framing/src/gmskframesync.c
+++ b/src/framing/src/gmskframesync.c
@@ -425,7 +425,7 @@ int gmskframesync_update_symsync(gmskframesync _q,
         // compute actual filterbank index
         _q->pfb_index = roundf(_q->pfb_soft);
 
-        // contrain index to be in [0, npfb-1]
+        // constrain index to be in [0, npfb-1]
         while (_q->pfb_index < 0) {
             _q->pfb_index += _q->npfb;
             _q->pfb_soft  += _q->npfb;
@@ -433,7 +433,7 @@ int gmskframesync_update_symsync(gmskframesync _q,
             // adjust pfb output timer
             _q->pfb_timer--;
         }
-        while (_q->pfb_index > _q->npfb-1) {
+        while ((unsigned int)_q->pfb_index > _q->npfb-1) {
             _q->pfb_index -= _q->npfb;
             _q->pfb_soft  -= _q->npfb;
 

--- a/src/math/src/poly.expand.c
+++ b/src/math/src/poly.expand.c
@@ -44,7 +44,7 @@ void POLY(_expandbinomial)(unsigned int _n,
         return;
     }
 
-    int i, j;
+    unsigned int i, j;
     // initialize coefficients array to [1,0,0,....0]
     for (i=0; i<=_n; i++)
         _c[i] = (i==0) ? 1 : 0;
@@ -74,7 +74,7 @@ void POLY(_expandbinomial_pm)(unsigned int _m,
         return;
     }
 
-    int i, j;
+    unsigned int i, j;
     // initialize coefficients array to [1,0,0,....0]
     for (i=0; i<=n; i++)
         _c[i] = (i==0) ? 1 : 0;
@@ -153,7 +153,7 @@ void POLY(_expandroots)(T * _a,
         return;
     }
 
-    int i, j;
+    unsigned int i, j;
     // initialize coefficients array to [1,0,0,....0]
     for (i=0; i<=_n; i++)
         _c[i] = (i==0) ? 1 : 0;

--- a/src/math/src/poly.findroots.c
+++ b/src/math/src/poly.findroots.c
@@ -256,14 +256,14 @@ void POLY(_findroots_bairstow_recursion)(T *          _p,
     b[n] = b[n-1] = 0;
     f[n] = f[n-1] = 0;
 
-    int i;
+    unsigned int i;
     unsigned int k=0;
     unsigned int max_num_iterations=50;
     int continue_iterating = 1;
 
     while (continue_iterating) {
         // update reduced polynomial coefficients
-        for (i=n-2; i>=0; i--) {
+        for (i=n-2; i < n; i--) {
             b[i] = _p[i+2] - u*b[i+1] - v*b[i+2];
             f[i] =  b[i+2] - u*f[i+1] - v*f[i+2];
         }

--- a/src/matrix/tests/matrixcf_autotest.c
+++ b/src/matrix/tests/matrixcf_autotest.c
@@ -333,7 +333,7 @@ void autotest_matrixcf_qrdecomp()
     float complex I4[16];
     matrixcf_eye(I4,4);
     for (i=0; i<16; i++)
-        CONTEND_DELTA( QQT_test[i], I4[i], tol );
+        CONTEND_DELTA_COMPLEX( QQT_test[i], I4[i], tol );
 
     // ensure Q and R are correct
     for (i=0; i<16; i++) {

--- a/src/modem/src/modem_arb.c
+++ b/src/modem/src/modem_arb.c
@@ -30,7 +30,7 @@ MODEM() MODEM(_create_arbitrary)(TC * _table,
 {
     // strip out bits/symbol
     unsigned int m = liquid_nextpow2(_M);
-    if ( (1<<m) != _M ) {
+    if ( (1u<<m) != _M ) {
         // TODO : eventually support non radix-2 constellation sizes
         fprintf(stderr,"error: modem_create_arbitrary(), input constellation size must be power of 2\n");
         exit(1);

--- a/src/multichannel/tests/ofdmframesync_autotest.c
+++ b/src/multichannel/tests/ofdmframesync_autotest.c
@@ -128,7 +128,7 @@ void ofdmframesync_acquire_test(unsigned int _num_subcarriers,
     for (i=0; i<M; i++) {
         if (p[i] == OFDMFRAME_SCTYPE_DATA) {
             float e = crealf( (X[i] - X_test[i])*conjf(X[i] - X_test[i]) );
-            CONTEND_DELTA( cabsf(e), 0.0f, tol );
+            CONTEND_DELTA( fabsf(e), 0.0f, tol );
         }
     }
 

--- a/src/optim/src/gasearch.c
+++ b/src/optim/src/gasearch.c
@@ -71,8 +71,8 @@ gasearch gasearch_create_advanced(gasearch_utility _utility,
     gasearch ga;
     ga = (gasearch) malloc( sizeof(struct gasearch_s) );
 
-    if (_population_size > LIQUID_GA_SEARCH_MAX_POPULATION_SIZE) {
-        fprintf(stderr,"error: gasearch_create(), population size exceeds maximum\n");
+    if (_population_size == 0 || _population_size > LIQUID_GA_SEARCH_MAX_POPULATION_SIZE) {
+        fprintf(stderr,"error: gasearch_create(), population size is invalid\n");
         exit(1);
     } else if (_mutation_rate < 0.0f || _mutation_rate > 1.0f) {
         fprintf(stderr,"error: gasearch_create(), mutation rate must be in [0,1]\n");

--- a/src/optim/src/gradsearch.c
+++ b/src/optim/src/gradsearch.c
@@ -315,6 +315,9 @@ float gradsearch_norm(float *      _v,
     for (i=0; i<_n; i++)
         vnorm += _v[i]*_v[i];
 
+    if (vnorm == 0.0f)
+        return vnorm;
+
     vnorm = sqrtf(vnorm);
 
     for (i=0; i<_n; i++)

--- a/src/sequence/src/bsequence.c
+++ b/src/sequence/src/bsequence.c
@@ -166,7 +166,7 @@ void bsequence_push(bsequence _bs,
 void bsequence_circshift(bsequence _bs)
 {
     // extract most-significant (left-most) bit
-    unsigned int msb_mask = 1 << (_bs->num_bits_msb-1);
+    unsigned int msb_mask = 1u << (_bs->num_bits_msb-1);
     unsigned int b = (_bs->s[0] & msb_mask) >> (_bs->num_bits_msb-1);
 
     // push bit into sequence

--- a/src/sequence/tests/complementary_codes_autotest.c
+++ b/src/sequence/tests/complementary_codes_autotest.c
@@ -52,7 +52,7 @@ void complementary_codes_test(unsigned int _n)
         raa = 2*bsequence_correlate(a,ax) - _n;
         rbb = 2*bsequence_correlate(b,bx) - _n;
 
-        if (i==0) { CONTEND_EQUALITY(raa+rbb,2*_n); }
+        if (i==0) { CONTEND_EQUALITY((unsigned int)(raa+rbb),2*_n); }
         else      { CONTEND_EQUALITY(raa+rbb,0);    }
 
         bsequence_circshift(ax);

--- a/src/sequence/tests/msequence_autotest.c
+++ b/src/sequence/tests/msequence_autotest.c
@@ -64,7 +64,7 @@ void msequence_test_autocorrelation(unsigned int _m)
     // when sequences are aligned, autocorrelation is equal to length
     signed int rxy;
     rxy = bsequence_correlate(bs1, bs2);
-    CONTEND_EQUALITY( rxy, n )
+    CONTEND_EQUALITY( (unsigned int)rxy, n )
 
     // when sequences are misaligned, autocorrelation is equal to -1
     unsigned int i;

--- a/src/utility/src/byte_utilities.c
+++ b/src/utility/src/byte_utilities.c
@@ -212,24 +212,24 @@ unsigned char liquid_reverse_byte(unsigned char _x)
 // reverse integer with 16 bits of data
 unsigned int liquid_reverse_uint16(unsigned int _x)
 {
-    return (liquid_reverse_byte_gentab[(_x     ) & 0xff] << 8) |
-           (liquid_reverse_byte_gentab[(_x >> 8) & 0xff]     );
+    return ((unsigned int) liquid_reverse_byte_gentab[(_x     ) & 0xff] << 8) |
+           ((unsigned int) liquid_reverse_byte_gentab[(_x >> 8) & 0xff]     );
 }
 
 // reverse integer with 24 bits of data
 unsigned int liquid_reverse_uint24(unsigned int _x)
 {
-    return (liquid_reverse_byte_gentab[(_x      ) & 0xff] << 16) |
-           (liquid_reverse_byte_gentab[(_x >>  8) & 0xff] <<  8) |
-           (liquid_reverse_byte_gentab[(_x >> 16) & 0xff]      );
+    return ((unsigned int) liquid_reverse_byte_gentab[(_x      ) & 0xff] << 16) |
+           ((unsigned int) liquid_reverse_byte_gentab[(_x >>  8) & 0xff] <<  8) |
+           ((unsigned int) liquid_reverse_byte_gentab[(_x >> 16) & 0xff]      );
 }
 
 // reverse integer with 32 bits of data
 unsigned int liquid_reverse_uint32(unsigned int _x)
 {
-    return (liquid_reverse_byte_gentab[(_x      ) & 0xff] << 24) |
-           (liquid_reverse_byte_gentab[(_x >>  8) & 0xff] << 16) |
-           (liquid_reverse_byte_gentab[(_x >> 16) & 0xff] <<  8) |
-           (liquid_reverse_byte_gentab[(_x >> 24) & 0xff]      );
+    return ((unsigned int) liquid_reverse_byte_gentab[(_x      ) & 0xff] << 24) |
+           ((unsigned int) liquid_reverse_byte_gentab[(_x >>  8) & 0xff] << 16) |
+           ((unsigned int) liquid_reverse_byte_gentab[(_x >> 16) & 0xff] <<  8) |
+           ((unsigned int) liquid_reverse_byte_gentab[(_x >> 24) & 0xff]      );
 }
 


### PR DESCRIPTION
I tested the changes with `make test` on both x86_64 and arm.

Note that on arm (`-ffast-math -mcpu=cortex-a7 -mfloat-abi=hard -mfpu-neon-vfpv4`), I get ~1360 / 84663 failures, and on x86_64 (`-march=corei7-avx`), I get 1 / 84663 failures (`dotprod_cccf_struct_lengths`). It appears that the failures are all due to issues with floating-point tolerance, but I haven't verified each test results.