### PR TITLE
Typo's + Question

### DIFF
--- a/examples/symtrack_cccf_example.c
+++ b/examples/symtrack_cccf_example.c
@@ -63,8 +63,6 @@ int main(int argc, char*argv[])
         case 's':   SNRdB       = atof(optarg);     break;
         case 'w':   bandwidth   = atof(optarg);     break;
         case 'n':   num_symbols = atoi(optarg);     break;
-        case 't':   tau         = atof(optarg);     break;
-        case 'r':   rate        = atof(optarg);     break;
         default:
             exit(1);
         }

--- a/examples/symtrack_cccf_example.c
+++ b/examples/symtrack_cccf_example.c
@@ -31,7 +31,7 @@ void usage()
     printf("  b     : filter excess bandwidth, default: 0.5\n");
     printf("  s     : signal-to-noise ratio,   default: 30 dB\n");
     printf("  w     : timing pll bandwidth,    default: 0.02\n");
-    printf("  n     : number of symbols,       default: 4000\n");
+    printf("  n     : number of samples,       default: 200000\n");
 }
 
 int main(int argc, char*argv[])
@@ -42,7 +42,6 @@ int main(int argc, char*argv[])
     unsigned int k           = 2;       // samples per symbol
     unsigned int m           = 7;       // filter delay (symbols)
     float        beta        = 0.20f;   // filter excess bandwidth factor
-    unsigned int num_symbols = 4000;    // number of data symbols
     unsigned int hc_len      =   4;     // channel filter length
     float        noise_floor = -60.0f;  // noise floor [dB]
     float        SNRdB       = 30.0f;   // signal-to-noise ratio [dB]
@@ -62,7 +61,7 @@ int main(int argc, char*argv[])
         case 'b':   beta        = atof(optarg);     break;
         case 's':   SNRdB       = atof(optarg);     break;
         case 'w':   bandwidth   = atof(optarg);     break;
-        case 'n':   num_symbols = atoi(optarg);     break;
+        case 'n':   num_samples = atoi(optarg);     break;
         default:
             exit(1);
         }
