### PR TITLE
spgram_reset(q) clears the internal spgram buffers (except for window buffer)

### DIFF
--- a/examples/symtrack_cccf_example.c
+++ b/examples/symtrack_cccf_example.c
@@ -32,7 +32,6 @@ void usage()
     printf("  s     : signal-to-noise ratio,   default: 30 dB\n");
     printf("  w     : timing pll bandwidth,    default: 0.02\n");
     printf("  n     : number of symbols,       default: 4000\n");
-    printf("  t     : timing phase offset [%% symbol], t in [-0.5,0.5], default: -0.2\n");
 }
 
 int main(int argc, char*argv[])
@@ -48,8 +47,6 @@ int main(int argc, char*argv[])
     float        noise_floor = -60.0f;  // noise floor [dB]
     float        SNRdB       = 30.0f;   // signal-to-noise ratio [dB]
     float        bandwidth   =  0.10f;  // loop filter bandwidth
-    float        tau         = -0.2f;   // fractional symbol offset
-    float        rate        = 1.001f;  // sample rate offset
     float        dphi        =  0.02f;  // carrier frequency offset [radians/sample]
     float        phi         =  2.1f;   // carrier phase offset [radians]
 
@@ -88,12 +85,6 @@ int main(int argc, char*argv[])
         exit(1);
     } else if (num_symbols == 0) {
         fprintf(stderr,"error: number of symbols must be greater than 0\n");
-        exit(1);
-    } else if (tau < -1.0f || tau > 1.0f) {
-        fprintf(stderr,"error: timing phase offset must be in [-1,1]\n");
-        exit(1);
-    } else if (rate > 1.02f || rate < 0.98f) {
-        fprintf(stderr,"error: timing rate offset must be in [1.02,0.98]\n");
         exit(1);
     }
 

--- a/src/fft/src/spgram.c
+++ b/src/fft/src/spgram.c
@@ -147,7 +147,7 @@ SPGRAM() SPGRAM(_create)(unsigned int _nfft,
     // scale window and copy
     for (i=0; i<q->window_len; i++)
         q->w[i] = g * q->w[i];
-    
+
     // reset the spgram object
     q->num_samples_total    = 0;
     q->num_transforms_total = 0;
@@ -184,7 +184,7 @@ void SPGRAM(_destroy)(SPGRAM() _q)
     free(_q);
 }
 
-// resets the internal state of the spgram object
+// resets the internal state of the spgram object except for the window buffer
 void SPGRAM(_reset)(SPGRAM() _q)
 {
     // clear the window buffer
@@ -203,6 +203,15 @@ void SPGRAM(_reset)(SPGRAM() _q)
     // clear PSD accumulation
     for (i=0; i<_q->nfft; i++)
         _q->psd[i] = 0.0f;
+}
+
+// completely resets the internal state of the spgram object
+void SPGRAM(_reset_all)(SPGRAM() _q)
+{
+    // reset spgram object except for the window buffer
+    SPGRAM(_reset)(_q);
+    // clear the window buffer
+    WINDOW(_reset)(_q->buffer);
 }
 
 // prints the spgram object's parameters
@@ -436,4 +445,3 @@ void SPGRAM(_estimate_psd)(unsigned int _nfft,
     // destroy object
     SPGRAM(_destroy)(q);
 }
-

--- a/src/filter/src/iirfiltsos.c
+++ b/src/filter/src/iirfiltsos.c
@@ -199,7 +199,7 @@ void IIRFILTSOS(_execute_df1)(IIRFILTSOS() _q,
     *_y = _q->y[0];
 }
 
-// compute filter output, direct form I method
+// compute filter output, direct form II method
 //  _q      : iirfiltsos object
 //  _x      : input sample
 //  _y      : output sample pointer
@@ -223,7 +223,7 @@ void IIRFILTSOS(_execute_df2)(IIRFILTSOS() _q,
     DOTPROD(_execute)(_q->dpb, _q->v, _y);
 #else
     // compute new v[0]
-    _q->v[0] = _x - 
+    _q->v[0] = _x -
                _q->a[1]*_q->v[1] -
                _q->a[2]*_q->v[2];
 
@@ -250,4 +250,3 @@ float IIRFILTSOS(_groupdelay)(IIRFILTSOS() _q,
     }
     return iir_group_delay(b, 3, a, 3, _fc) + 2.0;
 }
-


### PR DESCRIPTION
reset() not clearing the window buffer turned out to be my bug, so I added a reset_all() function?