### PR TITLE
Fix resamp2_crcf_example.c.

### DIFF
--- a/examples/resamp2_crcf_example.c
+++ b/examples/resamp2_crcf_example.c
@@ -53,7 +53,7 @@ int main() {
 
     // execute decimation stage
     for (i=0; i<n; i++)
-        resamp2_crcf_interp_execute(q, y[2*i], &z[i]);
+        resamp2_crcf_decim_execute(q, &y[2*i], &z[i]);
 
     // clean up allocated objects
     resamp2_crcf_destroy(q);
@@ -61,7 +61,7 @@ int main() {
     // compute RMS error
     float rmse = 0.0f;
     for (i=2*m; i<n; i++) {
-        float e = cabsf(x[i-2*m] - z[i]);
+        float e = cabsf(x[i-2*m] - 0.5*z[i]);
         rmse += e*e;
     }
     rmse = sqrtf( rmse / (float)(n-2*m) );
@@ -85,7 +85,7 @@ int main() {
         fprintf(fid,"y(%3u) = %12.4e + j*%12.4e;\n", i+1, crealf(y[i]), cimagf(y[i]));
 
     for (i=0; i<n; i++)
-        fprintf(fid,"z(%3u) = %12.4e + j*%12.4e;\n", i+1, crealf(z[i]), cimagf(z[i]));
+        fprintf(fid,"z(%3u) = %12.4e + j*%12.4e;\n", i+1, 0.5*crealf(z[i]), 0.5*cimagf(z[i]));
 
     // print results
     fprintf(fid,"\n\n");


### PR DESCRIPTION
Fixes #109.

I've changed the second `resamp2_crcf_interp_execute` to `resamp2_crcf_decim_execute` and multiplied the output samples by 0.5 like in resamp2_crcf_decim_example:
https://github.com/jgaeddert/liquid-dsp/blob/b5d9a8af9f360f0cb528991518a05df3b53cbd52/examples/resamp2_crcf_decim_example.c#L103