### PR TITLE
add -msse flag to makefile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,12 +161,21 @@ else
                            src/dotprod/src/dotprod_crcf.mmx.o \
                            src/dotprod/src/dotprod_rrrf.mmx.o \
                            src/dotprod/src/sumsq.mmx.o"
+            ARCH_OPTION='-msse4.1'
+        elif [ test "$ax_cv_have_sse3_ext" = yes && test "$ac_cv_header_pmmintrin_h" = yes ]; then
+            # SSE3 extensions
+            MLIBS_DOTPROD="src/dotprod/src/dotprod_cccf.mmx.o \
+                           src/dotprod/src/dotprod_crcf.mmx.o \
+                           src/dotprod/src/dotprod_rrrf.mmx.o \
+                           src/dotprod/src/sumsq.mmx.o"
+            ARCH_OPTION='-msse3'
         elif [ test "$ax_cv_have_sse2_ext" = yes && test "$ac_cv_header_emmintrin_h" = yes ]; then
             # SSE2 extensions
             MLIBS_DOTPROD="src/dotprod/src/dotprod_cccf.mmx.o \
                            src/dotprod/src/dotprod_crcf.mmx.o \
                            src/dotprod/src/dotprod_rrrf.mmx.o \
                            src/dotprod/src/sumsq.mmx.o"
+            ARCH_OPTION='-msse2'
         else
             # portable C version
             MLIBS_DOTPROD="src/dotprod/src/dotprod_cccf.o \


### PR DESCRIPTION
gcc is fairly strict about this. just having -march doesn't necessarily
work, since the arch might be guaranteed to offer only a limited subset
of sse

there are usually two workarounds to this -- either set -march=native,
or explicitly set sse level with -msse. this does the latter.