### PR TITLE
Header props

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3858,6 +3858,10 @@ void ofdmflexframegen_getprops(ofdmflexframegen _q,
 void ofdmflexframegen_setprops(ofdmflexframegen _q,
                                ofdmflexframegenprops_s * _props);
 
+// set user-defined header length
+void ofdmflexframegen_set_header_len(ofdmflexframegen _q,
+                                     unsigned int     _len);
+
 // get length of frame (symbols)
 //  _q              :   OFDM frame generator object
 unsigned int ofdmflexframegen_getframelen(ofdmflexframegen _q);
@@ -3900,6 +3904,10 @@ ofdmflexframesync ofdmflexframesync_create(unsigned int       _M,
 
 void ofdmflexframesync_destroy(ofdmflexframesync _q);
 void ofdmflexframesync_print(ofdmflexframesync _q);
+// set user-defined header length
+void ofdmflexframesync_set_header_len(ofdmflexframesync _q,
+                                      unsigned int      _len);
+
 void ofdmflexframesync_reset(ofdmflexframesync _q);
 void ofdmflexframesync_execute(ofdmflexframesync _q,
                                liquid_float_complex * _x,

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3772,6 +3772,7 @@ typedef struct gmskframegen_s * gmskframegen;
 gmskframegen gmskframegen_create();
 void gmskframegen_destroy(gmskframegen _fg);
 void gmskframegen_print(gmskframegen _fg);
+void gmskframegen_set_header_len(gmskframegen _fg, unsigned int _len);
 void gmskframegen_reset(gmskframegen _fg);
 void gmskframegen_assemble(gmskframegen    _fg,
                            unsigned char * _header,
@@ -3798,6 +3799,7 @@ gmskframesync gmskframesync_create(framesync_callback _callback,
                                    void *             _userdata);
 void gmskframesync_destroy(gmskframesync _q);
 void gmskframesync_print(gmskframesync _q);
+void gmskframesync_set_header_len(gmskframesync _q, unsigned int _len);
 void gmskframesync_reset(gmskframesync _q);
 void gmskframesync_execute(gmskframesync _q,
                            liquid_float_complex * _x,

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3700,6 +3700,10 @@ int flexframegen_setprops(flexframegen _q, flexframegenprops_s * _props);
 // set length of user-defined portion of header
 void flexframegen_set_header_len(flexframegen _q, unsigned int _len);
 
+// set properties for header section
+int flexframegen_set_header_props(flexframegen          _q,
+                                  flexframegenprops_s * _props);
+
 // get length of assembled frame (samples)
 unsigned int flexframegen_getframelen(flexframegen _q);
 
@@ -3745,6 +3749,18 @@ void flexframesync_reset(flexframesync _q);
 // change length of user-defined region in header
 void flexframesync_set_header_len(flexframesync _q,
                                   unsigned int  _len);
+
+// enable or disable soft decoding of header
+void flexframesync_decode_header_soft(flexframesync _q,
+                                      int           _soft);
+
+// enable or disable soft decoding of payload
+void flexframesync_decode_payload_soft(flexframesync _q,
+                                       int           _soft);
+
+// set properties for header section
+int flexframesync_set_header_props(flexframesync          _q,
+                                   flexframegenprops_s * _props);
 
 // push samples through frame synchronizer
 //  _q      :   frame synchronizer object
@@ -3958,6 +3974,9 @@ void ofdmflexframegen_setprops(ofdmflexframegen _q,
 void ofdmflexframegen_set_header_len(ofdmflexframegen _q,
                                      unsigned int     _len);
 
+void ofdmflexframegen_set_header_props(ofdmflexframegen _q,
+                                       ofdmflexframegenprops_s * _props);
+
 // get length of frame (symbols)
 //  _q              :   OFDM frame generator object
 unsigned int ofdmflexframegen_getframelen(ofdmflexframegen _q);
@@ -4003,6 +4022,15 @@ void ofdmflexframesync_print(ofdmflexframesync _q);
 // set user-defined header length
 void ofdmflexframesync_set_header_len(ofdmflexframesync _q,
                                       unsigned int      _len);
+
+void ofdmflexframesync_decode_header_soft(ofdmflexframesync _q,
+                                           int _soft);
+
+void ofdmflexframesync_decode_payload_soft(ofdmflexframesync _q,
+                                           int _soft);
+
+void ofdmflexframesync_set_header_props(ofdmflexframesync _q,
+                                        ofdmflexframegenprops_s * _props);
 
 void ofdmflexframesync_reset(ofdmflexframesync _q);
 void ofdmflexframesync_execute(ofdmflexframesync _q,

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3604,6 +3604,9 @@ void flexframegen_getprops(flexframegen _q, flexframegenprops_s * _props);
 // set frame properties
 int flexframegen_setprops(flexframegen _q, flexframegenprops_s * _props);
 
+// set length of user-defined portion of header
+void flexframegen_set_header_len(flexframegen _q, unsigned int _len);
+
 // get length of assembled frame (samples)
 unsigned int flexframegen_getframelen(flexframegen _q);
 
@@ -3645,6 +3648,10 @@ void flexframesync_print(flexframesync _q);
 
 // reset frame synchronizer internal state
 void flexframesync_reset(flexframesync _q);
+
+// change length of user-defined region in header
+void flexframesync_set_header_len(flexframesync _q,
+                                  unsigned int  _len);
 
 // push samples through frame synchronizer
 //  _q      :   frame synchronizer object

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -1129,6 +1129,7 @@ void bpacketsync_reconfig(bpacketsync _q);
 #define FLEXFRAME_H_CRC          (LIQUID_CRC_32)         // header CRC
 #define FLEXFRAME_H_FEC0         (LIQUID_FEC_SECDED7264) // header FEC (inner)
 #define FLEXFRAME_H_FEC1         (LIQUID_FEC_HAMMING84)  // header FEC (outer)
+#define FLEXFRAME_H_MOD          (LIQUID_MODEM_QPSK)     // modulation scheme
 
 
 // 
@@ -1154,7 +1155,8 @@ void bpacketsync_reconfig(bpacketsync _q);
 #define OFDMFLEXFRAME_H_USER_DEFAULT (8)                         // default length for user-defined array
 #define OFDMFLEXFRAME_H_DEC          (6)                         // decoded length
 #define OFDMFLEXFRAME_H_CRC          (LIQUID_CRC_32)             // header CRC
-#define OFDMFLEXFRAME_H_FEC          (LIQUID_FEC_GOLAY2412)      // header FEC
+#define OFDMFLEXFRAME_H_FEC0         (LIQUID_FEC_GOLAY2412)      // header FEC (inner)
+#define OFDMFLEXFRAME_H_FEC1         (LIQUID_FEC_NONE)           // header FEC (outer)
 #define OFDMFLEXFRAME_H_MOD          (LIQUID_MODEM_BPSK)         // modulation scheme
 
 //

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -1138,12 +1138,10 @@ void bpacketsync_reconfig(bpacketsync _q);
 #define GMSKFRAME_VERSION   (3)
 
 // header description
-#define GMSKFRAME_H_USER    (8)                     // user-defined array
-#define GMSKFRAME_H_DEC     (GMSKFRAME_H_USER+5)    // decoded length
-#define GMSKFRAME_H_CRC     (LIQUID_CRC_32)         // header CRC
-#define GMSKFRAME_H_FEC     (LIQUID_FEC_HAMMING128) // header FEC
-#define GMSKFRAME_H_ENC     (26)                    // encoded length (bytes)
-#define GMSKFRAME_H_SYM     (208)                   // number of encoded bits
+#define GMSKFRAME_H_USER_DEFAULT   (8)                     // user-defined array
+#define GMSKFRAME_H_DEC            (5)                     // decoded length
+#define GMSKFRAME_H_CRC            (LIQUID_CRC_32)         // header CRC
+#define GMSKFRAME_H_FEC            (LIQUID_FEC_HAMMING128) // header FEC
 
 
 // 

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -1124,11 +1124,11 @@ void bpacketsync_reconfig(bpacketsync _q);
 //       which also generates a 54-byte frame. Improves header decoding
 //       by about 1 dB (99% probability of decoding with SNR = -1 dB);
 //       however this requires that the 'libfec' libraries are installed.
-#define FLEXFRAME_H_USER    (14)                    // user-defined array
-#define FLEXFRAME_H_DEC     (FLEXFRAME_H_USER+6)    // decoded length
-#define FLEXFRAME_H_CRC     (LIQUID_CRC_32)         // header CRC
-#define FLEXFRAME_H_FEC0    (LIQUID_FEC_SECDED7264) // header FEC (inner)
-#define FLEXFRAME_H_FEC1    (LIQUID_FEC_HAMMING84)  // header FEC (outer)
+#define FLEXFRAME_H_USER_DEFAULT (14)                    // default length for user-defined array
+#define FLEXFRAME_H_DEC          (6)                     // decoded length
+#define FLEXFRAME_H_CRC          (LIQUID_CRC_32)         // header CRC
+#define FLEXFRAME_H_FEC0         (LIQUID_FEC_SECDED7264) // header FEC (inner)
+#define FLEXFRAME_H_FEC1         (LIQUID_FEC_HAMMING84)  // header FEC (outer)
 
 
 // 

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -1153,14 +1153,11 @@ void bpacketsync_reconfig(bpacketsync _q);
 #define OFDMFLEXFRAME_PROTOCOL  (104)
 
 // header description
-#define OFDMFLEXFRAME_H_USER    (8)                         // user-defined array
-#define OFDMFLEXFRAME_H_DEC     (OFDMFLEXFRAME_H_USER+6)    // decoded length
-#define OFDMFLEXFRAME_H_CRC     (LIQUID_CRC_32)             // header CRC
-#define OFDMFLEXFRAME_H_FEC     (LIQUID_FEC_GOLAY2412)      // header FEC
-#define OFDMFLEXFRAME_H_ENC     (36)                        // encoded length
-#define OFDMFLEXFRAME_H_MOD     (LIQUID_MODEM_BPSK)         // modulation scheme
-#define OFDMFLEXFRAME_H_BPS     (1)                         // modulation depth
-#define OFDMFLEXFRAME_H_SYM     (288)                       // number of symbols
+#define OFDMFLEXFRAME_H_USER_DEFAULT (8)                         // default length for user-defined array
+#define OFDMFLEXFRAME_H_DEC          (6)                         // decoded length
+#define OFDMFLEXFRAME_H_CRC          (LIQUID_CRC_32)             // header CRC
+#define OFDMFLEXFRAME_H_FEC          (LIQUID_FEC_GOLAY2412)      // header FEC
+#define OFDMFLEXFRAME_H_MOD          (LIQUID_MODEM_BPSK)         // modulation scheme
 
 //
 // MODULE : math

--- a/src/framing/src/flexframegen.c
+++ b/src/framing/src/flexframegen.c
@@ -157,6 +157,7 @@ void flexframegen_destroy(flexframegen _q)
     free(_q->preamble_pn);  // preamble symbols
     free(_q->header);       // header bytes
     free(_q->header_mod);   // encoded/modulated header symbols 
+    free(_q->header_sym);
     free(_q->payload_sym);  // encoded/modulated payload symbols
 
     // destroy frame generator

--- a/src/framing/src/flexframegen.c
+++ b/src/framing/src/flexframegen.c
@@ -73,6 +73,8 @@ struct flexframegen_s {
 
     // header
     unsigned char * header;             // header data
+    unsigned int    header_user_len;    // header user section length
+    unsigned int    header_dec_len;     // header length (decoded)
     qpacketmodem    header_encoder;     // header encoder/modulator
     unsigned int    header_mod_len;     // header length (encoded/modulated)
     float complex * header_mod;         // header symbols (encoded/modulated)
@@ -119,32 +121,22 @@ flexframegen flexframegen_create(flexframegenprops_s * _fgprops)
     }
     msequence_destroy(ms);
 
-    // create header encoder/modulator
-    q->header     = (unsigned char *) malloc(FLEXFRAME_H_DEC*sizeof(unsigned char));
-    q->header_encoder = qpacketmodem_create();
-    qpacketmodem_configure(q->header_encoder,
-                           FLEXFRAME_H_DEC,
-                           FLEXFRAME_H_CRC,
-                           FLEXFRAME_H_FEC0,
-                           FLEXFRAME_H_FEC1,
-                           LIQUID_MODEM_QPSK);
-    q->header_mod_len = qpacketmodem_get_frame_len(q->header_encoder);
-    q->header_mod     = (float complex *) malloc(q->header_mod_len*sizeof(float complex));
+    // reset object
+    flexframegen_reset(q);
 
-    // create header pilot sequence generator
-    q->header_pilotgen = qpilotgen_create(q->header_mod_len, 16);
-    q->header_sym_len  = qpilotgen_get_frame_len(q->header_pilotgen);
-    q->header_sym      = (float complex *) malloc(q->header_sym_len*sizeof(float complex));
-    //printf("header: %u bytes > %u mod > %u sym\n", 64, q->header_mod_len, q->header_sym_len);
+    // create header encoder/modulator
+    q->header = NULL;
+    q->header_mod = NULL;
+    q->header_sym = NULL;
+    q->header_encoder = NULL;
+    q->header_pilotgen = NULL;
+    flexframegen_set_header_len(q, FLEXFRAME_H_USER_DEFAULT);
 
     // payload encoder/modulator (initialize with default parameters to be reconfigured later)
     q->payload_encoder = qpacketmodem_create();
     q->payload_dec_len = 64;
     q->payload_sym_len = qpacketmodem_get_frame_len(q->payload_encoder);
     q->payload_sym     = (float complex *) malloc( q->payload_sym_len*sizeof(float complex));
-
-    // reset object
-    flexframegen_reset(q);
 
     // set payload properties
     flexframegen_setprops(q, _fgprops);
@@ -185,7 +177,7 @@ void flexframegen_print(flexframegen _q)
     printf("flexframegen:\n");
     printf("  head          : %u symbols\n", _q->m);
     printf("  preamble      : %u\n", 64);
-    printf("  header        : %u symbols (%u bytes)\n", _q->header_sym_len, FLEXFRAME_H_DEC);
+    printf("  header        : %u symbols (%u bytes)\n", _q->header_sym_len, _q->header_dec_len);
     printf("  payload       : %u symbols (%u bytes)\n", _q->payload_sym_len, _q->payload_dec_len);
     printf("    payload crc : %s\n", crc_scheme_str[_q->props.check][1]);
     printf("    fec (inner) : %s\n", fec_scheme_str[_q->props.fec0][1]);
@@ -264,6 +256,42 @@ int flexframegen_setprops(flexframegen          _q,
     return 0;
 }
 
+void flexframegen_set_header_len(flexframegen   _q,
+                                 unsigned int   _len)
+{
+    // if frame is already assembled, give warning
+    if (_q->frame_assembled) {
+        fprintf(stderr, "warning: flexframegen_setprops(), frame is already assembled; must reset() first\n");
+        return;
+    }
+
+    _q->header_user_len = _len;
+    _q->header_dec_len = FLEXFRAME_H_DEC + _q->header_user_len;
+    _q->header     = (unsigned char *) realloc(_q->header, _q->header_dec_len*sizeof(unsigned char));
+
+    if (_q->header_encoder) {
+        qpacketmodem_destroy(_q->header_encoder);
+    }
+    _q->header_encoder = qpacketmodem_create();
+    qpacketmodem_configure(_q->header_encoder,
+                           _q->header_dec_len,
+                           FLEXFRAME_H_CRC,
+                           FLEXFRAME_H_FEC0,
+                           FLEXFRAME_H_FEC1,
+                           LIQUID_MODEM_QPSK);
+    _q->header_mod_len = qpacketmodem_get_frame_len(_q->header_encoder);
+    _q->header_mod     = (float complex *) realloc(_q->header_mod, _q->header_mod_len*sizeof(float complex));
+
+    // create header pilot sequence generator
+    if (_q->header_pilotgen) {
+        qpilotgen_destroy(_q->header_pilotgen);
+    }
+    _q->header_pilotgen = qpilotgen_create(_q->header_mod_len, 16);
+    _q->header_sym_len  = qpilotgen_get_frame_len(_q->header_pilotgen);
+    _q->header_sym      = (float complex *) realloc(_q->header_sym, _q->header_sym_len*sizeof(float complex));
+    //printf("header: %u bytes > %u mod > %u sym\n", 64, _q->header_mod_len, _q->header_sym_len);
+}
+
 // get frame length (number of samples)
 unsigned int flexframegen_getframelen(flexframegen _q)
 {
@@ -297,10 +325,10 @@ void flexframegen_assemble(flexframegen    _q,
     _q->payload_dec_len = _payload_dec_len;
 
     // copy user-defined header to internal
-    memmove(_q->header, _header, FLEXFRAME_H_USER*sizeof(unsigned char));
+    memmove(_q->header, _header, _q->header_user_len*sizeof(unsigned char));
 
     // first several bytes of header are user-defined
-    unsigned int n = FLEXFRAME_H_USER;
+    unsigned int n = _q->header_user_len;
 
     // add FLEXFRAME_PROTOCOL
     _q->header[n+0] = FLEXFRAME_PROTOCOL;

--- a/src/framing/src/flexframesync.c
+++ b/src/framing/src/flexframesync.c
@@ -69,6 +69,13 @@ void flexframesync_execute_rxheader(flexframesync _q,
 void flexframesync_execute_rxpayload(flexframesync _q,
                                      float complex _x);
 
+static flexframegenprops_s flexframesyncprops_header_default = {
+   FLEXFRAME_H_CRC,
+   FLEXFRAME_H_FEC0,
+   FLEXFRAME_H_FEC1,
+   FLEXFRAME_H_MOD,
+};
+
 // flexframesync object structure
 struct flexframesync_s {
     // callback
@@ -102,6 +109,7 @@ struct flexframesync_s {
     float complex * preamble_rx;        // received p/n symbols
     
     // header
+    int             header_soft;        // header performs soft demod
     float complex * header_sym;         // header symbols with pilots (received)
     unsigned int    header_sym_len;     // header symbols with pilots (length)
     qpilotsync      header_pilotsync;   // header demodulator/decoder
@@ -112,8 +120,11 @@ struct flexframesync_s {
     unsigned int    header_dec_len;     // length of header (decoded)
     unsigned char * header_dec;         // header bytes (decoded)
     int             header_valid;       // header CRC flag
-    
+
+    flexframegenprops_s header_props;   // header properties
+
     // payload
+    int             payload_soft;       // payload performs soft demod
     modem           payload_demod;      // payload demod (for phase recovery only)
     float complex * payload_sym;        // payload symbols (received)
     unsigned int    payload_sym_len;    // payload symbols (length)
@@ -191,7 +202,9 @@ flexframesync flexframesync_create(framesync_callback _callback,
     q->header_dec = NULL;
     q->header_pilotsync = NULL;
     q->header_decoder = NULL;
-    flexframesync_set_header_len(q, FLEXFRAME_H_USER_DEFAULT);
+    q->header_user_len = FLEXFRAME_H_USER_DEFAULT;
+    q->header_soft = 0;
+    flexframesync_set_header_props(q, NULL);
 
     // payload demodulator for phase recovery
     q->payload_demod = modem_create(LIQUID_MODEM_QPSK);
@@ -201,7 +214,7 @@ flexframesync flexframesync_create(framesync_callback _callback,
     int check      = LIQUID_CRC_24;
     int fec0       = LIQUID_FEC_NONE;
     int fec1       = LIQUID_FEC_GOLAY2412;
-    int mod_scheme = LIQUID_MODEM_QPSK;
+    int mod_scheme = LIQUID_MODEM_BPSK;
     q->payload_decoder = qpacketmodem_create();
     qpacketmodem_configure(q->payload_decoder, q->payload_dec_len, check, fec0, fec1, mod_scheme);
     //qpacketmodem_print(q->payload_decoder);
@@ -211,6 +224,7 @@ flexframesync flexframesync_create(framesync_callback _callback,
     // allocate memory for payload symbols and recovered data bytes
     q->payload_sym = (float complex*) malloc(q->payload_sym_len*sizeof(float complex));
     q->payload_dec = (unsigned char*) malloc(q->payload_dec_len*sizeof(unsigned char));
+    q->payload_soft = 0;
 
     // reset global data counters
     flexframesync_reset_framedatastats(q);
@@ -304,10 +318,10 @@ void flexframesync_set_header_len(flexframesync _q,
     _q->header_decoder = qpacketmodem_create();
     qpacketmodem_configure(_q->header_decoder,
                            _q->header_dec_len,
-                           FLEXFRAME_H_CRC,
-                           FLEXFRAME_H_FEC0,
-                           FLEXFRAME_H_FEC1,
-                           LIQUID_MODEM_QPSK);
+                           _q->header_props.check,
+                           _q->header_props.fec0,
+                           _q->header_props.fec1,
+                           _q->header_props.mod_scheme);
     _q->header_mod_len = qpacketmodem_get_frame_len(_q->header_decoder);
     _q->header_mod     = (float complex*) realloc(_q->header_mod, _q->header_mod_len*sizeof(float complex));
 
@@ -318,6 +332,46 @@ void flexframesync_set_header_len(flexframesync _q,
     _q->header_pilotsync = qpilotsync_create(_q->header_mod_len, 16);
     _q->header_sym_len   = qpilotsync_get_frame_len(_q->header_pilotsync);
     _q->header_sym       = (float complex*) realloc(_q->header_sym, _q->header_sym_len*sizeof(float complex));
+}
+
+void flexframesync_decode_header_soft(flexframesync _q,
+                                      int           _soft)
+{
+    _q->header_soft = _soft;
+}
+
+void flexframesync_decode_payload_soft(flexframesync _q,
+                                       int           _soft)
+{
+    _q->payload_soft = _soft;
+}
+
+int flexframesync_set_header_props(flexframesync          _q,
+                                   flexframegenprops_s * _props)
+{
+    if (_props == NULL) {
+        _props = &flexframesyncprops_header_default;
+    }
+
+    // validate input
+    if (_props->check == LIQUID_CRC_UNKNOWN || _props->check >= LIQUID_CRC_NUM_SCHEMES) {
+        fprintf(stderr, "error: flexframesync_set_header_props(), invalid/unsupported CRC scheme\n");
+        exit(1);
+    } else if (_props->fec0 == LIQUID_FEC_UNKNOWN || _props->fec1 == LIQUID_FEC_UNKNOWN) {
+        fprintf(stderr, "error: flexframesync_set_header_props(), invalid/unsupported FEC scheme\n");
+        exit(1);
+    } else if (_props->mod_scheme == LIQUID_MODEM_UNKNOWN ) {
+        fprintf(stderr, "error: flexframesync_set_header_props(), invalid/unsupported modulation scheme\n");
+        exit(1);
+    }
+
+    // copy properties to internal structure
+    memmove(&_q->header_props, _props, sizeof(flexframegenprops_s));
+
+    // reconfigure payload buffers (reallocate as necessary)
+    flexframesync_set_header_len(_q, _q->header_user_len);
+
+    return 0;
 }
 
 // execute frame synchronizer
@@ -574,9 +628,15 @@ void flexframesync_decode_header(flexframesync _q)
     qpilotsync_execute(_q->header_pilotsync, _q->header_sym, _q->header_mod);
 
     // decode payload
-    _q->header_valid = qpacketmodem_decode(_q->header_decoder,
-                                           _q->header_mod,
-                                           _q->header_dec);
+    if (_q->header_soft) {
+        _q->header_valid = qpacketmodem_decode_soft(_q->header_decoder,
+                                                    _q->header_mod,
+                                                    _q->header_dec);
+    } else {
+        _q->header_valid = qpacketmodem_decode(_q->header_decoder,
+                                               _q->header_mod,
+                                               _q->header_dec);
+    }
 
     if (!_q->header_valid)
         return;
@@ -705,9 +765,15 @@ void flexframesync_execute_rxpayload(flexframesync _q,
 
         if (_q->symbol_counter == _q->payload_sym_len) {
             // decode payload
-            _q->payload_valid = qpacketmodem_decode(_q->payload_decoder,
-                                                    _q->payload_sym,
-                                                    _q->payload_dec);
+            if (_q->payload_soft) {
+                _q->payload_valid = qpacketmodem_decode_soft(_q->payload_decoder,
+                                                             _q->payload_sym,
+                                                             _q->payload_dec);
+            } else {
+                _q->payload_valid = qpacketmodem_decode(_q->payload_decoder,
+                                                        _q->payload_sym,
+                                                        _q->payload_dec);
+            }
 
             // update statistics
             _q->framedatastats.num_frames_detected++;

--- a/src/framing/src/gmskframegen.c
+++ b/src/framing/src/gmskframegen.c
@@ -109,6 +109,9 @@ gmskframegen gmskframegen_create()
     // preamble objects/arrays
     q->ms_preamble = msequence_create(6, 0x6d, 1);
 
+    // reset framing object
+    gmskframegen_reset(q);
+
     q->header_dec = NULL;
     q->header_enc = NULL;
     q->p_header   = NULL;
@@ -129,9 +132,6 @@ gmskframegen gmskframegen_create()
 
     // allocate memory for encoded packet
     q->payload_enc = (unsigned char*) malloc(q->enc_msg_len*sizeof(unsigned char));
-
-    // reset framing object
-    gmskframegen_reset(q);
 
     // return object
     return q;

--- a/src/framing/src/gmskframegen.c
+++ b/src/framing/src/gmskframegen.c
@@ -61,8 +61,10 @@ struct gmskframegen_s {
     msequence ms_preamble;      // preamble p/n sequence
 
     // header
-    unsigned char * header_dec; // uncoded header [GMSKFRAME_H_DEC]
-    unsigned char * header_enc; // encoded header [GMSKFRAME_H_ENC]
+    unsigned int header_user_len;
+    unsigned int header_enc_len;
+    unsigned char * header_dec; // uncoded header [header_user_len + GMSKFRAME_H_DEC]
+    unsigned char * header_enc; // encoded header [header_enc_len]
     packetizer p_header;        // header packetizer
 
     // payload
@@ -107,14 +109,10 @@ gmskframegen gmskframegen_create()
     // preamble objects/arrays
     q->ms_preamble = msequence_create(6, 0x6d, 1);
 
-    // header objects/arrays
-    q->header_dec = (unsigned char*)malloc(GMSKFRAME_H_DEC*sizeof(unsigned char));
-    q->header_enc = (unsigned char*)malloc(GMSKFRAME_H_ENC*sizeof(unsigned char));
-    q->header_len = GMSKFRAME_H_ENC * 8;
-    q->p_header   = packetizer_create(GMSKFRAME_H_DEC,
-                                      GMSKFRAME_H_CRC,
-                                      GMSKFRAME_H_FEC,
-                                      LIQUID_FEC_NONE);
+    q->header_dec = NULL;
+    q->header_enc = NULL;
+    q->p_header   = NULL;
+    gmskframegen_set_header_len(q, GMSKFRAME_H_USER_DEFAULT);
 
     // payload objects/arrays
     q->dec_msg_len = 0;
@@ -196,6 +194,32 @@ void gmskframegen_print(gmskframegen _q)
     printf("  total samples     :   %-4u sampels\n", gmskframegen_getframelen(_q));
 }
 
+void gmskframegen_set_header_len(gmskframegen _q,
+                                 unsigned int _len)
+{
+    if (_q->frame_assembled) {
+        fprintf(stderr, "warning: gmskframegen_set_header_len(), frame is already assembled; must reset() first\n");
+        return;
+    }
+
+    _q->header_user_len = _len;
+    unsigned int header_dec_len = GMSKFRAME_H_DEC + _q->header_user_len;
+    _q->header_dec = (unsigned char*)realloc(_q->header_dec, header_dec_len*sizeof(unsigned char));
+
+    if (_q->p_header) {
+        packetizer_destroy(_q->p_header);
+    }
+
+    _q->p_header = packetizer_create(header_dec_len,
+                                     GMSKFRAME_H_CRC,
+                                     GMSKFRAME_H_FEC,
+                                     LIQUID_FEC_NONE);
+
+    _q->header_enc_len = packetizer_get_enc_msg_len(_q->p_header);
+    _q->header_enc = (unsigned char*)realloc(_q->header_enc, _q->header_enc_len*sizeof(unsigned char));
+    _q->header_len = _q->header_enc_len * 8;
+}
+
 // assemble frame
 //  _q              :   frame generator object
 //  _header         :   raw header
@@ -255,7 +279,7 @@ unsigned int gmskframegen_getframelen(gmskframegen _q)
 
     unsigned int num_frame_symbols =
             _q->preamble_len +      // number of preamble p/n symbols
-            GMSKFRAME_H_SYM +       // number of header symbols
+            _q->header_len +        // number of header symbols
             _q->payload_len +       // number of payload symbols
             2*_q->m;                // number of tail symbols
 
@@ -313,8 +337,8 @@ void gmskframegen_encode_header(gmskframegen    _q,
                                 unsigned char * _header)
 {
     // first 'n' bytes user data
-    memmove(_q->header_dec, _header, GMSKFRAME_H_USER);
-    unsigned int n = GMSKFRAME_H_USER;
+    memmove(_q->header_dec, _header, _q->header_user_len);
+    unsigned int n = _q->header_user_len;
 
     // first byte is for expansion/version validation
     _q->header_dec[n+0] = GMSKFRAME_VERSION;
@@ -335,7 +359,7 @@ void gmskframegen_encode_header(gmskframegen    _q,
     packetizer_encode(_q->p_header, _q->header_dec, _q->header_enc);
 
     // scramble header
-    scramble_data(_q->header_enc, GMSKFRAME_H_ENC);
+    scramble_data(_q->header_enc, _q->header_enc_len);
 #if 0
     printf("    header_enc      :");
     unsigned int i;

--- a/src/framing/src/gmskframesync.c
+++ b/src/framing/src/gmskframesync.c
@@ -108,6 +108,9 @@ struct gmskframesync_s {
     float * preamble_rx;            // preamble p/n sequence (received)
 
     // header
+    unsigned int header_user_len;
+    unsigned int header_enc_len;
+    unsigned int header_mod_len;
     unsigned char * header_mod;
     unsigned char * header_enc;
     unsigned char * header_dec;
@@ -210,13 +213,11 @@ gmskframesync gmskframesync_create(framesync_callback _callback,
     q->nco_coarse = nco_crcf_create(LIQUID_NCO);
 
     // create/allocate header objects/arrays
-    q->header_mod = (unsigned char*)malloc(GMSKFRAME_H_SYM*sizeof(unsigned char));
-    q->header_enc = (unsigned char*)malloc(GMSKFRAME_H_ENC*sizeof(unsigned char));
-    q->header_dec = (unsigned char*)malloc(GMSKFRAME_H_DEC*sizeof(unsigned char));
-    q->p_header   = packetizer_create(GMSKFRAME_H_DEC,
-                                      GMSKFRAME_H_CRC,
-                                      GMSKFRAME_H_FEC,
-                                      LIQUID_FEC_NONE);
+    q->header_mod = NULL;
+    q->header_enc = NULL;
+    q->header_dec = NULL;
+    q->p_header = NULL;
+    gmskframesync_set_header_len(q, GMSKFRAME_H_USER_DEFAULT);
 
     // create/allocate payload objects/arrays
     q->payload_dec_len = 1;
@@ -295,6 +296,30 @@ void gmskframesync_destroy(gmskframesync _q)
 void gmskframesync_print(gmskframesync _q)
 {
     printf("gmskframesync:\n");
+}
+
+void gmskframesync_set_header_len(gmskframesync _q,
+                                  unsigned int _len)
+{
+
+    _q->header_user_len = _len;
+    unsigned int header_dec_len = GMSKFRAME_H_DEC + _q->header_user_len;
+    _q->header_dec = (unsigned char*)realloc(_q->header_dec, header_dec_len*sizeof(unsigned char));
+
+    if (_q->p_header) {
+        packetizer_destroy(_q->p_header);
+    }
+
+    _q->p_header = packetizer_create(header_dec_len,
+                                     GMSKFRAME_H_CRC,
+                                     GMSKFRAME_H_FEC,
+                                     LIQUID_FEC_NONE);
+
+    _q->header_enc_len = packetizer_get_enc_msg_len(_q->p_header);
+    _q->header_enc = (unsigned char*)realloc(_q->header_enc, _q->header_enc_len*sizeof(unsigned char));
+
+    _q->header_mod_len = _q->header_enc_len * 8;
+    _q->header_mod = (unsigned char*)realloc(_q->header_mod, _q->header_mod_len*sizeof(unsigned char));
 }
 
 // reset frame synchronizer object
@@ -615,7 +640,7 @@ void gmskframesync_execute_rxheader(gmskframesync _q,
 
         // increment header counter
         _q->header_counter++;
-        if (_q->header_counter == GMSKFRAME_H_SYM) {
+        if (_q->header_counter == _q->header_mod_len) {
             // decode header
             gmskframesync_decode_header(_q);
 
@@ -726,13 +751,13 @@ void gmskframesync_decode_header(gmskframesync _q)
 {
     // pack each 1-bit header symbols into 8-bit bytes
     unsigned int num_written;
-    liquid_pack_bytes(_q->header_mod, GMSKFRAME_H_SYM,
-                      _q->header_enc, GMSKFRAME_H_ENC,
+    liquid_pack_bytes(_q->header_mod, _q->header_mod_len,
+                      _q->header_enc, _q->header_enc_len,
                       &num_written);
-    assert(num_written==GMSKFRAME_H_ENC);
+    assert(num_written==_q->header_enc_len);
 
     // unscramble data
-    unscramble_data(_q->header_enc, GMSKFRAME_H_ENC);
+    unscramble_data(_q->header_enc, _q->header_enc_len);
 
     // run packet decoder
     _q->header_valid = packetizer_decode(_q->p_header, _q->header_enc, _q->header_dec);
@@ -744,7 +769,7 @@ void gmskframesync_decode_header(gmskframesync _q)
     if (!_q->header_valid)
         return;
 
-    unsigned int n = GMSKFRAME_H_USER;
+    unsigned int n = _q->header_user_len;
 
     // first byte is for expansion/version validation
     if (_q->header_dec[n+0] != GMSKFRAME_VERSION) {

--- a/src/framing/src/ofdmflexframegen.c
+++ b/src/framing/src/ofdmflexframegen.c
@@ -232,6 +232,9 @@ void ofdmflexframegen_destroy(ofdmflexframegen _q)
     free(_q->payload_mod);              // modulated payload symbols
     free(_q->X);                        // frequency-domain buffer
     free(_q->p);                        // subcarrier allocation
+    free(_q->header);                   // decoded header
+    free(_q->header_enc);               // encoded header
+    free(_q->header_mod);               // modulated header
 
     // free main object memory
     free(_q);

--- a/src/framing/src/ofdmflexframesync.c
+++ b/src/framing/src/ofdmflexframesync.c
@@ -220,6 +220,9 @@ void ofdmflexframesync_destroy(ofdmflexframesync _q)
     free(_q->payload_enc);
     free(_q->payload_dec);
     free(_q->payload_syms);
+    free(_q->header);
+    free(_q->header_enc);
+    free(_q->header_mod);
 
     // free main object memory
     free(_q);

--- a/src/framing/src/ofdmflexframesync.c
+++ b/src/framing/src/ofdmflexframesync.c
@@ -640,7 +640,8 @@ void ofdmflexframesync_decode_header(ofdmflexframesync _q)
         // re-compute payload encoded message length
         if (_q->payload_soft) {
             _q->payload_enc_len = 8*packetizer_get_enc_msg_len(_q->p_payload);
-            _q->payload_mod_len = _q->payload_enc_len;
+            div_t d = div(_q->payload_enc_len, _q->bps_payload);
+            _q->payload_mod_len = d.quot + (d.rem ? 1 : 0);
         } else {
             _q->payload_enc_len = packetizer_get_enc_msg_len(_q->p_payload);
             // re-compute number of modulated payload symbols
@@ -681,8 +682,7 @@ void ofdmflexframesync_rxpayload(ofdmflexframesync _q,
             _q->payload_syms[_q->payload_symbol_index] = _X[i];
 
             if (_q->payload_soft) {
-                unsigned int bps = modem_get_bps(_q->mod_payload);
-                modem_demodulate_soft(_q->mod_payload, _X[i], &sym, &_q->payload_enc[bps*_q->payload_symbol_index]);
+                modem_demodulate_soft(_q->mod_payload, _X[i], &sym, &_q->payload_enc[_q->bps_payload*_q->payload_symbol_index]);
             } else {
                 modem_demodulate(_q->mod_payload, _X[i], &sym);
 

--- a/src/framing/src/ofdmflexframesync.c
+++ b/src/framing/src/ofdmflexframesync.c
@@ -639,9 +639,10 @@ void ofdmflexframesync_decode_header(ofdmflexframesync _q)
 
         // re-compute payload encoded message length
         if (_q->payload_soft) {
-            _q->payload_enc_len = 8*packetizer_get_enc_msg_len(_q->p_payload);
-            div_t d = div(_q->payload_enc_len, _q->bps_payload);
+            int packetizer_msg_len = packetizer_get_enc_msg_len(_q->p_payload);
+            div_t d = div((int)8*packetizer_msg_len, (int)_q->bps_payload);
             _q->payload_mod_len = d.quot + (d.rem ? 1 : 0);
+            _q->payload_enc_len = _q->bps_payload*_q->payload_mod_len;
         } else {
             _q->payload_enc_len = packetizer_get_enc_msg_len(_q->p_payload);
             // re-compute number of modulated payload symbols

--- a/src/framing/src/qpacketmodem.c
+++ b/src/framing/src/qpacketmodem.c
@@ -104,6 +104,8 @@ void qpacketmodem_destroy(qpacketmodem _q)
     // free arrays
     free(_q->payload_enc);
     free(_q->payload_mod);
+
+    free(_q);
 }
 
 // reset object


### PR DESCRIPTION
This PR builds on top of the user-defined header length PR from February

This allows user control of header mod/fec as well as soft demod for header and payload. This greatly improves the versatility of the flexframe object.

It'd be great to do gmsk like this too but after tinkering with it I must admit I can't figure out how to perform soft demod with gmsk.
