### PR TITLE
define order for msequence

### DIFF
--- a/src/framing/src/flexframegen.c
+++ b/src/framing/src/flexframegen.c
@@ -114,8 +114,8 @@ flexframegen flexframegen_create(flexframegenprops_s * _fgprops)
     q->preamble_pn = (float complex *) malloc(64*sizeof(float complex));
     msequence ms = msequence_create(7, 0x0089, 1);
     for (i=0; i<64; i++) {
-        q->preamble_pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) +
-                            (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) * _Complex_I;
+        q->preamble_pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2);
+        q->preamble_pn[i] += (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) * _Complex_I;
     }
     msequence_destroy(ms);
 

--- a/src/framing/src/flexframesync.c
+++ b/src/framing/src/flexframesync.c
@@ -157,8 +157,8 @@ flexframesync flexframesync_create(framesync_callback _callback,
     q->preamble_rx = (float complex*) malloc(64*sizeof(float complex));
     msequence ms = msequence_create(7, 0x0089, 1);
     for (i=0; i<64; i++) {
-        q->preamble_pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) +
-                            (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2)*_Complex_I;
+        q->preamble_pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2);
+        q->preamble_pn[i] += (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) * _Complex_I;
     }
     msequence_destroy(ms);
 


### PR DESCRIPTION
This patch resolves undefined behavior in flexframegen.

In C, the evaluation order of any statement is not defined. The compiler may order the operations however it wants, although parens forces some ordering. Since msequence_advance(ms) is stateful, a different preamble is built depending on whether the compiler chooses to evaluate left-to-right or right-to-left.

I have gone with left-to-right, which I believe was the intended ordering. It seems this is the way clang chooses. gcc seemingly goes right-to-left. This means previously compiled versions may be incompatible with this patch, but moving forward all versions should be compatible with one another.

More broadly, we should thoroughly inspect for other instances of this sort bug. It seems just for msequence alone there are other places where it occurs, though I haven't touched them here. Ideally, we should split any statement with multiple calls of some stateful operation into multiple statements, each with one stateful operation.