### PR TITLE
resamp: add adjust_timing_phase()

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3074,6 +3074,9 @@ void RESAMP(_set_rate)(RESAMP() _q, float _rate);               \
 /* adjust rate of arbitrary resampler                       */  \
 void RESAMP(_adjust_rate)(RESAMP() _q, float _delta);           \
                                                                 \
+/* adjust resampling timing phase                           */  \
+void RESAMP(_adjust_timing_phase)(RESAMP() _q, float _delta);   \
+                                                                \
 /* execute arbitrary resampler                              */  \
 /*  _q              :   resamp object                       */  \
 /*  _x              :   single input sample                 */  \

--- a/src/filter/src/resamp.c
+++ b/src/filter/src/resamp.c
@@ -237,6 +237,19 @@ void RESAMP(_adjust_rate)(RESAMP() _q,
 }
 
 
+// adjust resampling timing phase
+void RESAMP(_adjust_timing_phase)(RESAMP() _q,
+                                  float    _delta)
+{
+    if (_delta > 1.0f || _delta < -1.0f) {
+        fprintf(stderr,"error: resamp_%s_adjust_timing_phase(), timing phase must be in [-1,1], is %f\n.", EXTENSION_FULL, _delta);
+        exit(1);
+    }
+
+    // adjust internal timing phase
+    _q->tau += _delta;
+}
+
 // run arbitrary resampler
 //  _q          :   resampling object
 //  _x          :   single input sample


### PR DESCRIPTION
This function adjust the internal timing phase of the resampler, making it possible to
use custom timing error detectors with resamp.