### PR TITLE
examples: remove cruft from symtrack_cccf example

### DIFF
--- a/examples/symtrack_cccf_example.c
+++ b/examples/symtrack_cccf_example.c
@@ -63,8 +63,6 @@ int main(int argc, char*argv[])
         case 's':   SNRdB       = atof(optarg);     break;
         case 'w':   bandwidth   = atof(optarg);     break;
         case 'n':   num_symbols = atoi(optarg);     break;
-        case 't':   tau         = atof(optarg);     break;
-        case 'r':   rate        = atof(optarg);     break;
         default:
             exit(1);
         }


### PR DESCRIPTION
Completes removal of spurious variables started in fb27bb8. Without this change, building with `make examples` fails.