### PR TITLE
.travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: cpp
+
+matrix:
+    include:
+        - os: linux
+          compiler: gcc
+          env: BUILD_CXX=off
+        - os: osx
+          compiler: clang
+          env: BUILD_CXX=off
+
+script:
+    - git clone https://github.com/quiet/libcorrect.git
+    - cd libcorrect
+    - mkdir build
+    - cd build
+    - set -e
+    - cmake -DCMAKE_BUILD_TYPE=Release .. && make && make shim
+    - sudo make install
+    - set +e
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ldconfig; fi
+    - cd ../..
+    - set -e
+    - ./bootstrap.sh
+    - ./configure
+    - make
+    - make check


### PR DESCRIPTION
This gives liquid-dsp a .travis.yml file. If you sign up for a [Travis](https://travis-ci.org/) account, then you can add a build shield to your README with
```
[![Build Status](https://travis-ci.org/jgaeddert/liquid-dsp.svg?branch=master)](https://travis-ci.org/jgaeddert/liquid-dsp)
```
which will update automatically with the build status of the latest master.

This .travis.yml is sort of just a starter. It does a build on OSX (w/ clang) and Linux (w/ gcc) and runs autotest on both. It includes my libcorrect so that it'll build/test the FEC bindings, but doesn't add any FFT, which could be interesting. There's actually quite a lot of [configuration](https://docs.travis-ci.com/user/customizing-the-build/) but most of it's probably not super relevant here.