@@ -81,8 +80,8 @@ int main(int argc, char*argv[])
     } else if (bandwidth <= 0.0f) {
         fprintf(stderr,"error: timing PLL bandwidth must be greater than 0\n");
         exit(1);
-    } else if (num_symbols == 0) {
-        fprintf(stderr,"error: number of symbols must be greater than 0\n");
+    } else if (num_samples == 0) {
+        fprintf(stderr,"error: number of samples must be greater than 0\n");
         exit(1);
     }
 

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -4294,11 +4294,11 @@ int detector_cccf_correlate(detector_cccf        _q,
 typedef struct SYMSTREAM(_s) * SYMSTREAM();                     \
                                                                 \
 /* create default symstream object                          */  \
-/* (LIQUID_RNYQUIST_ARKAISER, k=2, m=7, beta=0.3, QPSK)     */  \
+/* (LIQUID_FIRFILT_ARKAISER, k=2, m=7, beta=0.3, QPSK)     */  \
 SYMSTREAM() SYMSTREAM(_create)(void);                           \
                                                                 \
 /* create symstream object with linear modulation           */  \
-/*  _ftype  : filter type (e.g. LIQUID_RNYQUIST_RRC)        */  \
+/*  _ftype  : filter type (e.g. LIQUID_FIRFILT_RRC)        */  \
 /*  _k      : samples per symbol                            */  \
 /*  _m      : filter delay (symbols)                        */  \
 /*  _beta   : filter excess bandwidth                       */  \
@@ -4413,7 +4413,7 @@ LIQUID_MSOURCE_DEFINE_API(LIQUID_MSOURCE_MANGLE_CFLOAT, liquid_float_complex)
 typedef struct SYMTRACK(_s) * SYMTRACK();                       \
                                                                 \
 /* create symtrack object with default parameters           */  \
-/*  _ftype  : filter type (e.g. LIQUID_RNYQUIST_RRC)        */  \
+/*  _ftype  : filter type (e.g. LIQUID_FIRFILT_RRC)        */  \
 /*  _k      : samples per symbol                            */  \
 /*  _m      : filter delay (symbols)                        */  \
 /*  _beta   : filter excess bandwidth                       */  \

--- a/src/channel/src/channel.c
+++ b/src/channel/src/channel.c
@@ -170,7 +170,7 @@ void CHANNEL(_add_multipath)(CHANNEL()    _q,
 
     // update length
     _q->h_len = _h_len;
-    
+
     // copy coefficients internally
     if (_h == NULL) {
         // generate random coefficients using m-sequence generator
@@ -271,7 +271,7 @@ void CHANNEL(_execute)(CHANNEL() _q,
     *_y = r;
 }
 
-// apply channel impairments on single input sample
+// apply channel impairments on input array
 //  _q      : channel object
 //  _x      : input array [size: _n x 1]
 //  _n      : input array length
@@ -287,4 +287,3 @@ void CHANNEL(_execute_block)(CHANNEL()    _q,
     for (i=0; i<_n; i++)
         CHANNEL(_execute)(_q, _x[i], &_y[i]);
 }
-

--- a/src/channel/src/channel.c
+++ b/src/channel/src/channel.c
@@ -40,8 +40,8 @@ struct CHANNEL(_s) {
 
     // carrier offset
     int             enabled_carrier;    // carrier offset enabled?
-    float           dphi;               // channel gain
-    float           phi;                // noise standard deviation
+    float           dphi;               // carrier frequency offset [radians/sample]
+    float           phi;                // carrier phase offset [radians]
     NCO()           nco;                // oscillator
 
     // multi-path channel

--- a/src/equalization/src/eqlms.c
+++ b/src/equalization/src/eqlms.c
@@ -87,7 +87,7 @@ EQLMS() EQLMS(_create)(T *          _h,
 }
 
 // create square-root Nyquist interpolator
-//  _type   :   filter type (e.g. LIQUID_RNYQUIST_RRC)
+//  _type   :   filter type (e.g. LIQUID_FIRFILT_RRC)
 //  _k      :   samples/symbol _k > 1
 //  _m      :   filter delay (symbols), _m > 0
 //  _beta   :   excess bandwidth factor, 0 < _beta < 1

--- a/src/filter/src/firdecim.c
+++ b/src/filter/src/firdecim.c
@@ -118,7 +118,7 @@ FIRDECIM() FIRDECIM(_create_kaiser)(unsigned int _M,
 }
 
 // create square-root Nyquist decimator
-//  _type   :   filter type (e.g. LIQUID_RNYQUIST_RRC)
+//  _type   :   filter type (e.g. LIQUID_FIRFILT_RRC)
 //  _M      :   samples/symbol _M > 1
 //  _m      :   filter delay (symbols), _m > 0
 //  _beta   :   excess bandwidth factor, 0 < _beta < 1

--- a/src/filter/src/firfilt.c
+++ b/src/filter/src/firfilt.c
@@ -132,7 +132,7 @@ FIRFILT() FIRFILT(_create_kaiser)(unsigned int _n,
 }
 
 // create from square-root Nyquist prototype
-//  _type   : filter type (e.g. LIQUID_RNYQUIST_RRC)
+//  _type   : filter type (e.g. LIQUID_FIRFILT_RRC)
 //  _k      : nominal samples/symbol, _k > 1
 //  _m      : filter delay [symbols], _m > 0
 //  _beta   : rolloff factor, 0 < beta <= 1

--- a/src/filter/src/firpfb.c
+++ b/src/filter/src/firpfb.c
@@ -138,7 +138,7 @@ FIRPFB() FIRPFB(_create_kaiser)(unsigned int _M,
 }
 
 // create square-root Nyquist filterbank
-//  _type   :   filter type (e.g. LIQUID_RNYQUIST_RRC)
+//  _type   :   filter type (e.g. LIQUID_FIRFILT_RRC)
 //  _M      :   number of filters in the bank
 //  _k      :   samples/symbol _k > 1
 //  _m      :   filter delay (symbols), _m > 0
@@ -180,7 +180,7 @@ FIRPFB() FIRPFB(_create_rnyquist)(int          _type,
 }
 
 // create firpfb derivative square-root Nyquist filterbank
-//  _type   :   filter type (e.g. LIQUID_RNYQUIST_RRC)
+//  _type   :   filter type (e.g. LIQUID_FIRFILT_RRC)
 //  _M      :   number of filters in the bank
 //  _k      :   samples/symbol _k > 1
 //  _m      :   filter delay (symbols), _m > 0

--- a/src/filter/src/symsync.c
+++ b/src/filter/src/symsync.c
@@ -200,7 +200,7 @@ SYMSYNC() SYMSYNC(_create)(unsigned int _k,
 }
 
 // create square-root Nyquist symbol synchronizer
-//  _type   : filter type (e.g. LIQUID_RNYQUIST_RRC)
+//  _type   : filter type (e.g. LIQUID_FIRFILT_RRC)
 //  _k      : samples/symbol
 //  _m      : symbol delay
 //  _beta   : rolloff factor (0 < beta <= 1)

--- a/src/framing/src/symstream.c
+++ b/src/framing/src/symstream.c
@@ -35,7 +35,7 @@ struct SYMSTREAM(_s) {
     unsigned int    k;              // samples/symbol
     unsigned int    m;              // filter semi-length
     float           beta;           // filter excess bandwidth
-    int             mod_scheme;     // demodulator
+    int             mod_scheme;     // modulation scheme (e.g. LIQUID_MODEM_QPSK)
     MODEM()         mod;            // modulator
     FIRINTERP()     interp;         // interpolator
     TO *            buf;            // output buffer
@@ -166,4 +166,3 @@ void SYMSTREAM(_write_samples)(SYMSTREAM()  _q,
         _q->buf_index = (_q->buf_index + 1) % _q->k;
     }
 }
-

--- a/src/framing/src/symstream.c
+++ b/src/framing/src/symstream.c
@@ -31,7 +31,7 @@
 
 // internal structure
 struct SYMSTREAM(_s) {
-    int             filter_type;    // filter type (e.g. LIQUID_RNYQUIST_RKAISER)
+    int             filter_type;    // filter type (e.g. LIQUID_FIRFILT_RKAISER)
     unsigned int    k;              // samples/symbol
     unsigned int    m;              // filter semi-length
     float           beta;           // filter excess bandwidth
@@ -53,7 +53,7 @@ SYMSTREAM() SYMSTREAM(_create)()
 }
 
 // create symstream object with linear modulation
-//  _ftype  : filter type (e.g. LIQUID_RNYQUIST_RRC)
+//  _ftype  : filter type (e.g. LIQUID_FIRFILT_RRC)
 //  _k      : samples per symbol
 //  _m      : filter delay (symbols)
 //  _beta   : filter excess bandwidth

--- a/src/framing/src/symtrack.c
+++ b/src/framing/src/symtrack.c
@@ -41,7 +41,7 @@
 // internal structure
 struct SYMTRACK(_s) {
     // parameters
-    int             filter_type;        // filter type (e.g. LIQUID_RNYQUIST_RKAISER)
+    int             filter_type;        // filter type (e.g. LIQUID_FIRFILT_RKAISER)
     unsigned int    k;                  // samples/symbol
     unsigned int    m;                  // filter semi-length
     float           beta;               // filter excess bandwidth
@@ -74,7 +74,7 @@ struct SYMTRACK(_s) {
 };
 
 // create symtrack object with basic parameters
-//  _ftype  : filter type (e.g. LIQUID_RNYQUIST_RRC)
+//  _ftype  : filter type (e.g. LIQUID_FIRFILT_RRC)
 //  _k      : samples per symbol
 //  _m      : filter delay (symbols)
 //  _beta   : filter excess bandwidth
@@ -109,7 +109,7 @@ SYMTRACK() SYMTRACK(_create)(int          _ftype,
 
     // create automatic gain control
     q->agc = AGC(_create)();
-    
+
     // create symbol synchronizer (output rate: 2 samples per symbol)
     if (q->filter_type == LIQUID_FIRFILT_UNKNOWN)
         q->symsync = SYMSYNC(_create_kaiser)(q->k, q->m, 0.9f, 16);
@@ -218,7 +218,7 @@ void SYMTRACK(_set_bandwidth)(SYMTRACK() _q,
 
     // equalizer
     EQLMS(_set_bw)(_q->eq, eq_bandwidth);
-    
+
     // phase-locked loop
     NCO(_pll_set_bandwidth)(_q->nco, pll_bandwidth);
 }
@@ -327,4 +327,3 @@ void SYMTRACK(_execute_block)(SYMTRACK()     _q,
     //
     *_ny = num_written;
 }
-


### PR DESCRIPTION
Hi Joseph!

Besides the typo's I wanted to ask you for any reference or reasoning that went into picking these bandwidth calculating factors inside `symtrack.c`, or is it solely based on experience?

```c
// set bandwidths accordingly
// TODO: set bandwidths based on input bandwidth
float agc_bandwidth     = 0.02f  * _bw;
float symsync_bandwidth = 0.001f * _bw;
float eq_bandwidth      = 0.02f  * _bw;
float pll_bandwidth     = 0.001f * _bw;
```

What also got me going for a while is the following statement inside `modem_qam.c`

_EDIT: after dubble checking it does gives the expected result so I must have looked over something_
```c
// re-modulate symbol (subtract residual) and store state
_q->x_hat = _x - (res_i + _Complex_I*res_q);
```
Because the value that is put into `_q->x_hat` is not an estimate or re-modulation of `_x` right? For 16-QAM, the thing that is being put into `res_i` is `cimagf(_x) - _ref[1] - _ref[0] ` ,  same for `res_q` and `crealf(_x)`. Because `_ref[0]` is just 0, `_q->x_hat` will contain `_ref[1]`, but that still  works as an indication of the error calculated by `modem_get_demodulator_evm`, so that might be how it is supposed to be? 

Thanks in advance!