### PR TITLE
DSSS generator/sync

### DIFF
--- a/examples/dsssframesync_example.c
+++ b/examples/dsssframesync_example.c
@@ -1,0 +1,153 @@
+//
+// dsssframesync_example.c
+//
+
+#include <assert.h>
+#include <getopt.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "liquid.h"
+
+void usage()
+{
+    printf("dsssframesync_example [options]\n");
+    printf("  u/h   : print usage\n");
+    printf("  s     : signal-to-noise ratio [dB], default: 20\n");
+    printf("  F     : carrier frequency offset, default: 0.01\n");
+    printf("  n     : payload length [bytes], default: 480\n");
+    printf("  v     : data integrity check: crc32 default\n");
+    liquid_print_crc_schemes();
+    printf("  c     : coding scheme (inner): h74 default\n");
+    printf("  k     : coding scheme (outer): none default\n");
+    liquid_print_fec_schemes();
+    printf("  d     : enable debugging\n");
+}
+
+// dsssframesync callback function
+static int callback(unsigned char *  _header,
+                    int              _header_valid,
+                    unsigned char *  _payload,
+                    unsigned int     _payload_len,
+                    int              _payload_valid,
+                    framesyncstats_s _stats,
+                    void *           _userdata);
+
+int main(int argc, char * argv[])
+{
+    srand(time(NULL));
+
+    // options
+    crc_scheme   check         = LIQUID_CRC_32;   // data validity check
+    fec_scheme   fec0          = LIQUID_FEC_NONE; // fec (inner)
+    fec_scheme   fec1          = LIQUID_FEC_NONE; // fec (outer)
+    unsigned int payload_len   = 20;              // payload length
+    int          debug_enabled = 0;               // enable debugging?
+    float        noise_floor   = -60.0f;          // noise floor
+    float        SNRdB         = -3.0f;           // signal-to-noise ratio
+    float        dphi          = 0.03f;           // carrier frequency offset
+
+    // get options
+    int dopt;
+    while ((dopt = getopt(argc, argv, "uhs:F:n:m:v:c:k:d")) != EOF) {
+        switch (dopt) {
+        case 'u':
+        case 'h': usage(); return 0;
+        case 's': SNRdB = atof(optarg); break;
+        case 'F': dphi = atof(optarg); break;
+        case 'n': payload_len = atol(optarg); break;
+        case 'v': check = liquid_getopt_str2crc(optarg); break;
+        case 'c': fec0 = liquid_getopt_str2fec(optarg); break;
+        case 'k': fec1 = liquid_getopt_str2fec(optarg); break;
+        case 'd': debug_enabled = 1; break;
+        default: exit(-1);
+        }
+    }
+
+    // derived values
+    unsigned int i;
+    float        nstd  = powf(10.0f, noise_floor / 20.0f);           // noise std. dev.
+    float        gamma = powf(10.0f, (SNRdB + noise_floor) / 20.0f); // channel gain
+
+    // create dsssframegen object
+    dsssframegenprops_s fgprops;
+    fgprops.check   = check;
+    fgprops.fec0    = fec0;
+    fgprops.fec1    = fec1;
+    dsssframegen fg = dsssframegen_create(&fgprops);
+
+    // create dsssframesync object
+    dsssframesync fs = dsssframesync_create(callback, NULL);
+    if (debug_enabled) {
+        // dsssframesync_debug_enable(fs);
+    }
+
+    // assemble the frame (NULL pointers for default values)
+    dsssframegen_assemble(fg, NULL, NULL, payload_len);
+    // dsssframegen_print(fg);
+
+    // generate the frame in blocks
+    unsigned int buf_len  = 256;
+    float complex x[buf_len];
+    float complex y[buf_len];
+
+    int   frame_complete = 0;
+    float phi            = 0.0f;
+    while (!frame_complete) {
+        frame_complete = dsssframegen_write_samples(fg, x, buf_len);
+
+        // add noise and push through synchronizer
+        for (i = 0; i < buf_len; i++) {
+            // apply channel gain and carrier offset to input
+            y[i] = gamma * x[i] * cexpf(_Complex_I * phi);
+            phi += dphi;
+
+            // add noise
+            y[i] += nstd * (randnf() + _Complex_I * randnf()) * M_SQRT1_2;
+        }
+
+        // run through frame synchronizer
+        dsssframesync_execute(fs, y, buf_len);
+    }
+
+    // export debugging file
+    if (debug_enabled) {
+        // dsssframesync_debug_print(fs, "dsssframesync_debug.m");
+    }
+
+    // dsssframesync_print(fs);
+    // destroy allocated objects
+    dsssframegen_destroy(fg);
+    dsssframesync_destroy(fs);
+
+    printf("done.\n");
+    return 0;
+}
+
+static int callback(unsigned char *  _header,
+                    int              _header_valid,
+                    unsigned char *  _payload,
+                    unsigned int     _payload_len,
+                    int              _payload_valid,
+                    framesyncstats_s _stats,
+                    void *           _userdata)
+{
+    printf("******** callback invoked\n");
+
+    // count bit errors (assuming all-zero message)
+    unsigned int bit_errors = 0;
+    unsigned int i;
+    for (i = 0; i < _payload_len; i++)
+        bit_errors += liquid_count_ones(_payload[i]);
+
+    framesyncstats_print(&_stats);
+    printf("    header crc          :   %s\n", _header_valid ? "pass" : "FAIL");
+    printf("    payload length      :   %u\n", _payload_len);
+    printf("    payload crc         :   %s\n", _payload_valid ? "pass" : "FAIL");
+    printf("    payload bit errors  :   %u / %u\n", bit_errors, 8 * _payload_len);
+
+    return 0;
+}

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3749,6 +3749,9 @@ unsigned int qpacketmodem_get_fec0     (qpacketmodem _q);
 unsigned int qpacketmodem_get_fec1     (qpacketmodem _q);
 unsigned int qpacketmodem_get_modscheme(qpacketmodem _q);
 
+float qpacketmodem_get_demodulator_phase_error(qpacketmodem _q);
+float qpacketmodem_get_demodulator_evm(qpacketmodem _q);
+
 // encode packet into un-modulated frame symbol indices
 //  _q          :   qpacketmodem object
 //  _payload    :   unencoded payload bytes
@@ -3798,6 +3801,12 @@ int qpacketmodem_decode(qpacketmodem           _q,
 int qpacketmodem_decode_soft(qpacketmodem           _q,
                              liquid_float_complex * _frame,
                              unsigned char *        _payload);
+
+int qpacketmodem_decode_soft_sym(qpacketmodem  _q,
+                                 float complex _symbol);
+
+int qpacketmodem_decode_soft_payload(qpacketmodem    _q,
+                                     unsigned char * _payload);
 
 //
 // pilot generator for streaming applications
@@ -4186,6 +4195,72 @@ void gmskframesync_debug_disable(gmskframesync _q);
 void gmskframesync_debug_print(gmskframesync _q, const char * _filename);
 
 
+//
+// DSSS frame generator
+//
+
+typedef struct {
+    unsigned int check;
+    unsigned int fec0;
+    unsigned int fec1;
+} dsssframegenprops_s;
+
+typedef struct dsssframegen_s * dsssframegen;
+
+dsssframegen dsssframegen_create(dsssframegenprops_s * _props);
+void dsssframegen_destroy(dsssframegen _q);
+void dsssframegen_reset(dsssframegen _q);
+int dsssframegen_is_assembled(dsssframegen _q);
+void dsssframegen_getprops(dsssframegen _q, dsssframegenprops_s * _props);
+int dsssframegen_setprops(dsssframegen _q, dsssframegenprops_s * _props);
+void dsssframegen_set_header_len(dsssframegen _q, unsigned int _len);
+int dsssframegen_set_header_props(dsssframegen          _q,
+                                  dsssframegenprops_s * _props);
+unsigned int dsssframegen_getframelen(dsssframegen _q);
+
+// assemble a frame from an array of data
+//  _q              :   frame generator object
+//  _header         :   frame header
+//  _payload        :   payload data [size: _payload_len x 1]
+//  _payload_len    :   payload data length
+void dsssframegen_assemble(dsssframegen          _q,
+                           const unsigned char * _header,
+                           const unsigned char * _payload,
+                           unsigned int          _payload_len);
+
+int dsssframegen_write_samples(dsssframegen           _q,
+                               liquid_float_complex * _buffer,
+                               unsigned int           _buffer_len);
+
+
+//
+// DSSS frame synchronizer
+//
+
+typedef struct dsssframesync_s * dsssframesync;
+
+dsssframesync dsssframesync_create(framesync_callback _callback, void * _userdata);
+void dsssframesync_destroy(dsssframesync _q);
+void dsssframesync_print(dsssframesync _q);
+void dsssframesync_reset(dsssframesync _q);
+int dsssframesync_is_frame_open(dsssframesync _q);
+void dsssframesync_set_header_len(dsssframesync _q,
+                                  unsigned int  _len);
+void dsssframesync_decode_header_soft(dsssframesync _q,
+                                      int           _soft);
+void dsssframesync_decode_payload_soft(dsssframesync _q,
+                                       int           _soft);
+int dsssframesync_set_header_props(dsssframesync          _q,
+                                   dsssframegenprops_s * _props);
+void dsssframesync_execute(dsssframesync          _q,
+                           liquid_float_complex * _x,
+                           unsigned int           _n);
+void             dsssframesync_reset_framedatastats(dsssframesync _q);
+framedatastats_s dsssframesync_get_framedatastats  (dsssframesync _q);
+
+void dsssframesync_debug_enable(dsssframesync _q);
+void dsssframesync_debug_disable(dsssframesync _q);
+void dsssframesync_debug_print(dsssframesync _q, const char * _filename);
 
 // 
 // OFDM flexframe generator
@@ -6424,6 +6499,74 @@ void liquid_unwrap_phase(float * _theta, unsigned int _n);
 
 // unwrap phase of array (advanced)
 void liquid_unwrap_phase2(float * _theta, unsigned int _n);
+
+#define SYNTH_MANGLE_FLOAT(name)  LIQUID_CONCAT(synth_crcf, name)
+
+// large macro
+//   SYNTH  : name-mangling macro
+//   T      : primitive data type
+//   TC     : input/output data type
+#define LIQUID_SYNTH_DEFINE_API(SYNTH,T,TC)                     \
+typedef struct SYNTH(_s) * SYNTH();                             \
+                                                                \
+SYNTH() SYNTH(_create)(const TC *_table, unsigned int _length); \
+void SYNTH(_destroy)(SYNTH() _q);                               \
+                                                                \
+void SYNTH(_reset)(SYNTH() _q);                                 \
+                                                                \
+/* get/set/adjust internal frequency/phase              */      \
+T    SYNTH(_get_frequency)(   SYNTH() _q);                      \
+void SYNTH(_set_frequency)(   SYNTH() _q, T _f);                \
+void SYNTH(_adjust_frequency)(SYNTH() _q, T _df);               \
+T    SYNTH(_get_phase)(       SYNTH() _q);                      \
+void SYNTH(_set_phase)(       SYNTH() _q, T _phi);              \
+void SYNTH(_adjust_phase)(    SYNTH() _q, T _dphi);             \
+                                                                \
+unsigned int SYNTH(_get_length)(SYNTH() _q);                    \
+TC SYNTH(_get_current)(SYNTH() _q);                             \
+TC SYNTH(_get_half_previous)(SYNTH() _q);                       \
+TC SYNTH(_get_half_next)(SYNTH() _q);                           \
+                                                                \
+void SYNTH(_step)(SYNTH() _q);                                  \
+                                                                \
+/* pll : phase-locked loop                              */      \
+void SYNTH(_pll_set_bandwidth)(SYNTH() _q, T _bandwidth);       \
+void SYNTH(_pll_step)(SYNTH() _q, T _dphi);                     \
+                                                                \
+/* Rotate input sample up by SYNTH angle (no stepping)    */    \
+void SYNTH(_mix_up)(SYNTH() _q, TC _x, TC *_y);                 \
+                                                                \
+/* Rotate input sample down by SYNTH angle (no stepping)  */    \
+void SYNTH(_mix_down)(SYNTH() _q, TC _x, TC *_y);               \
+                                                                \
+/* Rotate input vector up by SYNTH angle (stepping)       */    \
+void SYNTH(_mix_block_up)(SYNTH() _q,                           \
+                          TC *_x,                               \
+                          TC *_y,                               \
+                          unsigned int _N);                     \
+                                                                \
+/* Rotate input vector down by SYNTH angle (stepping)     */    \
+void SYNTH(_mix_block_down)(SYNTH() _q,                         \
+                            TC *_x,                             \
+                            TC *_y,                             \
+                            unsigned int _N);                   \
+                                                                \
+void SYNTH(_spread)(SYNTH() _q,                                 \
+                    TC _x,                                      \
+                    TC *_y);                                    \
+                                                                \
+void SYNTH(_despread)(SYNTH() _q,                               \
+                      TC *_x,                                   \
+                      TC *_y);                                  \
+                                                                \
+void SYNTH(_despread_triple)(SYNTH() _q,                        \
+                             TC *_x,                            \
+                             TC *_early,                        \
+                             TC *_punctual,                     \
+                             TC *_late);                        \
+
+// Define synth APIs
+LIQUID_SYNTH_DEFINE_API(SYNTH_MANGLE_FLOAT, float, liquid_float_complex)
 
 
 

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -1125,6 +1125,18 @@ void bpacketsync_reconfig(bpacketsync _q);
 #define OFDMFLEXFRAME_H_FEC1         (LIQUID_FEC_NONE)           // header FEC (outer)
 #define OFDMFLEXFRAME_H_MOD          (LIQUID_MODEM_BPSK)         // modulation scheme
 
+
+//
+// dsssframe
+//
+
+#define DSSSFRAME_PROTOCOL (101 + PACKETIZER_VERSION)
+#define DSSSFRAME_H_USER_DEFAULT (8)
+#define DSSSFRAME_H_DEC          (5)
+#define DSSSFRAME_H_CRC          (LIQUID_CRC_32)
+#define DSSSFRAME_H_FEC0         (LIQUID_FEC_GOLAY2412)
+#define DSSSFRAME_H_FEC1         (LIQUID_FEC_NONE)
+
 //
 // MODULE : math
 //
@@ -1524,6 +1536,21 @@ LIQUID_NCO_DEFINE_INTERNAL_API(LIQUID_NCO_MANGLE_FLOAT,
                                float,
                                float complex)
 
+// Numerically-controlled synthesizer (direct digital synthesis)
+#define LIQUID_SYNTH_DEFINE_INTERNAL_API(SYNTH,T,TC)            \
+                                                                \
+/* constrain phase/frequency to be in [-pi,pi)          */      \
+void SYNTH(_constrain_phase)(SYNTH() _q);                       \
+void SYNTH(_constrain_frequency)(SYNTH() _q);                   \
+void SYNTH(_compute_synth)(SYNTH() _q);                         \
+                                                                \
+/* reset internal phase-locked loop filter              */      \
+void SYNTH(_pll_reset)(SYNTH() _q);                             \
+
+// Define nco internal APIs
+LIQUID_SYNTH_DEFINE_INTERNAL_API(SYNTH_MANGLE_FLOAT,
+                                 float,
+                                 liquid_float_complex)
 // 
 // MODULE : optim (non-linear optimization)
 //

--- a/makefile.in
+++ b/makefile.in
@@ -587,6 +587,8 @@ framing_objects :=						\
 	src/framing/src/bsync_crcf.o				\
 	src/framing/src/bsync_cccf.o				\
 	src/framing/src/detector_cccf.o				\
+	src/framing/src/dsssframegen.o				\
+	src/framing/src/dsssframesync.o				\
 	src/framing/src/framedatastats.o			\
 	src/framing/src/framesyncstats.o			\
 	src/framing/src/framegen64.o				\
@@ -616,6 +618,8 @@ src/framing/src/bsync_rrrf.o        : %.o : %.c $(include_headers) src/framing/s
 src/framing/src/bsync_crcf.o        : %.o : %.c $(include_headers) src/framing/src/bsync.c
 src/framing/src/bsync_cccf.o        : %.o : %.c $(include_headers) src/framing/src/bsync.c
 src/framing/src/detector_cccf.o     : %.o : %.c $(include_headers)
+src/framing/src/dsssframegen.o      : %.o : %.c $(include_headers)
+src/framing/src/dsssframesync.o     : %.o : %.c $(include_headers)
 src/framing/src/framedatastats.o    : %.o : %.c $(include_headers)
 src/framing/src/framesyncstats.o    : %.o : %.c $(include_headers)
 src/framing/src/framegen64.o        : %.o : %.c $(include_headers)
@@ -886,10 +890,12 @@ multichannel_benchmarks :=					\
 nco_objects :=							\
 	src/nco/src/nco_crcf.o					\
 	src/nco/src/nco.utilities.o				\
+	src/nco/src/synth_crcf.o				\
 
 
 src/nco/src/nco_crcf.o      : %.o : %.c $(include_headers) src/nco/src/nco.c
 src/nco/src/nco.utilities.o : %.o : %.c $(include_headers)
+src/nco/src/synth_crcf.o	: %.o : %.c $(include_headers) src/nco/src/synth.c
 
 
 # autotests
@@ -1379,6 +1385,7 @@ example_programs :=						\
 	examples/cpfskmodem_psd_example				\
 	examples/cvsd_example					\
 	examples/detector_cccf_example				\
+	examples/dsssframesync_example				\
 	examples/dotprod_rrrf_example				\
 	examples/dotprod_cccf_example				\
 	examples/eqlms_cccf_block_example			\
@@ -1626,6 +1633,22 @@ clean-sandbox:
 	$(RM) $(sandbox_programs)
 
 
+.PHONY: tools
+tools_programs =						\
+	tools/msequence_generator			\
+
+tools_objects	= $(patsubst %,%.o,$(tools_programs))
+tools: $(tools_programs)
+
+$(tools_objects): %.o: %.c
+
+$(tools_programs): % : %.o libliquid.a
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+clean-tools:
+	$(RM) tools/*.o
+	$(RM) $(tools_programs)
+
 ##
 ## TARGET : world     - build absolutely everything
 ##
@@ -1662,7 +1685,7 @@ clean-modules:
 	$(RM) src/vector/src/*.o       src/vector/bench/*.o       src/vector/tests/*.o
 	$(RM) src/libliquid.o
 
-clean: clean-modules clean-autoscript clean-check clean-bench clean-examples clean-sandbox
+clean: clean-modules clean-autoscript clean-check clean-bench clean-examples clean-sandbox clean-tools
 	$(RM) $(extra_clean)
 	$(RM) libliquid.a
 	$(RM) $(SHARED_LIB)

--- a/src/fec/src/packetizer.c
+++ b/src/fec/src/packetizer.c
@@ -176,6 +176,10 @@ packetizer packetizer_recreate(packetizer _p,
 // destroy packetizer object
 void packetizer_destroy(packetizer _p)
 {
+    if (!_p) {
+        return;
+    }
+
     // free fec, interleaver objects
     unsigned int i;
     for (i=0; i<_p->plan_len; i++) {

--- a/src/framing/src/dsssframegen.c
+++ b/src/framing/src/dsssframegen.c
@@ -325,8 +325,8 @@ int dsssframegen_write_samples(dsssframegen           _q,
                                liquid_float_complex * _buffer,
                                unsigned int           _buffer_len)
 {
-
-    for (unsigned int i = 0; i < _buffer_len; ++i) {
+    unsigned int i;
+    for (i = 0; i < _buffer_len; ++i) {
         if (_q->sample_counter == 0) {
             liquid_float_complex sym = dsssframegen_generate_symbol(_q);
 

--- a/src/framing/src/dsssframegen.c
+++ b/src/framing/src/dsssframegen.c
@@ -1,0 +1,465 @@
+/*
+ * Copyright (c) 2007 - 2015 Joseph Gaeddert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+//
+// dsssdsssframegen.c
+//
+// dsss flexible frame generator
+//
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <assert.h>
+
+#include "liquid.internal.h"
+
+// reconfigure internal properties
+void                 dsssframegen_reconfigure(dsssframegen _q);
+void                 dsssframegen_reconfigure_header(dsssframegen _q);
+liquid_float_complex dsssframegen_generate_symbol(dsssframegen _q);
+liquid_float_complex dsssframegen_generate_preamble(dsssframegen _q);
+liquid_float_complex dsssframegen_generate_header(dsssframegen _q);
+liquid_float_complex dsssframegen_generate_payload(dsssframegen _q);
+liquid_float_complex dsssframegen_generate_tail(dsssframegen _q);
+
+// default dsssframegen properties
+static dsssframegenprops_s dsssframegenprops_default = {
+    LIQUID_CRC_16,   // check
+    LIQUID_FEC_NONE, // fec0
+    LIQUID_FEC_NONE, // fec1
+};
+
+static dsssframegenprops_s dsssframegenprops_header_default = {
+    DSSSFRAME_H_CRC,
+    DSSSFRAME_H_FEC0,
+    DSSSFRAME_H_FEC1,
+};
+
+enum state {
+    STATE_PREAMBLE = 0, // write preamble p/n sequence
+    STATE_HEADER,       // write header symbols
+    STATE_PAYLOAD,      // write payload symbols
+    STATE_TAIL,         // tail symbols
+};
+
+struct dsssframegen_s {
+    // interpolator
+    unsigned int         k;             // interp samples/symbol (fixed at 2)
+    unsigned int         m;             // interp filter delay (symbols)
+    float                beta;          // excess bandwidth factor
+    firinterp_crcf       interp;        // interpolator object
+    liquid_float_complex buf_interp[2]; // output interpolator buffer [size: k x 1]
+
+    dsssframegenprops_s props;        // payload properties
+    dsssframegenprops_s header_props; // header properties
+
+    // preamble
+    liquid_float_complex * preamble_pn; // p/n sequence
+    synth_crcf             header_synth;
+    synth_crcf             payload_synth;
+
+    // header
+    unsigned char *        header;          // header data
+    unsigned int           header_user_len; // header user section length
+    unsigned int           header_dec_len;  // header length (decoded)
+    qpacketmodem           header_encoder;  // header encoder/modulator
+    unsigned int           header_mod_len;  // header length
+    liquid_float_complex * header_mod;
+
+    // payload
+    unsigned int           payload_dec_len; // length of decoded
+    qpacketmodem           payload_encoder;
+    unsigned int           payload_mod_len;
+    liquid_float_complex * payload_mod;
+
+    // counters/states
+    unsigned int         symbol_counter; // output symbol number
+    unsigned int         sample_counter; // output sample number
+    unsigned int         bit_counter;    // output bit number
+    int                  bit_high;       // current bit is 1
+    liquid_float_complex sym;
+    int                  frame_assembled; // frame assembled flag
+    int                  frame_complete;  // frame completed flag
+    enum state           state;           // write state
+};
+
+dsssframegen dsssframegen_create(dsssframegenprops_s * _fgprops)
+{
+    dsssframegen q = (dsssframegen)calloc(1, sizeof(struct dsssframegen_s));
+    unsigned int i;
+
+    // create pulse-shaping filter
+    q->k      = 2;
+    q->m      = 7;
+    q->beta   = 0.25f;
+    q->interp = firinterp_crcf_create_prototype(LIQUID_FIRFILT_ARKAISER, q->k, q->m, q->beta, 0);
+
+    // generate pn sequence
+    q->preamble_pn = (float complex *)malloc(64 * sizeof(liquid_float_complex));
+    msequence ms   = msequence_create(7, 0x0089, 1);
+    for (i = 0; i < 64; i++) {
+        q->preamble_pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2);
+        q->preamble_pn[i] += (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) * _Complex_I;
+    }
+    msequence_destroy(ms);
+
+    liquid_float_complex * pn = (float complex *)malloc(64 * sizeof(liquid_float_complex));
+    ms                        = msequence_create(7, 0x00cb, 0x53);
+    for (i = 0; i < 64; i++) {
+        pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2);
+        pn[i] += (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) * _Complex_I;
+    }
+    q->header_synth  = synth_crcf_create(pn, 64);
+    q->payload_synth = synth_crcf_create(pn, 64);
+    free(pn);
+    msequence_destroy(ms);
+
+    dsssframegen_reset(q);
+
+    q->header          = NULL;
+    q->header_user_len = DSSSFRAME_H_USER_DEFAULT;
+    q->header_dec_len  = DSSSFRAME_H_DEC + q->header_user_len;
+    q->header_mod      = NULL;
+    q->header_encoder  = qpacketmodem_create();
+
+    q->payload_encoder = qpacketmodem_create();
+    q->payload_dec_len = 0;
+    q->payload_mod_len = 0;
+    q->payload_mod     = NULL;
+
+    dsssframegen_setprops(q, _fgprops);
+    dsssframegen_set_header_props(q, NULL);
+    dsssframegen_set_header_len(q, q->header_user_len);
+
+    return q;
+}
+
+void dsssframegen_destroy(dsssframegen _q)
+{
+    if (!_q) {
+        return;
+    }
+
+    firinterp_crcf_destroy(_q->interp);
+    qpacketmodem_destroy(_q->header_encoder);
+    qpacketmodem_destroy(_q->payload_encoder);
+    synth_crcf_destroy(_q->header_synth);
+    synth_crcf_destroy(_q->payload_synth);
+
+    free(_q->preamble_pn);
+    free(_q->header);
+    free(_q->header_mod);
+    free(_q->payload_mod);
+
+    free(_q);
+}
+
+void dsssframegen_reset(dsssframegen _q)
+{
+    // reset internal counters and state
+    _q->symbol_counter  = 0;
+    _q->bit_counter     = 0;
+    _q->sample_counter  = 0;
+    _q->frame_assembled = 0;
+    _q->frame_complete  = 0;
+    _q->state           = STATE_PREAMBLE;
+}
+
+int dsssframegen_is_assembled(dsssframegen _q)
+{
+    return _q->frame_assembled;
+}
+
+void dsssframegen_getprops(dsssframegen _q, dsssframegenprops_s * _props)
+{
+    memmove(_props, &_q->props, sizeof(dsssframegenprops_s));
+}
+
+int dsssframegen_setprops(dsssframegen _q, dsssframegenprops_s * _props)
+{
+    if (_q->frame_assembled) {
+        fprintf(
+            stderr,
+            "warning: dsssframegen_setprops(), frame is already assembled; must reset() first\n");
+        return -1;
+    }
+
+    if (_props == NULL) {
+        dsssframegen_setprops(_q, &dsssframegenprops_default);
+        return 0;
+    }
+
+    if (_props->check == LIQUID_CRC_UNKNOWN || _props->check >= LIQUID_CRC_NUM_SCHEMES) {
+        fprintf(stderr, "error: dsssframegen_setprops(), invalid/unsupported CRC scheme\n");
+        exit(1);
+    } else if (_props->fec0 == LIQUID_FEC_UNKNOWN || _props->fec1 == LIQUID_FEC_UNKNOWN) {
+        fprintf(stderr, "error: dsssframegen_setprops(), invalid/unsupported FEC scheme\n");
+        exit(1);
+    }
+
+    // copy properties to internal structure
+    memmove(&_q->props, _props, sizeof(dsssframegenprops_s));
+
+    // reconfigure payload buffers (reallocate as necessary)
+    dsssframegen_reconfigure(_q);
+
+    return 0;
+}
+
+void dsssframegen_set_header_len(dsssframegen _q, unsigned int _len)
+{
+    if (_q->frame_assembled) {
+        fprintf(stderr,
+                "warning: dsssframegen_set_header_len(), frame is already assembled; must reset() "
+                "first\n");
+        return;
+    }
+
+    _q->header_user_len = _len;
+    _q->header_dec_len  = DSSSFRAME_H_DEC + _q->header_user_len;
+    _q->header = (unsigned char *)realloc(_q->header, _q->header_dec_len * sizeof(unsigned char));
+
+    dsssframegen_reconfigure_header(_q);
+}
+
+int dsssframegen_set_header_props(dsssframegen _q, dsssframegenprops_s * _props)
+{
+    if (_q->frame_assembled) {
+        fprintf(stderr,
+                "warning: dsssframegen_set_header_props(), frmae is already assembled; must "
+                "reset() first\n");
+        return -1;
+    }
+
+    if (_props == NULL) {
+        _props = &dsssframegenprops_header_default;
+    }
+
+    if (_props->check == LIQUID_CRC_UNKNOWN || _props->check >= LIQUID_CRC_NUM_SCHEMES) {
+        fprintf(stderr, "error: dsssframegen_set_header_props(), invalid/unsupported CRC scheme\n");
+        exit(1);
+    } else if (_props->fec0 == LIQUID_FEC_UNKNOWN || _props->fec1 == LIQUID_FEC_UNKNOWN) {
+        fprintf(stderr, "error: dsssframegen_set_header_props(), invalid/unsupported FEC scheme\n");
+        exit(1);
+    }
+
+    memmove(&_q->header_props, _props, sizeof(dsssframegenprops_s));
+
+    dsssframegen_reconfigure_header(_q);
+
+    return 0;
+}
+
+unsigned int dsssframegen_getframelen(dsssframegen _q)
+{
+    if (!_q->frame_assembled) {
+        fprintf(stderr, "warning: dsssframegen_getframelen(), frame not assembled\n");
+        return 0;
+    }
+
+    unsigned int num_frame_symbols
+        = 64 + // preamble
+          _q->header_mod_len * synth_crcf_get_length(_q->header_synth)
+          + _q->payload_mod_len * synth_crcf_get_length(_q->payload_synth) + 2 * _q->m; // tail
+
+    return num_frame_symbols * _q->k;
+}
+
+void dsssframegen_assemble(dsssframegen          _q,
+                           const unsigned char * _header,
+                           const unsigned char * _payload,
+                           unsigned int          _payload_dec_len)
+{
+    dsssframegen_reset(_q);
+
+    _q->payload_dec_len = _payload_dec_len;
+
+    if (_header == NULL) {
+        memset(_q->header, 0x00, _q->header_user_len * sizeof(unsigned char));
+    } else {
+        memmove(_q->header, _header, _q->header_user_len * sizeof(unsigned char));
+    }
+
+    unsigned int n = _q->header_user_len;
+
+    _q->header[n + 0] = DSSSFRAME_PROTOCOL;
+    _q->header[n + 1] = (_q->payload_dec_len >> 8) & 0xff;
+    _q->header[n + 2] = (_q->payload_dec_len) & 0xff;
+    _q->header[n + 3] = (_q->props.check & 0x07) << 5;
+    _q->header[n + 3] |= (_q->props.fec0) & 0x1f;
+    _q->header[n + 4] = (_q->props.fec1) & 0x1f;
+
+    qpacketmodem_encode(_q->header_encoder, _q->header, _q->header_mod);
+
+    _q->payload_dec_len = _payload_dec_len;
+    dsssframegen_reconfigure(_q);
+
+    qpacketmodem_encode(_q->payload_encoder, _payload, _q->payload_mod);
+
+    _q->frame_assembled = 1;
+}
+
+int dsssframegen_write_samples(dsssframegen           _q,
+                               liquid_float_complex * _buffer,
+                               unsigned int           _buffer_len)
+{
+
+    for (unsigned int i = 0; i < _buffer_len; ++i) {
+        if (_q->sample_counter == 0) {
+            liquid_float_complex sym = dsssframegen_generate_symbol(_q);
+
+            firinterp_crcf_execute(_q->interp, sym, _q->buf_interp);
+        }
+
+        _buffer[i] = _q->buf_interp[_q->sample_counter];
+
+        // apply ramping window to first 'm' symbols
+        if (_q->symbol_counter < _q->m && _q->state == STATE_PREAMBLE) {
+            _buffer[i]
+                *= hamming(_q->symbol_counter * _q->k + _q->sample_counter, 2 * _q->m * _q->k);
+        }
+
+        _q->sample_counter = (_q->sample_counter + 1) % _q->k;
+    }
+
+    return _q->frame_complete;
+}
+
+void dsssframegen_reconfigure(dsssframegen _q)
+{
+    qpacketmodem_configure(_q->payload_encoder,
+                           _q->payload_dec_len,
+                           _q->props.check,
+                           _q->props.fec0,
+                           _q->props.fec1,
+                           LIQUID_MODEM_BPSK);
+    _q->payload_mod_len = qpacketmodem_get_frame_len(_q->payload_encoder);
+    _q->payload_mod     = (liquid_float_complex *)realloc(
+        _q->payload_mod, _q->payload_mod_len * sizeof(liquid_float_complex));
+}
+
+void dsssframegen_reconfigure_header(dsssframegen _q)
+{
+    qpacketmodem_configure(_q->header_encoder,
+                           _q->header_dec_len,
+                           _q->header_props.check,
+                           _q->header_props.fec0,
+                           _q->header_props.fec1,
+                           LIQUID_MODEM_BPSK);
+    _q->header_mod_len = qpacketmodem_get_frame_len(_q->header_encoder);
+    _q->header_mod     = (liquid_float_complex *)realloc(
+        _q->header_mod, _q->header_mod_len * sizeof(liquid_float_complex));
+}
+
+liquid_float_complex dsssframegen_generate_symbol(dsssframegen _q)
+{
+    if (!_q->frame_assembled) {
+        return 0.f;
+    }
+
+    switch (_q->state) {
+    case STATE_PREAMBLE: return dsssframegen_generate_preamble(_q); break;
+    case STATE_HEADER: return dsssframegen_generate_header(_q); break;
+    case STATE_PAYLOAD: return dsssframegen_generate_payload(_q); break;
+    case STATE_TAIL: return dsssframegen_generate_tail(_q); break;
+    default:
+        fprintf(
+            stderr, "error: dsssframegen_generate_symbol(), unknown/unsupported internal state\n");
+        exit(1);
+    }
+
+    return 0.f;
+}
+
+liquid_float_complex dsssframegen_generate_preamble(dsssframegen _q)
+{
+    liquid_float_complex symbol = _q->preamble_pn[_q->symbol_counter];
+    ++_q->symbol_counter;
+
+    if (_q->symbol_counter == 64) {
+        _q->symbol_counter = 0;
+        _q->state          = STATE_HEADER;
+    }
+
+    return symbol;
+}
+
+liquid_float_complex dsssframegen_generate_header(dsssframegen _q)
+{
+    if (_q->symbol_counter == 0) {
+        _q->sym = _q->header_mod[_q->bit_counter];
+    }
+
+    liquid_float_complex symbol;
+    synth_crcf_mix_up(_q->header_synth, _q->sym, &symbol);
+    synth_crcf_step(_q->header_synth);
+
+    ++_q->symbol_counter;
+    if (_q->symbol_counter == synth_crcf_get_length(_q->header_synth)) {
+        _q->symbol_counter = 0;
+        ++_q->bit_counter;
+        if (_q->bit_counter == _q->header_mod_len) {
+            _q->bit_counter = 0;
+            _q->state       = STATE_PAYLOAD;
+        }
+    }
+
+    return symbol;
+}
+
+liquid_float_complex dsssframegen_generate_payload(dsssframegen _q)
+{
+    if (_q->symbol_counter == 0) {
+        _q->sym = _q->payload_mod[_q->bit_counter];
+    }
+
+    liquid_float_complex symbol;
+    synth_crcf_mix_up(_q->payload_synth, _q->sym, &symbol);
+    synth_crcf_step(_q->payload_synth);
+
+    ++_q->symbol_counter;
+    if (_q->symbol_counter == synth_crcf_get_length(_q->payload_synth)) {
+        _q->symbol_counter = 0;
+        ++_q->bit_counter;
+        if (_q->bit_counter == _q->payload_mod_len) {
+            _q->bit_counter = 0;
+            _q->state       = STATE_TAIL;
+        }
+    }
+
+    return symbol;
+}
+
+liquid_float_complex dsssframegen_generate_tail(dsssframegen _q)
+{
+    ++_q->symbol_counter;
+
+    if (_q->symbol_counter == 2 * _q->m) {
+        _q->symbol_counter  = 0;
+        _q->frame_complete  = 1;
+        _q->frame_assembled = 0;
+    }
+    return 0.f;
+}

--- a/src/framing/src/dsssframesync.c
+++ b/src/framing/src/dsssframesync.c
@@ -122,10 +122,11 @@ dsssframesync dsssframesync_create(framesync_callback _callback, void * _userdat
     q->m    = 7;
     q->beta = 0.3f;
 
+    unsigned int i;
     q->preamble_pn = (liquid_float_complex *)calloc(64, sizeof(liquid_float_complex));
     q->preamble_rx = (liquid_float_complex *)calloc(64, sizeof(liquid_float_complex));
     msequence ms   = msequence_create(7, 0x0089, 1);
-    for (unsigned int i = 0; i < 64; i++) {
+    for (i = 0; i < 64; i++) {
         q->preamble_pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2);
         q->preamble_pn[i] += (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) * _Complex_I;
     }
@@ -133,7 +134,7 @@ dsssframesync dsssframesync_create(framesync_callback _callback, void * _userdat
 
     liquid_float_complex * pn = (liquid_float_complex *)calloc(64, sizeof(liquid_float_complex));
     ms                        = msequence_create(7, 0x00cb, 0x53);
-    for (unsigned int i = 0; i < 64; i++) {
+    for (i = 0; i < 64; i++) {
         pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2);
         pn[i] += (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) * _Complex_I;
     }
@@ -277,7 +278,8 @@ int dsssframesync_set_header_props(dsssframesync _q, dsssframegenprops_s * _prop
 
 void dsssframesync_execute(dsssframesync _q, liquid_float_complex * _x, unsigned int _n)
 {
-    for (unsigned int i = 0; i < _n; i++) {
+    unsigned int i;
+    for (i = 0; i < _n; i++) {
         switch (_q->state) {
         case DSSSFRAMESYNC_STATE_DETECTFRAME:
             // detect frame (look for p/n sequence)

--- a/src/framing/src/dsssframesync.c
+++ b/src/framing/src/dsssframesync.c
@@ -1,0 +1,607 @@
+/*
+ * Copyright (c) 2007 - 2015 Joseph Gaeddert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+//
+// dsssframesync.c
+//
+
+#include <assert.h>
+#include <complex.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "liquid.internal.h"
+
+void dsssframesync_execute_seekpn(dsssframesync _q, liquid_float_complex _x);
+
+int dsssframesync_step(dsssframesync _q, liquid_float_complex _x, liquid_float_complex * _y);
+
+void dsssframesync_execute_rxpreamble(dsssframesync _q, liquid_float_complex _x);
+
+int dsssframesync_decode_header(dsssframesync _q);
+
+int dsssframesync_decode_payload(dsssframesync _q);
+
+void dsssframesync_execute_rxheader(dsssframesync _q, liquid_float_complex _x);
+
+void dsssframesync_execute_rxpayload(dsssframesync _q, liquid_float_complex _x);
+
+void dsssframesync_configure_payload(dsssframesync _q);
+
+static dsssframegenprops_s dsssframesyncprops_header_default = {
+    DSSSFRAME_H_CRC,
+    DSSSFRAME_H_FEC0,
+    DSSSFRAME_H_FEC1,
+};
+
+enum state {
+    DSSSFRAMESYNC_STATE_DETECTFRAME = 0,
+    DSSSFRAMESYNC_STATE_RXPREAMBLE,
+    DSSSFRAMESYNC_STATE_RXHEADER,
+    DSSSFRAMESYNC_STATE_RXPAYLOAD,
+};
+
+struct dsssframesync_s {
+    framesync_callback callback;
+    void *             userdata;
+    framesyncstats_s   framesyncstats;
+    framedatastats_s   framedatastats;
+
+    unsigned int   k;
+    unsigned int   m;
+    float          beta;
+    qdetector_cccf detector;
+    float          tau_hat;
+    float          dphi_hat;
+    float          phi_hat;
+    float          gamma_hat;
+    nco_crcf       mixer;
+    nco_crcf       pll;
+
+    firpfb_crcf  mf;
+    unsigned int npfb;
+    int          mf_counter;
+    unsigned int pfb_index;
+
+    liquid_float_complex * preamble_pn;
+    liquid_float_complex * preamble_rx;
+    synth_crcf             header_synth;
+    synth_crcf             payload_synth;
+
+    int                    header_soft;
+    flexframegenprops_s    header_props;
+    liquid_float_complex * header_spread;
+    unsigned int           header_spread_len;
+    qpacketmodem           header_decoder;
+    unsigned int           header_user_len;
+    unsigned int           header_dec_len;
+    unsigned char *        header_dec;
+    int                    header_valid;
+
+    int                    payload_soft;
+    liquid_float_complex * payload_spread;
+    unsigned int           payload_spread_len;
+    qpacketmodem           payload_decoder;
+    unsigned int           payload_dec_len;
+    unsigned char *        payload_dec;
+    int                    payload_valid;
+
+    unsigned int preamble_counter;
+    unsigned int symbol_counter;
+    enum state   state;
+};
+
+dsssframesync dsssframesync_create(framesync_callback _callback, void * _userdata)
+{
+    dsssframesync q = (dsssframesync)calloc(1, sizeof(struct dsssframesync_s));
+    q->callback     = _callback;
+    q->userdata     = _userdata;
+
+    q->k    = 2;
+    q->m    = 7;
+    q->beta = 0.3f;
+
+    q->preamble_pn = (liquid_float_complex *)calloc(64, sizeof(liquid_float_complex));
+    q->preamble_rx = (liquid_float_complex *)calloc(64, sizeof(liquid_float_complex));
+    msequence ms   = msequence_create(7, 0x0089, 1);
+    for (unsigned int i = 0; i < 64; i++) {
+        q->preamble_pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2);
+        q->preamble_pn[i] += (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) * _Complex_I;
+    }
+    msequence_destroy(ms);
+
+    liquid_float_complex * pn = (liquid_float_complex *)calloc(64, sizeof(liquid_float_complex));
+    ms                        = msequence_create(7, 0x00cb, 0x53);
+    for (unsigned int i = 0; i < 64; i++) {
+        pn[i] = (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2);
+        pn[i] += (msequence_advance(ms) ? M_SQRT1_2 : -M_SQRT1_2) * _Complex_I;
+    }
+    q->header_synth  = synth_crcf_create(pn, 64);
+    q->payload_synth = synth_crcf_create(pn, 64);
+    synth_crcf_pll_set_bandwidth(q->header_synth, 1e-4f);
+    synth_crcf_pll_set_bandwidth(q->payload_synth, 1e-4f);
+    free(pn);
+    msequence_destroy(ms);
+
+    q->detector = qdetector_cccf_create_linear(
+        q->preamble_pn, 64, LIQUID_FIRFILT_ARKAISER, q->k, q->m, q->beta);
+    qdetector_cccf_set_threshold(q->detector, 0.5f);
+
+    q->npfb = 32;
+    q->mf   = firpfb_crcf_create_rnyquist(LIQUID_FIRFILT_ARKAISER, q->npfb, q->k, q->m, q->beta);
+
+    q->mixer = nco_crcf_create(LIQUID_NCO);
+    q->pll   = nco_crcf_create(LIQUID_NCO);
+    nco_crcf_pll_set_bandwidth(q->pll, 1e-4f); // very low bandwidth
+
+    q->header_decoder  = qpacketmodem_create();
+    q->header_user_len = DSSSFRAME_H_USER_DEFAULT;
+    dsssframesync_set_header_props(q, NULL);
+
+    q->payload_decoder    = qpacketmodem_create();
+    q->payload_spread_len = 64;
+    q->payload_spread
+        = (liquid_float_complex *)malloc(q->payload_spread_len * sizeof(liquid_float_complex));
+
+    dsssframesync_reset_framedatastats(q);
+    dsssframesync_reset(q);
+
+    return q;
+}
+
+void dsssframesync_destroy(dsssframesync _q)
+{
+    if (!_q) {
+        return;
+    }
+
+    free(_q->preamble_pn);
+    free(_q->preamble_rx);
+    free(_q->header_spread);
+    free(_q->header_dec);
+    free(_q->payload_spread);
+    free(_q->payload_dec);
+
+    qpacketmodem_destroy(_q->header_decoder);
+    qpacketmodem_destroy(_q->payload_decoder);
+    qdetector_cccf_destroy(_q->detector);
+    firpfb_crcf_destroy(_q->mf);
+    nco_crcf_destroy(_q->mixer);
+    nco_crcf_destroy(_q->pll);
+    synth_crcf_destroy(_q->header_synth);
+    synth_crcf_destroy(_q->payload_synth);
+
+    free(_q);
+}
+
+void dsssframesync_print(dsssframesync _q)
+{
+    printf("dsssframesync:\n");
+    framedatastats_print(&_q->framedatastats);
+}
+
+void dsssframesync_reset(dsssframesync _q)
+{
+    qdetector_cccf_reset(_q->detector);
+
+    nco_crcf_reset(_q->mixer);
+    nco_crcf_reset(_q->pll);
+
+    firpfb_crcf_reset(_q->mf);
+
+    _q->state            = DSSSFRAMESYNC_STATE_DETECTFRAME;
+    _q->preamble_counter = 0;
+    _q->symbol_counter   = 0;
+
+    _q->framesyncstats.evm = 0.f;
+}
+
+int dsssframesync_is_frame_open(dsssframesync _q)
+{
+    return (_q->state == DSSSFRAMESYNC_STATE_DETECTFRAME) ? 0 : 1;
+}
+
+void dsssframesync_set_header_len(dsssframesync _q, unsigned int _len)
+{
+    _q->header_user_len = _len;
+    _q->header_dec_len  = DSSSFRAME_H_DEC + _q->header_user_len;
+    _q->header_dec
+        = (unsigned char *)realloc(_q->header_dec, _q->header_dec_len * sizeof(unsigned char));
+    qpacketmodem_configure(_q->header_decoder,
+                           _q->header_dec_len,
+                           _q->header_props.check,
+                           _q->header_props.fec0,
+                           _q->header_props.fec1,
+                           LIQUID_MODEM_BPSK);
+
+    _q->header_spread_len = synth_crcf_get_length(_q->header_synth);
+    _q->header_spread     = (liquid_float_complex *)realloc(
+        _q->header_spread, _q->header_spread_len * sizeof(liquid_float_complex));
+}
+
+void dsssframesync_decode_header_soft(dsssframesync _q, int _soft)
+{
+    _q->header_soft = _soft;
+}
+
+void dsssframesync_decode_payload_soft(dsssframesync _q, int _soft)
+{
+    _q->payload_soft = _soft;
+}
+
+int dsssframesync_set_header_props(dsssframesync _q, dsssframegenprops_s * _props)
+{
+    if (_props == NULL) {
+        _props = &dsssframesyncprops_header_default;
+    }
+
+    if (_props->check == LIQUID_CRC_UNKNOWN || _props->check >= LIQUID_CRC_NUM_SCHEMES) {
+        fprintf(
+            stderr, "error: dsssframesync_set_header_props(), invalid/unsupported CRC scheme\n");
+        exit(1);
+    } else if (_props->fec0 == LIQUID_FEC_UNKNOWN || _props->fec1 == LIQUID_FEC_UNKNOWN) {
+        fprintf(
+            stderr, "error: dsssframesync_set_header_props(), invalid/unsupported FEC scheme\n");
+        exit(1);
+    }
+
+    // copy properties to internal structure
+    memmove(&_q->header_props, _props, sizeof(dsssframegenprops_s));
+
+    // reconfigure payload buffers (reallocate as necessary)
+    dsssframesync_set_header_len(_q, _q->header_user_len);
+
+    return 0;
+}
+
+void dsssframesync_execute(dsssframesync _q, liquid_float_complex * _x, unsigned int _n)
+{
+    for (unsigned int i = 0; i < _n; i++) {
+        switch (_q->state) {
+        case DSSSFRAMESYNC_STATE_DETECTFRAME:
+            // detect frame (look for p/n sequence)
+            dsssframesync_execute_seekpn(_q, _x[i]);
+            break;
+        case DSSSFRAMESYNC_STATE_RXPREAMBLE:
+            // receive p/n sequence symbols
+            dsssframesync_execute_rxpreamble(_q, _x[i]);
+            break;
+        case DSSSFRAMESYNC_STATE_RXHEADER:
+            // receive header symbols
+            dsssframesync_execute_rxheader(_q, _x[i]);
+            break;
+        case DSSSFRAMESYNC_STATE_RXPAYLOAD:
+            // receive payload symbols
+            dsssframesync_execute_rxpayload(_q, _x[i]);
+            break;
+        default:
+            fprintf(stderr, "error: dsssframesync_exeucte(), unknown/unsupported state\n");
+            exit(1);
+        }
+    }
+}
+
+// execute synchronizer, seeking p/n sequence
+//  _q      :   frame synchronizer object
+//  _x      :   input sample
+//  _sym    :   demodulated symbol
+void dsssframesync_execute_seekpn(dsssframesync _q, float complex _x)
+{
+    // push through pre-demod synchronizer
+    float complex * v = qdetector_cccf_execute(_q->detector, _x);
+
+    // check if frame has been detected
+    if (v == NULL)
+        return;
+
+    // get estimates
+    _q->tau_hat   = qdetector_cccf_get_tau(_q->detector);
+    _q->gamma_hat = qdetector_cccf_get_gamma(_q->detector);
+    _q->dphi_hat  = qdetector_cccf_get_dphi(_q->detector);
+    _q->phi_hat   = qdetector_cccf_get_phi(_q->detector);
+
+    // set appropriate filterbank index
+    if (_q->tau_hat > 0) {
+        _q->pfb_index  = (unsigned int)(_q->tau_hat * _q->npfb) % _q->npfb;
+        _q->mf_counter = 0;
+    } else {
+        _q->pfb_index  = (unsigned int)((1.0f + _q->tau_hat) * _q->npfb) % _q->npfb;
+        _q->mf_counter = 1;
+    }
+
+    // output filter scale (gain estimate, scaled by 1/2 for k=2 samples/symbol)
+    firpfb_crcf_set_scale(_q->mf, 0.5f / _q->gamma_hat);
+
+    // set frequency/phase of mixer
+    nco_crcf_set_frequency(_q->mixer, _q->dphi_hat);
+    nco_crcf_set_phase(_q->mixer, _q->phi_hat);
+
+    // update state
+    _q->state = DSSSFRAMESYNC_STATE_RXPREAMBLE;
+
+    // run buffered samples through synchronizer
+    unsigned int buf_len = qdetector_cccf_get_buf_len(_q->detector);
+    dsssframesync_execute(_q, v, buf_len);
+}
+
+int dsssframesync_step(dsssframesync _q, float complex _x, float complex * _y)
+{
+    // mix sample down
+    float complex v;
+    nco_crcf_mix_down(_q->mixer, _x, &v);
+    nco_crcf_step(_q->mixer);
+
+    // push sample into filterbank
+    firpfb_crcf_push(_q->mf, v);
+    firpfb_crcf_execute(_q->mf, _q->pfb_index, &v);
+
+    // increment counter to determine if sample is available
+    _q->mf_counter++;
+    int sample_available = (_q->mf_counter >= 1) ? 1 : 0;
+
+    // set output sample if available
+    if (sample_available) {
+        // set output
+        *_y = v;
+
+        // decrement counter by k=2 samples/symbol
+        _q->mf_counter -= _q->k;
+    }
+
+    // return flag
+    return sample_available;
+}
+
+void dsssframesync_execute_rxpreamble(dsssframesync _q, float complex _x)
+{
+    // step synchronizer
+    float complex mf_out           = 0.0f;
+    int           sample_available = dsssframesync_step(_q, _x, &mf_out);
+
+    // compute output if timeout
+    if (!sample_available) {
+        return;
+    }
+
+    // save output in p/n symbols buffer
+    unsigned int delay = _q->k * _q->m; // delay from matched filter
+    if (_q->preamble_counter >= delay) {
+        unsigned int index     = _q->preamble_counter - delay;
+        _q->preamble_rx[index] = mf_out;
+    }
+
+    // update p/n counter
+    _q->preamble_counter++;
+
+    // update state
+    if (_q->preamble_counter == 64 + delay) {
+        _q->state = DSSSFRAMESYNC_STATE_RXHEADER;
+    }
+}
+
+void dsssframesync_execute_rxheader(dsssframesync _q, liquid_float_complex _x)
+{
+    liquid_float_complex mf_out           = 0.f;
+    int                  sample_available = dsssframesync_step(_q, _x, &mf_out);
+
+    if (!sample_available) {
+        return;
+    }
+
+    _q->header_spread[_q->symbol_counter % synth_crcf_get_length(_q->header_synth)] = mf_out;
+    ++_q->symbol_counter;
+
+    if (_q->symbol_counter % synth_crcf_get_length(_q->header_synth) != 0) {
+        return;
+    }
+
+    int header_complete = dsssframesync_decode_header(_q);
+
+    if (!header_complete) {
+        return;
+    }
+
+    if (_q->header_valid) {
+        _q->symbol_counter = 0;
+        _q->state = DSSSFRAMESYNC_STATE_RXPAYLOAD;
+        return;
+    }
+
+    // if not taken, header is NOT valid
+
+    ++_q->framedatastats.num_frames_detected;
+
+    if (_q->callback != NULL) {
+        _q->framesyncstats.evm           = 0.f;
+        _q->framesyncstats.rssi          = 20 * log10f(_q->gamma_hat);
+        _q->framesyncstats.cfo           = nco_crcf_get_frequency(_q->mixer);
+        _q->framesyncstats.framesyms     = NULL;
+        _q->framesyncstats.num_framesyms = 0;
+        _q->framesyncstats.check         = LIQUID_CRC_UNKNOWN;
+        _q->framesyncstats.fec0          = LIQUID_FEC_UNKNOWN;
+        _q->framesyncstats.fec1          = LIQUID_FEC_UNKNOWN;
+
+        _q->callback(
+            _q->header_dec, _q->header_valid, NULL, 0, 0, _q->framesyncstats, _q->userdata);
+    }
+
+    dsssframesync_reset(_q);
+}
+
+int dsssframesync_decode_header(dsssframesync _q)
+{
+    liquid_float_complex prev_corr, corr, next_corr;
+    nco_crcf_mix_block_down(
+        _q->pll, _q->header_spread, _q->header_spread, synth_crcf_get_length(_q->header_synth));
+    synth_crcf_despread_triple(_q->header_synth, _q->header_spread, &prev_corr, &corr, &next_corr);
+
+    int   complete    = qpacketmodem_decode_soft_sym(_q->header_decoder, corr);
+    float phase_error = qpacketmodem_get_demodulator_phase_error(_q->header_decoder);
+
+    nco_crcf_pll_step(_q->pll, synth_crcf_get_length(_q->header_synth) * phase_error);
+
+    if (!complete) {
+        return 0;
+    }
+
+    dsssframesync_configure_payload(_q);
+    return 1;
+}
+
+void dsssframesync_configure_payload(dsssframesync _q)
+{
+    _q->header_valid = qpacketmodem_decode_soft_payload(_q->header_decoder, _q->header_dec);
+
+    if (!_q->header_valid) {
+        return;
+    }
+
+    unsigned int n = _q->header_user_len;
+
+    unsigned int protocol = _q->header_dec[n + 0];
+    if (protocol != DSSSFRAME_PROTOCOL) {
+        fprintf(
+            stderr,
+            "warning, dsssframesync_decode_header(), invalid framing protocol %u (expected %u)\n",
+            protocol,
+            DSSSFRAME_PROTOCOL);
+        _q->header_valid = 0;
+        return;
+    }
+
+    unsigned int payload_dec_len = (_q->header_dec[n + 1] << 8) | (_q->header_dec[n + 2]);
+    _q->payload_dec_len          = payload_dec_len;
+
+    unsigned int check = (_q->header_dec[n + 3] >> 5) & 0x07;
+    unsigned int fec0  = (_q->header_dec[n + 3]) & 0x1f;
+    unsigned int fec1  = (_q->header_dec[n + 4]) & 0x1f;
+
+    if (check == LIQUID_CRC_UNKNOWN || check >= LIQUID_CRC_NUM_SCHEMES) {
+        fprintf(stderr, "warning: dsssframesync_decode_header(), decoded CRC exceeds available\n");
+        _q->header_valid = 0;
+        return;
+    } else if (fec0 == LIQUID_FEC_UNKNOWN || fec0 >= LIQUID_FEC_NUM_SCHEMES) {
+        fprintf(stderr,
+                "warning: dsssframesync_decode_header(), decoded FEC (inner) exceeds available\n");
+        _q->header_valid = 0;
+        return;
+    } else if (fec1 == LIQUID_FEC_UNKNOWN || fec1 >= LIQUID_FEC_NUM_SCHEMES) {
+        fprintf(stderr,
+                "warning: dsssframesync_decode_header(), decoded FEC (outer) exceeds available\n");
+        _q->header_valid = 0;
+        return;
+    }
+
+    _q->payload_dec
+        = (unsigned char *)realloc(_q->payload_dec, (_q->payload_dec_len) * sizeof(unsigned char));
+    qpacketmodem_configure(
+        _q->payload_decoder, _q->payload_dec_len, check, fec0, fec1, LIQUID_MODEM_BPSK);
+
+    synth_crcf_set_frequency(_q->payload_synth, synth_crcf_get_frequency(_q->header_synth));
+
+    return;
+}
+
+void dsssframesync_execute_rxpayload(dsssframesync _q, liquid_float_complex _x)
+{
+    liquid_float_complex mf_out           = 0.f;
+    int                  sample_available = dsssframesync_step(_q, _x, &mf_out);
+
+    if (!sample_available) {
+        return;
+    }
+
+    _q->payload_spread[_q->symbol_counter % synth_crcf_get_length(_q->payload_synth)] = mf_out;
+    ++_q->symbol_counter;
+
+    if (_q->symbol_counter % synth_crcf_get_length(_q->payload_synth) != 0) {
+        return;
+    }
+
+    int payload_complete = dsssframesync_decode_payload(_q);
+
+    if (!payload_complete) {
+        return;
+    }
+
+    _q->framesyncstats.check = qpacketmodem_get_crc(_q->payload_decoder);
+    _q->framesyncstats.fec0  = qpacketmodem_get_fec0(_q->payload_decoder);
+    _q->framesyncstats.fec1  = qpacketmodem_get_fec1(_q->payload_decoder);
+
+    if (_q->callback != NULL) {
+        _q->callback(_q->header_dec,
+                     _q->header_valid,
+                     _q->payload_dec,
+                     _q->payload_dec_len,
+                     _q->payload_valid,
+                     _q->framesyncstats,
+                     _q->userdata);
+    }
+
+    dsssframesync_reset(_q);
+}
+
+int dsssframesync_decode_payload(dsssframesync _q)
+{
+    liquid_float_complex prev_corr, corr, next_corr;
+    nco_crcf_mix_block_down(
+        _q->pll, _q->payload_spread, _q->payload_spread, synth_crcf_get_length(_q->payload_synth));
+    synth_crcf_despread_triple(
+        _q->payload_synth, _q->payload_spread, &prev_corr, &corr, &next_corr);
+
+    int   complete    = qpacketmodem_decode_soft_sym(_q->payload_decoder, corr);
+    float phase_error = qpacketmodem_get_demodulator_phase_error(_q->payload_decoder);
+
+    nco_crcf_pll_step(_q->pll, synth_crcf_get_length(_q->payload_synth) * phase_error);
+
+    if (!complete) {
+        return 0;
+    }
+
+    _q->payload_valid = qpacketmodem_decode_soft_payload(_q->payload_decoder, _q->payload_dec);
+
+    return 1;
+}
+
+void dsssframesync_reset_framedatastats(dsssframesync _q)
+{
+    framedatastats_reset(&_q->framedatastats);
+}
+
+framedatastats_s dsssframesync_get_framedatastats(dsssframesync _q)
+{
+    return _q->framedatastats;
+}
+
+void dsssframesync_debug_enable(dsssframesync _q)
+{
+}
+
+void dsssframesync_debug_disable(dsssframesync _q)
+{
+}
+
+void dsssframesync_debug_print(dsssframesync _q, const char * _filename)
+{
+}

--- a/src/framing/src/qdetector_cccf.c
+++ b/src/framing/src/qdetector_cccf.c
@@ -24,122 +24,117 @@
 // qdetector_cccf.c
 //
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 #include <assert.h>
 
 #include "liquid.internal.h"
 
-#define DEBUG_QDETECTOR              0
-#define DEBUG_QDETECTOR_PRINT        0
-#define DEBUG_QDETECTOR_FILENAME     "qdetector_cccf_debug.m"
+#define DEBUG_QDETECTOR 0
+#define DEBUG_QDETECTOR_PRINT 0
+#define DEBUG_QDETECTOR_FILENAME "qdetector_cccf_debug.m"
 
 // seek signal (initial detection)
-void qdetector_cccf_execute_seek(qdetector_cccf _q,
-                                 float complex  _x);
+void qdetector_cccf_execute_seek(qdetector_cccf _q, liquid_float_complex _x);
 
 // align signal in time, compute offset estimates
-void qdetector_cccf_execute_align(qdetector_cccf _q,
-                                  float complex  _x);
+void qdetector_cccf_execute_align(qdetector_cccf _q, liquid_float_complex _x);
+
+enum state {
+    QDETECTOR_STATE_SEEK,  // seek sequence
+    QDETECTOR_STATE_ALIGN, // align sequence
+};
 
 // main object definition
 struct qdetector_cccf_s {
-    unsigned int    s_len;          // template (time) length: k * (sequence_len + 2*m)
-    float complex * s;              // template (time), [size: s_len x 1]
-    float complex * S;              // template (freq), [size: nfft x 1]
-    float           s2_sum;         // sum{ s^2 }
+    unsigned int           s_len;  // template (time) length: k * (sequence_len + 2*m)
+    liquid_float_complex * s;      // template (time), [size: s_len x 1]
+    liquid_float_complex * S;      // template (freq), [size: nfft x 1]
+    float                  s2_sum; // sum{ s^2 }
 
-    float complex * buf_time_0;     // time-domain buffer (FFT)
-    float complex * buf_freq_0;     // frequence-domain buffer (FFT)
-    float complex * buf_freq_1;     // frequence-domain buffer (IFFT)
-    float complex * buf_time_1;     // time-domain buffer (IFFT)
-    unsigned int    nfft;           // fft size
-    fftplan         fft;            // FFT object:  buf_time_0 > buf_freq_0
-    fftplan         ifft;           // IFFT object: buf_freq_1 > buf_freq_1
+    liquid_float_complex * buf_time_0; // time-domain buffer (FFT)
+    liquid_float_complex * buf_freq_0; // frequence-domain buffer (FFT)
+    liquid_float_complex * buf_freq_1; // frequence-domain buffer (IFFT)
+    liquid_float_complex * buf_time_1; // time-domain buffer (IFFT)
+    unsigned int           nfft;       // fft size
+    fftplan                fft;        // FFT object:  buf_time_0 > buf_freq_0
+    fftplan                ifft;       // IFFT object: buf_freq_1 > buf_freq_1
 
-    unsigned int    counter;        // sample counter for determining when to compute FFTs
-    float           threshold;      // detection threshold
-    int             range;          // carrier offset search range (subcarriers)
-    unsigned int    num_transforms; // number of transforms taken (debugging)
+    unsigned int counter;        // sample counter for determining when to compute FFTs
+    float        threshold;      // detection threshold
+    int          range;          // carrier offset search range (subcarriers)
+    unsigned int num_transforms; // number of transforms taken (debugging)
 
-    float           x2_sum_0;       // sum{ |x|^2 } of first half of buffer
-    float           x2_sum_1;       // sum{ |x|^2 } of second half of buffer
+    float x2_sum_0; // sum{ |x|^2 } of first half of buffer
+    float x2_sum_1; // sum{ |x|^2 } of second half of buffer
 
-    int             offset;         // FFT offset index for peak correlation (coarse carrier estimate)
-    float           tau_hat;        // timing offset estimate
-    float           gamma_hat;      // signal level estimate (channel gain)
-    float           dphi_hat;       // carrier frequency offset estimate
-    float           phi_hat;        // carrier phase offset estimate
+    int   offset;    // FFT offset index for peak correlation (coarse carrier estimate)
+    float tau_hat;   // timing offset estimate
+    float gamma_hat; // signal level estimate (channel gain)
+    float dphi_hat;  // carrier frequency offset estimate
+    float phi_hat;   // carrier phase offset estimate
 
-    enum {
-        QDETECTOR_STATE_SEEK,       // seek sequence
-        QDETECTOR_STATE_ALIGN,      // align sequence
-    }               state;          // execution state
-    int             frame_detected; // frame detected?
+    enum state state;          // execution state
+    int        frame_detected; // frame detected?
 };
 
-// create detector with generic sequence
-//  _s      :   sample sequence
-//  _s_len  :   length of sample sequence
-qdetector_cccf qdetector_cccf_create(float complex * _s,
-                                     unsigned int    _s_len)
+qdetector_cccf qdetector_cccf_create(liquid_float_complex * _s, unsigned int _s_len)
 {
     // validate input
     if (_s_len == 0) {
-        fprintf(stderr,"error: qdetector_cccf_create(), sequence length cannot be zero\n");
+        fprintf(stderr, "error: qdetector_cccf_create(), sequence length cannot be zero\n");
         exit(1);
     }
-    
+
     // allocate memory for main object and set internal properties
-    qdetector_cccf q = (qdetector_cccf) malloc(sizeof(struct qdetector_cccf_s));
-    q->s_len = _s_len;
+    qdetector_cccf q = (qdetector_cccf)malloc(sizeof(struct qdetector_cccf_s));
+    q->s_len         = _s_len;
 
     // allocate memory and copy sequence
-    q->s = (float complex*) malloc(q->s_len * sizeof(float complex));
-    memmove(q->s, _s, q->s_len*sizeof(float complex));
+    q->s = (liquid_float_complex *)malloc(q->s_len * sizeof(liquid_float_complex));
+    memmove(q->s, _s, q->s_len * sizeof(liquid_float_complex));
     q->s2_sum = liquid_sumsqcf(q->s, q->s_len); // compute sum{ s^2 }
 
     // prepare transforms
-    q->nfft       = 1 << liquid_nextpow2( (unsigned int)( 2 * q->s_len ) ); // NOTE: must be even
-    q->buf_time_0 = (float complex*) malloc(q->nfft * sizeof(float complex));
-    q->buf_freq_0 = (float complex*) malloc(q->nfft * sizeof(float complex));
-    q->buf_freq_1 = (float complex*) malloc(q->nfft * sizeof(float complex));
-    q->buf_time_1 = (float complex*) malloc(q->nfft * sizeof(float complex));
+    q->nfft       = 1 << liquid_nextpow2((unsigned int)(2 * q->s_len)); // NOTE: must be even
+    q->buf_time_0 = (liquid_float_complex *) malloc(q->nfft * sizeof(liquid_float_complex));
+    q->buf_freq_0 = (liquid_float_complex *) malloc(q->nfft * sizeof(liquid_float_complex));
+    q->buf_freq_1 = (liquid_float_complex *) malloc(q->nfft * sizeof(liquid_float_complex));
+    q->buf_time_1 = (liquid_float_complex *) malloc(q->nfft * sizeof(liquid_float_complex));
 
-    q->fft  = fft_create_plan(q->nfft, q->buf_time_0, q->buf_freq_0, LIQUID_FFT_FORWARD,  0);
+    q->fft  = fft_create_plan(q->nfft, q->buf_time_0, q->buf_freq_0, LIQUID_FFT_FORWARD, 0);
     q->ifft = fft_create_plan(q->nfft, q->buf_freq_1, q->buf_time_1, LIQUID_FFT_BACKWARD, 0);
 
     // create frequency-domain template by taking nfft-point transform on 's', storing in 'S'
-    q->S = (float complex*) malloc(q->nfft * sizeof(float complex));
-    memset(q->buf_time_0, 0x00, q->nfft*sizeof(float complex));
-    memmove(q->buf_time_0, q->s, q->s_len*sizeof(float complex));
+    q->S = (liquid_float_complex *)malloc(q->nfft * sizeof(liquid_float_complex));
+    memset(q->buf_time_0, 0x00, q->nfft * sizeof(liquid_float_complex));
+    memmove(q->buf_time_0, q->s, q->s_len * sizeof(liquid_float_complex));
     fft_execute(q->fft);
-    memmove(q->S, q->buf_freq_0, q->nfft*sizeof(float complex));
+    memmove(q->S, q->buf_freq_0, q->nfft * sizeof(liquid_float_complex));
 
     // reset state variables
-    q->counter        = q->nfft/2;
+    q->counter        = q->nfft / 2;
     q->num_transforms = 0;
     q->x2_sum_0       = 0.0f;
     q->x2_sum_1       = 0.0f;
     q->state          = QDETECTOR_STATE_SEEK;
     q->frame_detected = 0;
-    memset(q->buf_time_0, 0x00, q->nfft*sizeof(float complex));
-    
+    memset(q->buf_time_0, 0x00, q->nfft * sizeof(liquid_float_complex));
+
     // reset estimates
     q->tau_hat   = 0.0f;
     q->gamma_hat = 0.0f;
     q->dphi_hat  = 0.0f;
     q->phi_hat   = 0.0f;
 
-    qdetector_cccf_set_threshold(q,0.5f);
-    qdetector_cccf_set_range    (q,0.3f); // set initial range for higher detection
+    qdetector_cccf_set_threshold(q, 0.5f);
+    qdetector_cccf_set_range(q, 0.3f); // set initial range for higher detection
 
     // return object
     return q;
 }
-
 
 // create detector from sequence of symbols using internal linear interpolator
 //  _sequence       :   symbol sequence
@@ -148,35 +143,38 @@ qdetector_cccf qdetector_cccf_create(float complex * _s,
 //  _k              :   samples/symbol
 //  _m              :   filter delay
 //  _beta           :   excess bandwidth factor
-qdetector_cccf qdetector_cccf_create_linear(float complex * _sequence,
-                                            unsigned int    _sequence_len,
-                                            int             _ftype,
-                                            unsigned int    _k,
-                                            unsigned int    _m,
-                                            float           _beta)
+qdetector_cccf qdetector_cccf_create_linear(liquid_float_complex * _sequence,
+                                            unsigned int           _sequence_len,
+                                            int                    _ftype,
+                                            unsigned int           _k,
+                                            unsigned int           _m,
+                                            float                  _beta)
 {
     // validate input
     if (_sequence_len == 0) {
-        fprintf(stderr,"error: qdetector_cccf_create_linear(), sequence length cannot be zero\n");
+        fprintf(stderr, "error: qdetector_cccf_create_linear(), sequence length cannot be zero\n");
         exit(1);
     } else if (_k < 2 || _k > 80) {
-        fprintf(stderr,"error: qdetector_cccf_create_linear(), samples per symbol must be in [2,80]\n");
+        fprintf(stderr,
+                "error: qdetector_cccf_create_linear(), samples per symbol must be in [2,80]\n");
         exit(1);
     } else if (_m < 1 || _m > 100) {
-        fprintf(stderr,"error: qdetector_cccf_create_linear(), filter delay must be in [1,100]\n");
+        fprintf(stderr, "error: qdetector_cccf_create_linear(), filter delay must be in [1,100]\n");
         exit(1);
     } else if (_beta < 0.0f || _beta > 1.0f) {
-        fprintf(stderr,"error: qdetector_cccf_create_linear(), excess bandwidth factor must be in [0,1]\n");
+        fprintf(
+            stderr,
+            "error: qdetector_cccf_create_linear(), excess bandwidth factor must be in [0,1]\n");
         exit(1);
     }
-    
+
     // create time-domain template
-    unsigned int    s_len = _k * (_sequence_len + 2*_m);
-    float complex * s     = (float complex*) malloc(s_len * sizeof(float complex));
-    firinterp_crcf interp = firinterp_crcf_create_prototype(_ftype, _k, _m, _beta, 0);
-    unsigned int i;
-    for (i=0; i<_sequence_len + 2*_m; i++)
-        firinterp_crcf_execute(interp, i < _sequence_len ? _sequence[i] : 0, &s[_k*i]);
+    unsigned int           s_len = _k * (_sequence_len + 2 * _m);
+    liquid_float_complex * s = (liquid_float_complex *) malloc(s_len * sizeof(liquid_float_complex));
+    firinterp_crcf         interp = firinterp_crcf_create_prototype(_ftype, _k, _m, _beta, 0);
+    unsigned int           i;
+    for (i = 0; i < _sequence_len + 2 * _m; i++)
+        firinterp_crcf_execute(interp, i < _sequence_len ? _sequence[i] : 0, &s[_k * i]);
     firinterp_crcf_destroy(interp);
 
     // create main object
@@ -203,26 +201,28 @@ qdetector_cccf qdetector_cccf_create_gmsk(unsigned char * _sequence,
 {
     // validate input
     if (_sequence_len == 0) {
-        fprintf(stderr,"error: qdetector_cccf_create_gmsk(), sequence length cannot be zero\n");
+        fprintf(stderr, "error: qdetector_cccf_create_gmsk(), sequence length cannot be zero\n");
         exit(1);
     } else if (_k < 2 || _k > 80) {
-        fprintf(stderr,"error: qdetector_cccf_create_gmsk(), samples per symbol must be in [2,80]\n");
+        fprintf(
+            stderr, "error: qdetector_cccf_create_gmsk(), samples per symbol must be in [2,80]\n");
         exit(1);
     } else if (_m < 1 || _m > 100) {
-        fprintf(stderr,"error: qdetector_cccf_create_gmsk(), filter delay must be in [1,100]\n");
+        fprintf(stderr, "error: qdetector_cccf_create_gmsk(), filter delay must be in [1,100]\n");
         exit(1);
     } else if (_beta < 0.0f || _beta > 1.0f) {
-        fprintf(stderr,"error: qdetector_cccf_create_gmsk(), excess bandwidth factor must be in [0,1]\n");
+        fprintf(stderr,
+                "error: qdetector_cccf_create_gmsk(), excess bandwidth factor must be in [0,1]\n");
         exit(1);
     }
-    
+
     // create time-domain template using GMSK modem
-    unsigned int    s_len = _k * (_sequence_len + 2*_m);
-    float complex * s     = (float complex*) malloc(s_len * sizeof(float complex));
-    gmskmod mod = gmskmod_create(_k, _m, _beta);
-    unsigned int i;
-    for (i=0; i<_sequence_len + 2*_m; i++)
-        gmskmod_modulate(mod, i < _sequence_len ? _sequence[i] : 0, &s[_k*i]);
+    unsigned int           s_len = _k * (_sequence_len + 2 * _m);
+    liquid_float_complex * s = (liquid_float_complex *) malloc(s_len * sizeof(liquid_float_complex));
+    gmskmod                mod = gmskmod_create(_k, _m, _beta);
+    unsigned int           i;
+    for (i = 0; i < _sequence_len + 2 * _m; i++)
+        gmskmod_modulate(mod, i < _sequence_len ? _sequence[i] : 0, &s[_k * i]);
     gmskmod_destroy(mod);
 
     // create main object
@@ -237,9 +237,13 @@ qdetector_cccf qdetector_cccf_create_gmsk(unsigned char * _sequence,
 
 void qdetector_cccf_destroy(qdetector_cccf _q)
 {
+    if (!_q) {
+        return;
+    }
+
     // free allocated arrays
-    free(_q->s         );
-    free(_q->S         );
+    free(_q->s);
+    free(_q->S);
     free(_q->buf_time_0);
     free(_q->buf_freq_0);
     free(_q->buf_freq_1);
@@ -256,18 +260,24 @@ void qdetector_cccf_destroy(qdetector_cccf _q)
 void qdetector_cccf_print(qdetector_cccf _q)
 {
     printf("qdetector_cccf:\n");
-    printf("  template length (time):   %-u\n",   _q->s_len);
-    printf("  FFT size              :   %-u\n",   _q->nfft);
+    printf("  template length (time):   %-u\n", _q->s_len);
+    printf("  FFT size              :   %-u\n", _q->nfft);
     printf("  detection threshold   :   %6.4f\n", _q->threshold);
-    printf("  sum{ s^2 }            :   %.2f\n",  _q->s2_sum);
+    printf("  sum{ s^2 }            :   %.2f\n", _q->s2_sum);
 }
 
 void qdetector_cccf_reset(qdetector_cccf _q)
 {
+    _q->counter        = _q->nfft / 2;
+    _q->num_transforms = 0;
+    _q->x2_sum_0       = 0.0f;
+    _q->x2_sum_1       = 0.0f;
+    _q->state          = QDETECTOR_STATE_SEEK;
+    _q->frame_detected = 0;
+    memset(_q->buf_time_0, 0x00, _q->nfft * sizeof(liquid_float_complex));
 }
 
-void * qdetector_cccf_execute(qdetector_cccf _q,
-                              float complex  _x)
+void * qdetector_cccf_execute(qdetector_cccf _q, liquid_float_complex _x)
 {
     switch (_q->state) {
     case QDETECTOR_STATE_SEEK:
@@ -287,7 +297,7 @@ void * qdetector_cccf_execute(qdetector_cccf _q,
         _q->frame_detected = 0;
 
         // return pointer to internal buffer of saved samples
-        return (void*)(_q->buf_time_1);
+        return (void *)(_q->buf_time_1);
     }
 
     // frame not yet ready
@@ -295,11 +305,10 @@ void * qdetector_cccf_execute(qdetector_cccf _q,
 }
 
 // set detection threshold (should be between 0 and 1, good starting point is 0.5)
-void qdetector_cccf_set_threshold(qdetector_cccf _q,
-                                  float          _threshold)
+void qdetector_cccf_set_threshold(qdetector_cccf _q, float _threshold)
 {
     if (_threshold <= 0.0f || _threshold > 2.0f) {
-        fprintf(stderr,"warning: threshold (%12.4e) out of range; ignoring\n", _threshold);
+        fprintf(stderr, "warning: threshold (%12.4e) out of range; ignoring\n", _threshold);
         return;
     }
 
@@ -308,18 +317,19 @@ void qdetector_cccf_set_threshold(qdetector_cccf _q,
 }
 
 // set carrier offset search range
-void qdetector_cccf_set_range(qdetector_cccf _q,
-                              float          _dphi_max)
+void qdetector_cccf_set_range(qdetector_cccf _q, float _dphi_max)
 {
     if (_dphi_max < 0.0f || _dphi_max > 0.5f) {
-        fprintf(stderr,"warning: carrier offset search range (%12.4e) out of range; ignoring\n", _dphi_max);
+        fprintf(stderr,
+                "warning: carrier offset search range (%12.4e) out of range; ignoring\n",
+                _dphi_max);
         return;
     }
 
     // set internal search range
-    _q->range = (int)(_dphi_max * _q->nfft / (2*M_PI));
+    _q->range = (int)(_dphi_max * _q->nfft / (2 * M_PI));
     _q->range = _q->range < 0 ? 0 : _q->range;
-    //printf("range: %d / %u\n", _q->range, _q->nfft);
+    // printf("range: %d / %u\n", _q->range, _q->nfft);
 }
 
 // get sequence length
@@ -331,7 +341,7 @@ unsigned int qdetector_cccf_get_seq_len(qdetector_cccf _q)
 // pointer to sequence
 const void * qdetector_cccf_get_sequence(qdetector_cccf _q)
 {
-    return (const void*) _q->s;
+    return (const void *)_q->s;
 }
 
 // buffer length
@@ -364,45 +374,59 @@ float qdetector_cccf_get_phi(qdetector_cccf _q)
     return _q->phi_hat;
 }
 
-
 //
 // internal methods
 //
 
 // seek signal (initial detection)
 void qdetector_cccf_execute_seek(qdetector_cccf _q,
-                                 float complex  _x)
+                                 liquid_float_complex _x)
 {
     // write sample to buffer and increment counter
     _q->buf_time_0[_q->counter++] = _x;
 
     // accumulate signal magnitude
-    _q->x2_sum_1 += crealf(_x)*crealf(_x) + cimagf(_x)*cimagf(_x);
+    _q->x2_sum_1 += crealf(_x) * crealf(_x) + cimagf(_x) * cimagf(_x);
 
     if (_q->counter < _q->nfft)
         return;
-    
+
     // reset counter (last half of time buffer)
-    _q->counter = _q->nfft/2;
+    _q->counter = _q->nfft / 2;
 
     // run forward transform
     fft_execute(_q->fft);
 
     // compute scaling factor (TODO: use median rather than mean signal level)
-    float g0 = sqrtf(_q->x2_sum_0 + _q->x2_sum_1) * sqrtf((float)(_q->s_len) / (float)(_q->nfft));
-    float g = 1.0f / ( (float)(_q->nfft) * g0 * sqrtf(_q->s2_sum) );
-    
+    float g0;
+    if (_q->x2_sum_0 == 0.f) {
+        g0 = sqrtf(_q->x2_sum_1) * sqrtf((float)(_q->s_len) / (float)(_q->nfft / 2));
+    } else {
+        g0 = sqrtf(_q->x2_sum_0 + _q->x2_sum_1) * sqrtf((float)(_q->s_len) / (float)(_q->nfft));
+    }
+    if (g0 < 1e-10) {
+        memmove(_q->buf_time_0,
+                _q->buf_time_0 + _q->nfft / 2,
+                (_q->nfft / 2) * sizeof(liquid_float_complex));
+
+        // swap accumulated signal levels
+        _q->x2_sum_0 = _q->x2_sum_1;
+        _q->x2_sum_1 = 0.0f;
+        return;
+    }
+    float g  = 1.0f / ((float)(_q->nfft) * g0 * sqrtf(_q->s2_sum));
+
     // sweep over carrier frequency offset range
-    int offset;
+    int          offset;
     unsigned int i;
     float        rxy_peak   = 0.0f;
     unsigned int rxy_index  = 0;
     int          rxy_offset = 0;
     // NOTE: this offset may be coarse as a fine carrier estimate is computed later
-    for (offset=-_q->range; offset<=_q->range; offset++) {
+    for (offset = -_q->range; offset <= _q->range; offset++) {
 
         // cross-multiply, aligning appropriately
-        for (i=0; i<_q->nfft; i++) {
+        for (i = 0; i < _q->nfft; i++) {
             // shifted index
             unsigned int j = (i + _q->nfft - offset) % _q->nfft;
 
@@ -411,32 +435,36 @@ void qdetector_cccf_execute_seek(qdetector_cccf _q,
 
         // run inverse transform
         fft_execute(_q->ifft);
-        
+
         // scale output appropriately
         liquid_vectorcf_mulscalar(_q->buf_time_1, _q->nfft, g, _q->buf_time_1);
 
 #if DEBUG_QDETECTOR
         // debug output
         char filename[64];
-        sprintf(filename,"qdetector_out_%u_%d.m", _q->num_transforms, offset+2);
+        sprintf(filename, "qdetector_out_%u_%d.m", _q->num_transforms, offset + 2);
         FILE * fid = fopen(filename, "w");
-        fprintf(fid,"clear all; close all;\n");
-        fprintf(fid,"nfft = %u;\n", _q->nfft);
-        for (i=0; i<_q->nfft; i++)
-            fprintf(fid,"rxy(%6u) = %12.4e + 1i*%12.4e;\n", i+1, crealf(_q->buf_time_1[i]), cimagf(_q->buf_time_1[i]));
-        fprintf(fid,"figure;\n");
-        fprintf(fid,"t=[0:(nfft-1)];\n");
-        fprintf(fid,"plot(t,abs(rxy));\n");
-        fprintf(fid,"grid on;\n");
-        fprintf(fid,"axis([0 %u 0 1.5]);\n", _q->nfft);
-        fprintf(fid,"[v i] = max(abs(rxy));\n");
-        fprintf(fid,"title(sprintf('peak of %%12.8f at index %%u', v, i));\n");
+        fprintf(fid, "clear all; close all;\n");
+        fprintf(fid, "nfft = %u;\n", _q->nfft);
+        for (i = 0; i < _q->nfft; i++)
+            fprintf(fid,
+                    "rxy(%6u) = %12.4e + 1i*%12.4e;\n",
+                    i + 1,
+                    crealf(_q->buf_time_1[i]),
+                    cimagf(_q->buf_time_1[i]));
+        fprintf(fid, "figure;\n");
+        fprintf(fid, "t=[0:(nfft-1)];\n");
+        fprintf(fid, "plot(t,abs(rxy));\n");
+        fprintf(fid, "grid on;\n");
+        fprintf(fid, "axis([0 %u 0 1.5]);\n", _q->nfft);
+        fprintf(fid, "[v i] = max(abs(rxy));\n");
+        fprintf(fid, "title(sprintf('peak of %%12.8f at index %%u', v, i));\n");
         fclose(fid);
         printf("debug: %s\n", filename);
 #endif
         // search for peak
         // TODO: only search over range [-nfft/2, nfft/2)
-        for (i=0; i<_q->nfft; i++) {
+        for (i = 0; i < _q->nfft; i++) {
             float rxy_abs = cabsf(_q->buf_time_1[i]);
             if (rxy_abs > rxy_peak) {
                 rxy_peak   = rxy_abs;
@@ -451,25 +479,35 @@ void qdetector_cccf_execute_seek(qdetector_cccf _q,
 
     if (rxy_peak > _q->threshold && rxy_index < _q->nfft - _q->s_len) {
 #if DEBUG_QDETECTOR_PRINT
-        printf("*** frame detected! rxy = %12.8f, time index=%u, freq. offset=%d\n", rxy_peak, rxy_index, rxy_offset);
+        printf("*** frame detected! rxy = %12.8f, time index=%u, freq. offset=%d\n",
+               rxy_peak,
+               rxy_index,
+               rxy_offset);
 #endif
         // update state, reset counter, copy buffer appropriately
-        _q->state = QDETECTOR_STATE_ALIGN;
+        _q->state  = QDETECTOR_STATE_ALIGN;
         _q->offset = rxy_offset;
         // TODO: check for edge case where rxy_index is zero (signal already aligned)
 
         // copy last part of fft input buffer to front
-        memmove(_q->buf_time_0, _q->buf_time_0 + rxy_index, (_q->nfft - rxy_index)*sizeof(float complex));
+        memmove(_q->buf_time_0,
+                _q->buf_time_0 + rxy_index,
+                (_q->nfft - rxy_index) * sizeof(liquid_float_complex));
         _q->counter = _q->nfft - rxy_index;
 
         return;
     }
 #if DEBUG_QDETECTOR_PRINT
-    printf(" no detect, rxy = %12.8f, time index=%u, freq. offset=%d\n", rxy_peak, rxy_index, rxy_offset);
+    printf(" no detect, rxy = %12.8f, time index=%u, freq. offset=%d\n",
+           rxy_peak,
+           rxy_index,
+           rxy_offset);
 #endif
-    
+
     // copy last half of fft input buffer to front
-    memmove(_q->buf_time_0, _q->buf_time_0 + _q->nfft/2, (_q->nfft/2)*sizeof(float complex));
+    memmove(_q->buf_time_0,
+            _q->buf_time_0 + _q->nfft / 2,
+            (_q->nfft / 2) * sizeof(liquid_float_complex));
 
     // swap accumulated signal levels
     _q->x2_sum_0 = _q->x2_sum_1;
@@ -477,8 +515,7 @@ void qdetector_cccf_execute_seek(qdetector_cccf _q,
 }
 
 // align signal in time, compute offset estimates
-void qdetector_cccf_execute_align(qdetector_cccf _q,
-                                  float complex  _x)
+void qdetector_cccf_execute_align(qdetector_cccf _q, liquid_float_complex _x)
 {
     // write sample to buffer and increment counter
     _q->buf_time_0[_q->counter++] = _x;
@@ -486,55 +523,63 @@ void qdetector_cccf_execute_align(qdetector_cccf _q,
     if (_q->counter < _q->nfft)
         return;
 
-    //printf("signal is aligned!\n");
+    // printf("signal is aligned!\n");
 
     // estimate timing offset
     fft_execute(_q->fft);
     // cross-multiply frequency-domain components, aligning appropriately with
     // estimated FFT offset index due to carrier frequency offset in received signal
     unsigned int i;
-    for (i=0; i<_q->nfft; i++) {
+    for (i = 0; i < _q->nfft; i++) {
         // shifted index
-        unsigned int j = (i + _q->nfft - _q->offset) % _q->nfft;
+        unsigned int j    = (i + _q->nfft - _q->offset) % _q->nfft;
         _q->buf_freq_1[i] = _q->buf_freq_0[i] * conjf(_q->S[j]);
     }
     fft_execute(_q->ifft);
     // time aligned to index 0
     // NOTE: taking the sqrt removes bias in the timing estimate, but messes up gamma estimate
-    float yneg = cabsf(_q->buf_time_1[_q->nfft-1]);  yneg = sqrtf(yneg);
-    float y0   = cabsf(_q->buf_time_1[         0]);  y0   = sqrtf(y0  );
-    float ypos = cabsf(_q->buf_time_1[         1]);  ypos = sqrtf(ypos);
+    float yneg = cabsf(_q->buf_time_1[_q->nfft - 1]);
+    yneg       = sqrtf(yneg);
+    float y0   = cabsf(_q->buf_time_1[0]);
+    y0         = sqrtf(y0);
+    float ypos = cabsf(_q->buf_time_1[1]);
+    ypos       = sqrtf(ypos);
     // compute timing offset estimate from quadratic polynomial fit
     //  y = a x^2 + b x + c, [xneg = -1, x0 = 0, xpos = +1]
-    float a     =  0.5f*(ypos + yneg) - y0;
-    float b     =  0.5f*(ypos - yneg);
-    float c     =  y0;
-    _q->tau_hat = -b / (2.0f*a); //-0.5f*(ypos - yneg) / (ypos + yneg - 2*y0);
-    float g_hat   = (a*_q->tau_hat*_q->tau_hat + b*_q->tau_hat + c);
-    _q->gamma_hat = g_hat * g_hat / ((float)(_q->nfft) * _q->s2_sum); // g_hat^2 because of sqrt for yneg/y0/ypos
+    float a       = 0.5f * (ypos + yneg) - y0;
+    float b       = 0.5f * (ypos - yneg);
+    float c       = y0;
+    _q->tau_hat   = -b / (2.0f * a); //-0.5f*(ypos - yneg) / (ypos + yneg - 2*y0);
+    float g_hat   = (a * _q->tau_hat * _q->tau_hat + b * _q->tau_hat + c);
+    _q->gamma_hat = g_hat * g_hat
+                    / ((float)(_q->nfft) * _q->s2_sum); // g_hat^2 because of sqrt for yneg/y0/ypos
 
     // copy buffer to preserve data integrity
-    memmove(_q->buf_time_1, _q->buf_time_0, _q->nfft*sizeof(float complex));
+    memmove(_q->buf_time_1, _q->buf_time_0, _q->nfft * sizeof(liquid_float_complex));
 
     // estimate carrier frequency offset
-    for (i=0; i<_q->nfft; i++)
+    for (i = 0; i < _q->nfft; i++)
         _q->buf_time_0[i] *= i < _q->s_len ? conjf(_q->s[i]) : 0.0f;
     fft_execute(_q->fft);
 #if DEBUG_QDETECTOR
     // debug output
     char filename[64];
-    sprintf(filename,"qdetector_fft.m");
+    sprintf(filename, "qdetector_fft.m");
     FILE * fid = fopen(filename, "w");
-    fprintf(fid,"clear all; close all;\n");
-    fprintf(fid,"nfft = %u;\n", _q->nfft);
-    for (i=0; i<_q->nfft; i++)
-        fprintf(fid,"V(%6u) = %12.4e + 1i*%12.4e;\n", i+1, crealf(_q->buf_freq_0[i]), cimagf(_q->buf_freq_0[i]));
-    fprintf(fid,"V = fftshift(V) / max(abs(V));\n");
-    fprintf(fid,"figure;\n");
-    fprintf(fid,"f=[0:(nfft-1)] - nfft/2;\n");
-    fprintf(fid,"plot(f,abs(V),'-x');\n");
-    fprintf(fid,"grid on;\n");
-    fprintf(fid,"axis([-10 10 0 1.2]);\n");
+    fprintf(fid, "clear all; close all;\n");
+    fprintf(fid, "nfft = %u;\n", _q->nfft);
+    for (i = 0; i < _q->nfft; i++)
+        fprintf(fid,
+                "V(%6u) = %12.4e + 1i*%12.4e;\n",
+                i + 1,
+                crealf(_q->buf_freq_0[i]),
+                cimagf(_q->buf_freq_0[i]));
+    fprintf(fid, "V = fftshift(V) / max(abs(V));\n");
+    fprintf(fid, "figure;\n");
+    fprintf(fid, "f=[0:(nfft-1)] - nfft/2;\n");
+    fprintf(fid, "plot(f,abs(V),'-x');\n");
+    fprintf(fid, "grid on;\n");
+    fprintf(fid, "axis([-10 10 0 1.2]);\n");
     fclose(fid);
     printf("debug: %s\n", filename);
 #endif
@@ -542,7 +587,7 @@ void qdetector_cccf_execute_align(qdetector_cccf _q,
     // TODO: don't search for peak but just use internal offset
     float        v0 = 0.0f;
     unsigned int i0 = 0;
-    for (i=0; i<_q->nfft; i++) {
+    for (i = 0; i < _q->nfft; i++) {
         float v_abs = cabsf(_q->buf_freq_0[i]);
         if (v_abs > v0) {
             v0 = v_abs;
@@ -550,16 +595,17 @@ void qdetector_cccf_execute_align(qdetector_cccf _q,
         }
     }
     // interpolate using quadratic polynomial for carrier frequency estimate
-    unsigned int ineg = (i0 + _q->nfft - 1)%_q->nfft;
-    unsigned int ipos = (i0            + 1)%_q->nfft;
+    unsigned int ineg = (i0 + _q->nfft - 1) % _q->nfft;
+    unsigned int ipos = (i0 + 1) % _q->nfft;
     float        vneg = cabsf(_q->buf_freq_0[ineg]);
     float        vpos = cabsf(_q->buf_freq_0[ipos]);
-    a            =  0.5f*(vpos + vneg) - v0;
-    b            =  0.5f*(vpos - vneg);
-    //c            =  v0;
-    float idx    = -b / (2.0f*a); //-0.5f*(vpos - vneg) / (vpos + vneg - 2*v0);
-    float index  = (float)i0 + idx;
-    _q->dphi_hat = (i0 > _q->nfft/2 ? index-(float)_q->nfft : index) * 2*M_PI / (float)(_q->nfft);
+    a                 = 0.5f * (vpos + vneg) - v0;
+    b                 = 0.5f * (vpos - vneg);
+    // c            =  v0;
+    float idx   = -b / (2.0f * a); //-0.5f*(vpos - vneg) / (vpos + vneg - 2*v0);
+    float index = (float)i0 + idx;
+    _q->dphi_hat
+        = (i0 > _q->nfft / 2 ? index - (float)_q->nfft : index) * 2 * M_PI / (float)(_q->nfft);
 
     // estimate carrier phase offset
 #if 0
@@ -573,23 +619,23 @@ void qdetector_cccf_execute_align(qdetector_cccf _q,
     // METHOD 2: compute metric by de-rotating signal and measuring resulting phase
     // NOTE: this is possibly more accurate than the above method but might also
     //       be more computationally complex
-    float complex metric = 0;
-    for (i=0; i<_q->s_len; i++)
-        metric += _q->buf_time_0[i] * cexpf(-_Complex_I*_q->dphi_hat*i);
-    //printf("metric : %12.8f <%12.8f>\n", cabsf(metric), cargf(metric));
+    liquid_float_complex metric = 0;
+    for (i = 0; i < _q->s_len; i++)
+        metric += _q->buf_time_0[i] * cexpf(-_Complex_I * (float)(_q->dphi_hat * i));
+    // printf("metric : %12.8f <%12.8f>\n", cabsf(metric), cargf(metric));
     _q->phi_hat = cargf(metric);
 #endif
 
 #if DEBUG_QDETECTOR_PRINT
     printf("  y[    -1] : %12.8f\n", yneg);
-    printf("  y[     0] : %12.8f\n", y0  );
+    printf("  y[     0] : %12.8f\n", y0);
     printf("  y[    +1] : %12.8f\n", ypos);
     printf("  tau-hat   : %12.8f\n", _q->tau_hat);
-    //printf("  g-hat:    : %12.8f\n", g_hat);
+    // printf("  g-hat:    : %12.8f\n", g_hat);
     printf("  gamma-hat : %12.8f\n", _q->gamma_hat);
-    printf("  v[%4u-1] : %12.8f\n", i0,vneg);
-    printf("  v[%4u+0] : %12.8f\n", i0,v0  );
-    printf("  v[%4u+1] : %12.8f\n", i0,vpos);
+    printf("  v[%4u-1] : %12.8f\n", i0, vneg);
+    printf("  v[%4u+0] : %12.8f\n", i0, v0);
+    printf("  v[%4u+1] : %12.8f\n", i0, vpos);
     printf("  dphi-hat  : %12.8f\n", _q->dphi_hat);
     printf("  phi-hat   : %12.8f\n", _q->phi_hat);
 #endif
@@ -599,10 +645,11 @@ void qdetector_cccf_execute_align(qdetector_cccf _q,
 
     // reset state
     // copy saved buffer state (last half of buf_time_1 to front half of buf_time_0)
-    memmove(_q->buf_time_0, _q->buf_time_1 + _q->nfft/2, (_q->nfft/2)*sizeof(float complex));
-    _q->state = QDETECTOR_STATE_SEEK;
-    _q->x2_sum_0 = liquid_sumsqcf(_q->buf_time_0, _q->nfft/2);
+    memmove(_q->buf_time_0,
+            _q->buf_time_1 + _q->nfft / 2,
+            (_q->nfft / 2) * sizeof(liquid_float_complex));
+    _q->state    = QDETECTOR_STATE_SEEK;
+    _q->x2_sum_0 = liquid_sumsqcf(_q->buf_time_0, _q->nfft / 2);
     _q->x2_sum_1 = 0;
-    _q->counter = _q->nfft/2;
+    _q->counter  = _q->nfft / 2;
 }
-

--- a/src/framing/src/qdetector_cccf.c
+++ b/src/framing/src/qdetector_cccf.c
@@ -24,117 +24,122 @@
 // qdetector_cccf.c
 //
 
-#include <stdio.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <math.h>
 #include <assert.h>
 
 #include "liquid.internal.h"
 
-#define DEBUG_QDETECTOR 0
-#define DEBUG_QDETECTOR_PRINT 0
-#define DEBUG_QDETECTOR_FILENAME "qdetector_cccf_debug.m"
+#define DEBUG_QDETECTOR              0
+#define DEBUG_QDETECTOR_PRINT        0
+#define DEBUG_QDETECTOR_FILENAME     "qdetector_cccf_debug.m"
 
 // seek signal (initial detection)
-void qdetector_cccf_execute_seek(qdetector_cccf _q, liquid_float_complex _x);
+void qdetector_cccf_execute_seek(qdetector_cccf _q,
+                                 float complex  _x);
 
 // align signal in time, compute offset estimates
-void qdetector_cccf_execute_align(qdetector_cccf _q, liquid_float_complex _x);
-
-enum state {
-    QDETECTOR_STATE_SEEK,  // seek sequence
-    QDETECTOR_STATE_ALIGN, // align sequence
-};
+void qdetector_cccf_execute_align(qdetector_cccf _q,
+                                  float complex  _x);
 
 // main object definition
 struct qdetector_cccf_s {
-    unsigned int           s_len;  // template (time) length: k * (sequence_len + 2*m)
-    liquid_float_complex * s;      // template (time), [size: s_len x 1]
-    liquid_float_complex * S;      // template (freq), [size: nfft x 1]
-    float                  s2_sum; // sum{ s^2 }
+    unsigned int    s_len;          // template (time) length: k * (sequence_len + 2*m)
+    float complex * s;              // template (time), [size: s_len x 1]
+    float complex * S;              // template (freq), [size: nfft x 1]
+    float           s2_sum;         // sum{ s^2 }
 
-    liquid_float_complex * buf_time_0; // time-domain buffer (FFT)
-    liquid_float_complex * buf_freq_0; // frequence-domain buffer (FFT)
-    liquid_float_complex * buf_freq_1; // frequence-domain buffer (IFFT)
-    liquid_float_complex * buf_time_1; // time-domain buffer (IFFT)
-    unsigned int           nfft;       // fft size
-    fftplan                fft;        // FFT object:  buf_time_0 > buf_freq_0
-    fftplan                ifft;       // IFFT object: buf_freq_1 > buf_freq_1
+    float complex * buf_time_0;     // time-domain buffer (FFT)
+    float complex * buf_freq_0;     // frequence-domain buffer (FFT)
+    float complex * buf_freq_1;     // frequence-domain buffer (IFFT)
+    float complex * buf_time_1;     // time-domain buffer (IFFT)
+    unsigned int    nfft;           // fft size
+    fftplan         fft;            // FFT object:  buf_time_0 > buf_freq_0
+    fftplan         ifft;           // IFFT object: buf_freq_1 > buf_freq_1
 
-    unsigned int counter;        // sample counter for determining when to compute FFTs
-    float        threshold;      // detection threshold
-    int          range;          // carrier offset search range (subcarriers)
-    unsigned int num_transforms; // number of transforms taken (debugging)
+    unsigned int    counter;        // sample counter for determining when to compute FFTs
+    float           threshold;      // detection threshold
+    int             range;          // carrier offset search range (subcarriers)
+    unsigned int    num_transforms; // number of transforms taken (debugging)
 
-    float x2_sum_0; // sum{ |x|^2 } of first half of buffer
-    float x2_sum_1; // sum{ |x|^2 } of second half of buffer
+    float           x2_sum_0;       // sum{ |x|^2 } of first half of buffer
+    float           x2_sum_1;       // sum{ |x|^2 } of second half of buffer
 
-    int   offset;    // FFT offset index for peak correlation (coarse carrier estimate)
-    float tau_hat;   // timing offset estimate
-    float gamma_hat; // signal level estimate (channel gain)
-    float dphi_hat;  // carrier frequency offset estimate
-    float phi_hat;   // carrier phase offset estimate
+    int             offset;         // FFT offset index for peak correlation (coarse carrier estimate)
+    float           tau_hat;        // timing offset estimate
+    float           gamma_hat;      // signal level estimate (channel gain)
+    float           dphi_hat;       // carrier frequency offset estimate
+    float           phi_hat;        // carrier phase offset estimate
 
-    enum state state;          // execution state
-    int        frame_detected; // frame detected?
+    enum {
+        QDETECTOR_STATE_SEEK,       // seek sequence
+        QDETECTOR_STATE_ALIGN,      // align sequence
+    }               state;          // execution state
+    int             frame_detected; // frame detected?
 };
 
-qdetector_cccf qdetector_cccf_create(liquid_float_complex * _s, unsigned int _s_len)
+// create detector with generic sequence
+//  _s      :   sample sequence
+//  _s_len  :   length of sample sequence
+qdetector_cccf qdetector_cccf_create(float complex * _s,
+                                     unsigned int    _s_len)
 {
     // validate input
     if (_s_len == 0) {
-        fprintf(stderr, "error: qdetector_cccf_create(), sequence length cannot be zero\n");
+        fprintf(stderr,"error: qdetector_cccf_create(), sequence length cannot be zero\n");
         exit(1);
     }
-
+    
     // allocate memory for main object and set internal properties
-    qdetector_cccf q = (qdetector_cccf)malloc(sizeof(struct qdetector_cccf_s));
-    q->s_len         = _s_len;
+    qdetector_cccf q = (qdetector_cccf) malloc(sizeof(struct qdetector_cccf_s));
+    q->s_len = _s_len;
 
     // allocate memory and copy sequence
-    q->s = (liquid_float_complex *)malloc(q->s_len * sizeof(liquid_float_complex));
-    memmove(q->s, _s, q->s_len * sizeof(liquid_float_complex));
+    q->s = (float complex*) malloc(q->s_len * sizeof(float complex));
+    memmove(q->s, _s, q->s_len*sizeof(float complex));
     q->s2_sum = liquid_sumsqcf(q->s, q->s_len); // compute sum{ s^2 }
 
     // prepare transforms
-    q->nfft       = 1 << liquid_nextpow2((unsigned int)(2 * q->s_len)); // NOTE: must be even
-    q->buf_time_0 = (liquid_float_complex *) malloc(q->nfft * sizeof(liquid_float_complex));
-    q->buf_freq_0 = (liquid_float_complex *) malloc(q->nfft * sizeof(liquid_float_complex));
-    q->buf_freq_1 = (liquid_float_complex *) malloc(q->nfft * sizeof(liquid_float_complex));
-    q->buf_time_1 = (liquid_float_complex *) malloc(q->nfft * sizeof(liquid_float_complex));
+    q->nfft       = 1 << liquid_nextpow2( (unsigned int)( 2 * q->s_len ) ); // NOTE: must be even
+    q->buf_time_0 = (float complex*) malloc(q->nfft * sizeof(float complex));
+    q->buf_freq_0 = (float complex*) malloc(q->nfft * sizeof(float complex));
+    q->buf_freq_1 = (float complex*) malloc(q->nfft * sizeof(float complex));
+    q->buf_time_1 = (float complex*) malloc(q->nfft * sizeof(float complex));
 
-    q->fft  = fft_create_plan(q->nfft, q->buf_time_0, q->buf_freq_0, LIQUID_FFT_FORWARD, 0);
+    q->fft  = fft_create_plan(q->nfft, q->buf_time_0, q->buf_freq_0, LIQUID_FFT_FORWARD,  0);
     q->ifft = fft_create_plan(q->nfft, q->buf_freq_1, q->buf_time_1, LIQUID_FFT_BACKWARD, 0);
 
     // create frequency-domain template by taking nfft-point transform on 's', storing in 'S'
-    q->S = (liquid_float_complex *)malloc(q->nfft * sizeof(liquid_float_complex));
-    memset(q->buf_time_0, 0x00, q->nfft * sizeof(liquid_float_complex));
-    memmove(q->buf_time_0, q->s, q->s_len * sizeof(liquid_float_complex));
+    q->S = (float complex*) malloc(q->nfft * sizeof(float complex));
+    memset(q->buf_time_0, 0x00, q->nfft*sizeof(float complex));
+    memmove(q->buf_time_0, q->s, q->s_len*sizeof(float complex));
     fft_execute(q->fft);
-    memmove(q->S, q->buf_freq_0, q->nfft * sizeof(liquid_float_complex));
+    memmove(q->S, q->buf_freq_0, q->nfft*sizeof(float complex));
 
     // reset state variables
-    q->counter        = q->nfft / 2;
+    q->counter        = q->nfft/2;
     q->num_transforms = 0;
     q->x2_sum_0       = 0.0f;
     q->x2_sum_1       = 0.0f;
     q->state          = QDETECTOR_STATE_SEEK;
     q->frame_detected = 0;
-    memset(q->buf_time_0, 0x00, q->nfft * sizeof(liquid_float_complex));
-
+    memset(q->buf_time_0, 0x00, q->nfft*sizeof(float complex));
+    
     // reset estimates
     q->tau_hat   = 0.0f;
     q->gamma_hat = 0.0f;
     q->dphi_hat  = 0.0f;
     q->phi_hat   = 0.0f;
 
-    qdetector_cccf_set_threshold(q, 0.5f);
-    qdetector_cccf_set_range(q, 0.3f); // set initial range for higher detection
+    qdetector_cccf_set_threshold(q,0.5f);
+    qdetector_cccf_set_range    (q,0.3f); // set initial range for higher detection
 
     // return object
     return q;
 }
+
 
 // create detector from sequence of symbols using internal linear interpolator
 //  _sequence       :   symbol sequence
@@ -143,38 +148,35 @@ qdetector_cccf qdetector_cccf_create(liquid_float_complex * _s, unsigned int _s_
 //  _k              :   samples/symbol
 //  _m              :   filter delay
 //  _beta           :   excess bandwidth factor
-qdetector_cccf qdetector_cccf_create_linear(liquid_float_complex * _sequence,
-                                            unsigned int           _sequence_len,
-                                            int                    _ftype,
-                                            unsigned int           _k,
-                                            unsigned int           _m,
-                                            float                  _beta)
+qdetector_cccf qdetector_cccf_create_linear(float complex * _sequence,
+                                            unsigned int    _sequence_len,
+                                            int             _ftype,
+                                            unsigned int    _k,
+                                            unsigned int    _m,
+                                            float           _beta)
 {
     // validate input
     if (_sequence_len == 0) {
-        fprintf(stderr, "error: qdetector_cccf_create_linear(), sequence length cannot be zero\n");
+        fprintf(stderr,"error: qdetector_cccf_create_linear(), sequence length cannot be zero\n");
         exit(1);
     } else if (_k < 2 || _k > 80) {
-        fprintf(stderr,
-                "error: qdetector_cccf_create_linear(), samples per symbol must be in [2,80]\n");
+        fprintf(stderr,"error: qdetector_cccf_create_linear(), samples per symbol must be in [2,80]\n");
         exit(1);
     } else if (_m < 1 || _m > 100) {
-        fprintf(stderr, "error: qdetector_cccf_create_linear(), filter delay must be in [1,100]\n");
+        fprintf(stderr,"error: qdetector_cccf_create_linear(), filter delay must be in [1,100]\n");
         exit(1);
     } else if (_beta < 0.0f || _beta > 1.0f) {
-        fprintf(
-            stderr,
-            "error: qdetector_cccf_create_linear(), excess bandwidth factor must be in [0,1]\n");
+        fprintf(stderr,"error: qdetector_cccf_create_linear(), excess bandwidth factor must be in [0,1]\n");
         exit(1);
     }
-
+    
     // create time-domain template
-    unsigned int           s_len = _k * (_sequence_len + 2 * _m);
-    liquid_float_complex * s = (liquid_float_complex *) malloc(s_len * sizeof(liquid_float_complex));
-    firinterp_crcf         interp = firinterp_crcf_create_prototype(_ftype, _k, _m, _beta, 0);
-    unsigned int           i;
-    for (i = 0; i < _sequence_len + 2 * _m; i++)
-        firinterp_crcf_execute(interp, i < _sequence_len ? _sequence[i] : 0, &s[_k * i]);
+    unsigned int    s_len = _k * (_sequence_len + 2*_m);
+    float complex * s     = (float complex*) malloc(s_len * sizeof(float complex));
+    firinterp_crcf interp = firinterp_crcf_create_prototype(_ftype, _k, _m, _beta, 0);
+    unsigned int i;
+    for (i=0; i<_sequence_len + 2*_m; i++)
+        firinterp_crcf_execute(interp, i < _sequence_len ? _sequence[i] : 0, &s[_k*i]);
     firinterp_crcf_destroy(interp);
 
     // create main object
@@ -201,28 +203,26 @@ qdetector_cccf qdetector_cccf_create_gmsk(unsigned char * _sequence,
 {
     // validate input
     if (_sequence_len == 0) {
-        fprintf(stderr, "error: qdetector_cccf_create_gmsk(), sequence length cannot be zero\n");
+        fprintf(stderr,"error: qdetector_cccf_create_gmsk(), sequence length cannot be zero\n");
         exit(1);
     } else if (_k < 2 || _k > 80) {
-        fprintf(
-            stderr, "error: qdetector_cccf_create_gmsk(), samples per symbol must be in [2,80]\n");
+        fprintf(stderr,"error: qdetector_cccf_create_gmsk(), samples per symbol must be in [2,80]\n");
         exit(1);
     } else if (_m < 1 || _m > 100) {
-        fprintf(stderr, "error: qdetector_cccf_create_gmsk(), filter delay must be in [1,100]\n");
+        fprintf(stderr,"error: qdetector_cccf_create_gmsk(), filter delay must be in [1,100]\n");
         exit(1);
     } else if (_beta < 0.0f || _beta > 1.0f) {
-        fprintf(stderr,
-                "error: qdetector_cccf_create_gmsk(), excess bandwidth factor must be in [0,1]\n");
+        fprintf(stderr,"error: qdetector_cccf_create_gmsk(), excess bandwidth factor must be in [0,1]\n");
         exit(1);
     }
-
+    
     // create time-domain template using GMSK modem
-    unsigned int           s_len = _k * (_sequence_len + 2 * _m);
-    liquid_float_complex * s = (liquid_float_complex *) malloc(s_len * sizeof(liquid_float_complex));
-    gmskmod                mod = gmskmod_create(_k, _m, _beta);
-    unsigned int           i;
-    for (i = 0; i < _sequence_len + 2 * _m; i++)
-        gmskmod_modulate(mod, i < _sequence_len ? _sequence[i] : 0, &s[_k * i]);
+    unsigned int    s_len = _k * (_sequence_len + 2*_m);
+    float complex * s     = (float complex*) malloc(s_len * sizeof(float complex));
+    gmskmod mod = gmskmod_create(_k, _m, _beta);
+    unsigned int i;
+    for (i=0; i<_sequence_len + 2*_m; i++)
+        gmskmod_modulate(mod, i < _sequence_len ? _sequence[i] : 0, &s[_k*i]);
     gmskmod_destroy(mod);
 
     // create main object
@@ -237,13 +237,9 @@ qdetector_cccf qdetector_cccf_create_gmsk(unsigned char * _sequence,
 
 void qdetector_cccf_destroy(qdetector_cccf _q)
 {
-    if (!_q) {
-        return;
-    }
-
     // free allocated arrays
-    free(_q->s);
-    free(_q->S);
+    free(_q->s         );
+    free(_q->S         );
     free(_q->buf_time_0);
     free(_q->buf_freq_0);
     free(_q->buf_freq_1);
@@ -260,24 +256,18 @@ void qdetector_cccf_destroy(qdetector_cccf _q)
 void qdetector_cccf_print(qdetector_cccf _q)
 {
     printf("qdetector_cccf:\n");
-    printf("  template length (time):   %-u\n", _q->s_len);
-    printf("  FFT size              :   %-u\n", _q->nfft);
+    printf("  template length (time):   %-u\n",   _q->s_len);
+    printf("  FFT size              :   %-u\n",   _q->nfft);
     printf("  detection threshold   :   %6.4f\n", _q->threshold);
-    printf("  sum{ s^2 }            :   %.2f\n", _q->s2_sum);
+    printf("  sum{ s^2 }            :   %.2f\n",  _q->s2_sum);
 }
 
 void qdetector_cccf_reset(qdetector_cccf _q)
 {
-    _q->counter        = _q->nfft / 2;
-    _q->num_transforms = 0;
-    _q->x2_sum_0       = 0.0f;
-    _q->x2_sum_1       = 0.0f;
-    _q->state          = QDETECTOR_STATE_SEEK;
-    _q->frame_detected = 0;
-    memset(_q->buf_time_0, 0x00, _q->nfft * sizeof(liquid_float_complex));
 }
 
-void * qdetector_cccf_execute(qdetector_cccf _q, liquid_float_complex _x)
+void * qdetector_cccf_execute(qdetector_cccf _q,
+                              float complex  _x)
 {
     switch (_q->state) {
     case QDETECTOR_STATE_SEEK:
@@ -297,7 +287,7 @@ void * qdetector_cccf_execute(qdetector_cccf _q, liquid_float_complex _x)
         _q->frame_detected = 0;
 
         // return pointer to internal buffer of saved samples
-        return (void *)(_q->buf_time_1);
+        return (void*)(_q->buf_time_1);
     }
 
     // frame not yet ready
@@ -305,10 +295,11 @@ void * qdetector_cccf_execute(qdetector_cccf _q, liquid_float_complex _x)
 }
 
 // set detection threshold (should be between 0 and 1, good starting point is 0.5)
-void qdetector_cccf_set_threshold(qdetector_cccf _q, float _threshold)
+void qdetector_cccf_set_threshold(qdetector_cccf _q,
+                                  float          _threshold)
 {
     if (_threshold <= 0.0f || _threshold > 2.0f) {
-        fprintf(stderr, "warning: threshold (%12.4e) out of range; ignoring\n", _threshold);
+        fprintf(stderr,"warning: threshold (%12.4e) out of range; ignoring\n", _threshold);
         return;
     }
 
@@ -317,19 +308,18 @@ void qdetector_cccf_set_threshold(qdetector_cccf _q, float _threshold)
 }
 
 // set carrier offset search range
-void qdetector_cccf_set_range(qdetector_cccf _q, float _dphi_max)
+void qdetector_cccf_set_range(qdetector_cccf _q,
+                              float          _dphi_max)
 {
     if (_dphi_max < 0.0f || _dphi_max > 0.5f) {
-        fprintf(stderr,
-                "warning: carrier offset search range (%12.4e) out of range; ignoring\n",
-                _dphi_max);
+        fprintf(stderr,"warning: carrier offset search range (%12.4e) out of range; ignoring\n", _dphi_max);
         return;
     }
 
     // set internal search range
-    _q->range = (int)(_dphi_max * _q->nfft / (2 * M_PI));
+    _q->range = (int)(_dphi_max * _q->nfft / (2*M_PI));
     _q->range = _q->range < 0 ? 0 : _q->range;
-    // printf("range: %d / %u\n", _q->range, _q->nfft);
+    //printf("range: %d / %u\n", _q->range, _q->nfft);
 }
 
 // get sequence length
@@ -341,7 +331,7 @@ unsigned int qdetector_cccf_get_seq_len(qdetector_cccf _q)
 // pointer to sequence
 const void * qdetector_cccf_get_sequence(qdetector_cccf _q)
 {
-    return (const void *)_q->s;
+    return (const void*) _q->s;
 }
 
 // buffer length
@@ -374,25 +364,26 @@ float qdetector_cccf_get_phi(qdetector_cccf _q)
     return _q->phi_hat;
 }
 
+
 //
 // internal methods
 //
 
 // seek signal (initial detection)
 void qdetector_cccf_execute_seek(qdetector_cccf _q,
-                                 liquid_float_complex _x)
+                                 float complex  _x)
 {
     // write sample to buffer and increment counter
     _q->buf_time_0[_q->counter++] = _x;
 
     // accumulate signal magnitude
-    _q->x2_sum_1 += crealf(_x) * crealf(_x) + cimagf(_x) * cimagf(_x);
+    _q->x2_sum_1 += crealf(_x)*crealf(_x) + cimagf(_x)*cimagf(_x);
 
     if (_q->counter < _q->nfft)
         return;
-
+    
     // reset counter (last half of time buffer)
-    _q->counter = _q->nfft / 2;
+    _q->counter = _q->nfft/2;
 
     // run forward transform
     fft_execute(_q->fft);
@@ -414,19 +405,19 @@ void qdetector_cccf_execute_seek(qdetector_cccf _q,
         _q->x2_sum_1 = 0.0f;
         return;
     }
-    float g  = 1.0f / ((float)(_q->nfft) * g0 * sqrtf(_q->s2_sum));
-
+    float g = 1.0f / ((float)(_q->nfft) * g0 * sqrtf(_q->s2_sum));
+    
     // sweep over carrier frequency offset range
-    int          offset;
+    int offset;
     unsigned int i;
     float        rxy_peak   = 0.0f;
     unsigned int rxy_index  = 0;
     int          rxy_offset = 0;
     // NOTE: this offset may be coarse as a fine carrier estimate is computed later
-    for (offset = -_q->range; offset <= _q->range; offset++) {
+    for (offset=-_q->range; offset<=_q->range; offset++) {
 
         // cross-multiply, aligning appropriately
-        for (i = 0; i < _q->nfft; i++) {
+        for (i=0; i<_q->nfft; i++) {
             // shifted index
             unsigned int j = (i + _q->nfft - offset) % _q->nfft;
 
@@ -435,36 +426,32 @@ void qdetector_cccf_execute_seek(qdetector_cccf _q,
 
         // run inverse transform
         fft_execute(_q->ifft);
-
+        
         // scale output appropriately
         liquid_vectorcf_mulscalar(_q->buf_time_1, _q->nfft, g, _q->buf_time_1);
 
 #if DEBUG_QDETECTOR
         // debug output
         char filename[64];
-        sprintf(filename, "qdetector_out_%u_%d.m", _q->num_transforms, offset + 2);
+        sprintf(filename,"qdetector_out_%u_%d.m", _q->num_transforms, offset+2);
         FILE * fid = fopen(filename, "w");
-        fprintf(fid, "clear all; close all;\n");
-        fprintf(fid, "nfft = %u;\n", _q->nfft);
-        for (i = 0; i < _q->nfft; i++)
-            fprintf(fid,
-                    "rxy(%6u) = %12.4e + 1i*%12.4e;\n",
-                    i + 1,
-                    crealf(_q->buf_time_1[i]),
-                    cimagf(_q->buf_time_1[i]));
-        fprintf(fid, "figure;\n");
-        fprintf(fid, "t=[0:(nfft-1)];\n");
-        fprintf(fid, "plot(t,abs(rxy));\n");
-        fprintf(fid, "grid on;\n");
-        fprintf(fid, "axis([0 %u 0 1.5]);\n", _q->nfft);
-        fprintf(fid, "[v i] = max(abs(rxy));\n");
-        fprintf(fid, "title(sprintf('peak of %%12.8f at index %%u', v, i));\n");
+        fprintf(fid,"clear all; close all;\n");
+        fprintf(fid,"nfft = %u;\n", _q->nfft);
+        for (i=0; i<_q->nfft; i++)
+            fprintf(fid,"rxy(%6u) = %12.4e + 1i*%12.4e;\n", i+1, crealf(_q->buf_time_1[i]), cimagf(_q->buf_time_1[i]));
+        fprintf(fid,"figure;\n");
+        fprintf(fid,"t=[0:(nfft-1)];\n");
+        fprintf(fid,"plot(t,abs(rxy));\n");
+        fprintf(fid,"grid on;\n");
+        fprintf(fid,"axis([0 %u 0 1.5]);\n", _q->nfft);
+        fprintf(fid,"[v i] = max(abs(rxy));\n");
+        fprintf(fid,"title(sprintf('peak of %%12.8f at index %%u', v, i));\n");
         fclose(fid);
         printf("debug: %s\n", filename);
 #endif
         // search for peak
         // TODO: only search over range [-nfft/2, nfft/2)
-        for (i = 0; i < _q->nfft; i++) {
+        for (i=0; i<_q->nfft; i++) {
             float rxy_abs = cabsf(_q->buf_time_1[i]);
             if (rxy_abs > rxy_peak) {
                 rxy_peak   = rxy_abs;
@@ -479,35 +466,25 @@ void qdetector_cccf_execute_seek(qdetector_cccf _q,
 
     if (rxy_peak > _q->threshold && rxy_index < _q->nfft - _q->s_len) {
 #if DEBUG_QDETECTOR_PRINT
-        printf("*** frame detected! rxy = %12.8f, time index=%u, freq. offset=%d\n",
-               rxy_peak,
-               rxy_index,
-               rxy_offset);
+        printf("*** frame detected! rxy = %12.8f, time index=%u, freq. offset=%d\n", rxy_peak, rxy_index, rxy_offset);
 #endif
         // update state, reset counter, copy buffer appropriately
-        _q->state  = QDETECTOR_STATE_ALIGN;
+        _q->state = QDETECTOR_STATE_ALIGN;
         _q->offset = rxy_offset;
         // TODO: check for edge case where rxy_index is zero (signal already aligned)
 
         // copy last part of fft input buffer to front
-        memmove(_q->buf_time_0,
-                _q->buf_time_0 + rxy_index,
-                (_q->nfft - rxy_index) * sizeof(liquid_float_complex));
+        memmove(_q->buf_time_0, _q->buf_time_0 + rxy_index, (_q->nfft - rxy_index)*sizeof(float complex));
         _q->counter = _q->nfft - rxy_index;
 
         return;
     }
 #if DEBUG_QDETECTOR_PRINT
-    printf(" no detect, rxy = %12.8f, time index=%u, freq. offset=%d\n",
-           rxy_peak,
-           rxy_index,
-           rxy_offset);
+    printf(" no detect, rxy = %12.8f, time index=%u, freq. offset=%d\n", rxy_peak, rxy_index, rxy_offset);
 #endif
-
+    
     // copy last half of fft input buffer to front
-    memmove(_q->buf_time_0,
-            _q->buf_time_0 + _q->nfft / 2,
-            (_q->nfft / 2) * sizeof(liquid_float_complex));
+    memmove(_q->buf_time_0, _q->buf_time_0 + _q->nfft/2, (_q->nfft/2)*sizeof(float complex));
 
     // swap accumulated signal levels
     _q->x2_sum_0 = _q->x2_sum_1;
@@ -515,7 +492,8 @@ void qdetector_cccf_execute_seek(qdetector_cccf _q,
 }
 
 // align signal in time, compute offset estimates
-void qdetector_cccf_execute_align(qdetector_cccf _q, liquid_float_complex _x)
+void qdetector_cccf_execute_align(qdetector_cccf _q,
+                                  float complex  _x)
 {
     // write sample to buffer and increment counter
     _q->buf_time_0[_q->counter++] = _x;
@@ -523,63 +501,55 @@ void qdetector_cccf_execute_align(qdetector_cccf _q, liquid_float_complex _x)
     if (_q->counter < _q->nfft)
         return;
 
-    // printf("signal is aligned!\n");
+    //printf("signal is aligned!\n");
 
     // estimate timing offset
     fft_execute(_q->fft);
     // cross-multiply frequency-domain components, aligning appropriately with
     // estimated FFT offset index due to carrier frequency offset in received signal
     unsigned int i;
-    for (i = 0; i < _q->nfft; i++) {
+    for (i=0; i<_q->nfft; i++) {
         // shifted index
-        unsigned int j    = (i + _q->nfft - _q->offset) % _q->nfft;
+        unsigned int j = (i + _q->nfft - _q->offset) % _q->nfft;
         _q->buf_freq_1[i] = _q->buf_freq_0[i] * conjf(_q->S[j]);
     }
     fft_execute(_q->ifft);
     // time aligned to index 0
     // NOTE: taking the sqrt removes bias in the timing estimate, but messes up gamma estimate
-    float yneg = cabsf(_q->buf_time_1[_q->nfft - 1]);
-    yneg       = sqrtf(yneg);
-    float y0   = cabsf(_q->buf_time_1[0]);
-    y0         = sqrtf(y0);
-    float ypos = cabsf(_q->buf_time_1[1]);
-    ypos       = sqrtf(ypos);
+    float yneg = cabsf(_q->buf_time_1[_q->nfft-1]);  yneg = sqrtf(yneg);
+    float y0   = cabsf(_q->buf_time_1[         0]);  y0   = sqrtf(y0  );
+    float ypos = cabsf(_q->buf_time_1[         1]);  ypos = sqrtf(ypos);
     // compute timing offset estimate from quadratic polynomial fit
     //  y = a x^2 + b x + c, [xneg = -1, x0 = 0, xpos = +1]
-    float a       = 0.5f * (ypos + yneg) - y0;
-    float b       = 0.5f * (ypos - yneg);
-    float c       = y0;
-    _q->tau_hat   = -b / (2.0f * a); //-0.5f*(ypos - yneg) / (ypos + yneg - 2*y0);
-    float g_hat   = (a * _q->tau_hat * _q->tau_hat + b * _q->tau_hat + c);
-    _q->gamma_hat = g_hat * g_hat
-                    / ((float)(_q->nfft) * _q->s2_sum); // g_hat^2 because of sqrt for yneg/y0/ypos
+    float a     =  0.5f*(ypos + yneg) - y0;
+    float b     =  0.5f*(ypos - yneg);
+    float c     =  y0;
+    _q->tau_hat = -b / (2.0f*a); //-0.5f*(ypos - yneg) / (ypos + yneg - 2*y0);
+    float g_hat   = (a*_q->tau_hat*_q->tau_hat + b*_q->tau_hat + c);
+    _q->gamma_hat = g_hat * g_hat / ((float)(_q->nfft) * _q->s2_sum); // g_hat^2 because of sqrt for yneg/y0/ypos
 
     // copy buffer to preserve data integrity
-    memmove(_q->buf_time_1, _q->buf_time_0, _q->nfft * sizeof(liquid_float_complex));
+    memmove(_q->buf_time_1, _q->buf_time_0, _q->nfft*sizeof(float complex));
 
     // estimate carrier frequency offset
-    for (i = 0; i < _q->nfft; i++)
+    for (i=0; i<_q->nfft; i++)
         _q->buf_time_0[i] *= i < _q->s_len ? conjf(_q->s[i]) : 0.0f;
     fft_execute(_q->fft);
 #if DEBUG_QDETECTOR
     // debug output
     char filename[64];
-    sprintf(filename, "qdetector_fft.m");
+    sprintf(filename,"qdetector_fft.m");
     FILE * fid = fopen(filename, "w");
-    fprintf(fid, "clear all; close all;\n");
-    fprintf(fid, "nfft = %u;\n", _q->nfft);
-    for (i = 0; i < _q->nfft; i++)
-        fprintf(fid,
-                "V(%6u) = %12.4e + 1i*%12.4e;\n",
-                i + 1,
-                crealf(_q->buf_freq_0[i]),
-                cimagf(_q->buf_freq_0[i]));
-    fprintf(fid, "V = fftshift(V) / max(abs(V));\n");
-    fprintf(fid, "figure;\n");
-    fprintf(fid, "f=[0:(nfft-1)] - nfft/2;\n");
-    fprintf(fid, "plot(f,abs(V),'-x');\n");
-    fprintf(fid, "grid on;\n");
-    fprintf(fid, "axis([-10 10 0 1.2]);\n");
+    fprintf(fid,"clear all; close all;\n");
+    fprintf(fid,"nfft = %u;\n", _q->nfft);
+    for (i=0; i<_q->nfft; i++)
+        fprintf(fid,"V(%6u) = %12.4e + 1i*%12.4e;\n", i+1, crealf(_q->buf_freq_0[i]), cimagf(_q->buf_freq_0[i]));
+    fprintf(fid,"V = fftshift(V) / max(abs(V));\n");
+    fprintf(fid,"figure;\n");
+    fprintf(fid,"f=[0:(nfft-1)] - nfft/2;\n");
+    fprintf(fid,"plot(f,abs(V),'-x');\n");
+    fprintf(fid,"grid on;\n");
+    fprintf(fid,"axis([-10 10 0 1.2]);\n");
     fclose(fid);
     printf("debug: %s\n", filename);
 #endif
@@ -587,7 +557,7 @@ void qdetector_cccf_execute_align(qdetector_cccf _q, liquid_float_complex _x)
     // TODO: don't search for peak but just use internal offset
     float        v0 = 0.0f;
     unsigned int i0 = 0;
-    for (i = 0; i < _q->nfft; i++) {
+    for (i=0; i<_q->nfft; i++) {
         float v_abs = cabsf(_q->buf_freq_0[i]);
         if (v_abs > v0) {
             v0 = v_abs;
@@ -595,17 +565,16 @@ void qdetector_cccf_execute_align(qdetector_cccf _q, liquid_float_complex _x)
         }
     }
     // interpolate using quadratic polynomial for carrier frequency estimate
-    unsigned int ineg = (i0 + _q->nfft - 1) % _q->nfft;
-    unsigned int ipos = (i0 + 1) % _q->nfft;
+    unsigned int ineg = (i0 + _q->nfft - 1)%_q->nfft;
+    unsigned int ipos = (i0            + 1)%_q->nfft;
     float        vneg = cabsf(_q->buf_freq_0[ineg]);
     float        vpos = cabsf(_q->buf_freq_0[ipos]);
-    a                 = 0.5f * (vpos + vneg) - v0;
-    b                 = 0.5f * (vpos - vneg);
-    // c            =  v0;
-    float idx   = -b / (2.0f * a); //-0.5f*(vpos - vneg) / (vpos + vneg - 2*v0);
-    float index = (float)i0 + idx;
-    _q->dphi_hat
-        = (i0 > _q->nfft / 2 ? index - (float)_q->nfft : index) * 2 * M_PI / (float)(_q->nfft);
+    a            =  0.5f*(vpos + vneg) - v0;
+    b            =  0.5f*(vpos - vneg);
+    //c            =  v0;
+    float idx    = -b / (2.0f*a); //-0.5f*(vpos - vneg) / (vpos + vneg - 2*v0);
+    float index  = (float)i0 + idx;
+    _q->dphi_hat = (i0 > _q->nfft/2 ? index-(float)_q->nfft : index) * 2*M_PI / (float)(_q->nfft);
 
     // estimate carrier phase offset
 #if 0
@@ -619,23 +588,23 @@ void qdetector_cccf_execute_align(qdetector_cccf _q, liquid_float_complex _x)
     // METHOD 2: compute metric by de-rotating signal and measuring resulting phase
     // NOTE: this is possibly more accurate than the above method but might also
     //       be more computationally complex
-    liquid_float_complex metric = 0;
-    for (i = 0; i < _q->s_len; i++)
-        metric += _q->buf_time_0[i] * cexpf(-_Complex_I * (float)(_q->dphi_hat * i));
-    // printf("metric : %12.8f <%12.8f>\n", cabsf(metric), cargf(metric));
+    float complex metric = 0;
+    for (i=0; i<_q->s_len; i++)
+        metric += _q->buf_time_0[i] * cexpf(-_Complex_I*_q->dphi_hat*i);
+    //printf("metric : %12.8f <%12.8f>\n", cabsf(metric), cargf(metric));
     _q->phi_hat = cargf(metric);
 #endif
 
 #if DEBUG_QDETECTOR_PRINT
     printf("  y[    -1] : %12.8f\n", yneg);
-    printf("  y[     0] : %12.8f\n", y0);
+    printf("  y[     0] : %12.8f\n", y0  );
     printf("  y[    +1] : %12.8f\n", ypos);
     printf("  tau-hat   : %12.8f\n", _q->tau_hat);
-    // printf("  g-hat:    : %12.8f\n", g_hat);
+    //printf("  g-hat:    : %12.8f\n", g_hat);
     printf("  gamma-hat : %12.8f\n", _q->gamma_hat);
-    printf("  v[%4u-1] : %12.8f\n", i0, vneg);
-    printf("  v[%4u+0] : %12.8f\n", i0, v0);
-    printf("  v[%4u+1] : %12.8f\n", i0, vpos);
+    printf("  v[%4u-1] : %12.8f\n", i0,vneg);
+    printf("  v[%4u+0] : %12.8f\n", i0,v0  );
+    printf("  v[%4u+1] : %12.8f\n", i0,vpos);
     printf("  dphi-hat  : %12.8f\n", _q->dphi_hat);
     printf("  phi-hat   : %12.8f\n", _q->phi_hat);
 #endif
@@ -645,11 +614,10 @@ void qdetector_cccf_execute_align(qdetector_cccf _q, liquid_float_complex _x)
 
     // reset state
     // copy saved buffer state (last half of buf_time_1 to front half of buf_time_0)
-    memmove(_q->buf_time_0,
-            _q->buf_time_1 + _q->nfft / 2,
-            (_q->nfft / 2) * sizeof(liquid_float_complex));
-    _q->state    = QDETECTOR_STATE_SEEK;
-    _q->x2_sum_0 = liquid_sumsqcf(_q->buf_time_0, _q->nfft / 2);
+    memmove(_q->buf_time_0, _q->buf_time_1 + _q->nfft/2, (_q->nfft/2)*sizeof(float complex));
+    _q->state = QDETECTOR_STATE_SEEK;
+    _q->x2_sum_0 = liquid_sumsqcf(_q->buf_time_0, _q->nfft/2);
     _q->x2_sum_1 = 0;
-    _q->counter  = _q->nfft / 2;
+    _q->counter = _q->nfft/2;
 }
+

--- a/src/framing/src/qpacketmodem.c
+++ b/src/framing/src/qpacketmodem.c
@@ -46,6 +46,7 @@ struct qpacketmodem_s {
     unsigned int    payload_enc_len;    // number of encoded payload bytes
     unsigned int    payload_bit_len;    // number of bits in encoded payload
     unsigned int    payload_mod_len;    // number of symbols in encoded payload
+    unsigned int    n;                  // index into partially-received payload data
 };
 
 // create packet encoder
@@ -81,6 +82,8 @@ qpacketmodem qpacketmodem_create()
     // set symbol length appropriately
     q->payload_mod_len = q->payload_enc_len * q->bits_per_symbol;   // for QPSK
     q->payload_mod = (unsigned char*) malloc(q->payload_mod_len*sizeof(unsigned char));
+
+    q->n = 0;
 
     // return pointer to main object
     return q;
@@ -154,6 +157,8 @@ int qpacketmodem_configure(qpacketmodem _q,
     _q->payload_mod = (unsigned char*) realloc(_q->payload_mod,
                                                _q->payload_mod_len*sizeof(unsigned char));
 
+    _q->n = 0;
+
     return 0;
 }
 
@@ -188,6 +193,16 @@ unsigned int qpacketmodem_get_fec1(qpacketmodem _q)
 unsigned int qpacketmodem_get_modscheme(qpacketmodem _q)
 {
     return modem_get_scheme(_q->mod_payload);
+}
+
+float qpacketmodem_get_demodulator_phase_error(qpacketmodem _q)
+{
+    return modem_get_demodulator_phase_error(_q->mod_payload);
+}
+
+float qpacketmodem_get_demodulator_evm(qpacketmodem _q)
+{
+    return modem_get_demodulator_evm(_q->mod_payload);
 }
 
 // encode packet into un-modulated frame symbol indices
@@ -318,3 +333,22 @@ int qpacketmodem_decode_soft(qpacketmodem    _q,
     return packetizer_decode_soft(_q->p, _q->payload_enc, _payload);
 }
 
+// decode symbol from modulated frame samples, returning flag if all symbols received
+//  _q          :   qpacketmodem object
+//  _frame      :   encoded/modulated symbol
+int qpacketmodem_decode_soft_sym(qpacketmodem  _q,
+                                 float complex _symbol)
+{
+    unsigned int sym;
+    modem_demodulate_soft(_q->mod_payload, _symbol, &sym, _q->payload_enc + _q->n);
+    _q->n += _q->bits_per_symbol;
+    return _q->n == _q->payload_mod_len * _q->bits_per_symbol;
+}
+
+int qpacketmodem_decode_soft_payload(qpacketmodem    _q,
+                                     unsigned char * _payload)
+{
+    assert( _q->n == _q->payload_mod_len * _q->bits_per_symbol);
+    _q->n = 0;
+    return packetizer_decode_soft(_q->p, _q->payload_enc, _payload);
+}

--- a/src/nco/src/nco.c
+++ b/src/nco/src/nco.c
@@ -82,6 +82,10 @@ NCO() NCO(_create)(liquid_ncotype _type)
 // destroy nco object
 void NCO(_destroy)(NCO() _q)
 {
+    if (!_q) {
+        return;
+    }
+
     free(_q);
 }
 

--- a/src/nco/src/synth.c
+++ b/src/nco/src/synth.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2007 - 2015 Joseph Gaeddert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+//
+// Numerically-controlled synthesizer (direct digital synthesis)
+// with internal phase-locked loop (pll) implementation
+//
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SYNTH_PLL_BANDWIDTH_DEFAULT (0.1)
+#define SYNTH_PLL_GAIN_DEFAULT (1000)
+
+#define LIQUID_DEBUG_SYNTH (0)
+
+struct SYNTH(_s) {
+    T            theta;   // phase
+    T            d_theta; // frequency
+    TC *         tab;     // synth table
+    unsigned int index;   // table index
+    unsigned int length;  // table length
+    T            sumsq;
+
+    TC prev_half;
+    TC current;
+    TC next_half;
+
+    // phase-locked loop
+    T alpha;
+    T beta;
+};
+
+SYNTH() SYNTH(_create)(const TC * _table, unsigned int _length)
+{
+    SYNTH() q = (SYNTH())malloc(sizeof(struct SYNTH(_s)));
+
+    q->length = _length;
+    q->tab    = (TC *)malloc(q->length * sizeof(TC));
+    memcpy(q->tab, _table, q->length * sizeof(TC));
+
+    // set default pll bandwidth
+    SYNTH(_pll_set_bandwidth)(q, SYNTH_PLL_BANDWIDTH_DEFAULT);
+
+    // reset object and return
+    SYNTH(_reset)(q);
+    // default frequency is to visit each sample once
+    SYNTH(_set_frequency)(q, (2.f * M_PI) / _length);
+    SYNTH(_compute_synth)(q);
+    return q;
+}
+
+void SYNTH(_destroy)(SYNTH() _q)
+{
+    if (!_q) {
+        return;
+    }
+
+    free(_q->tab);
+    free(_q);
+}
+
+void SYNTH(_reset)(SYNTH() _q)
+{
+    _q->theta   = 0;
+    _q->d_theta = 0;
+
+    // reset sine table index
+    _q->index = 0;
+
+    // reset pll filter state
+    SYNTH(_pll_reset)(_q);
+}
+
+void SYNTH(_set_frequency)(SYNTH() _q, T _f)
+{
+    _q->d_theta = _f;
+}
+
+void SYNTH(_adjust_frequency)(SYNTH() _q, T _df)
+{
+    _q->d_theta += _df;
+}
+
+void SYNTH(_set_phase)(SYNTH() _q, T _phi)
+{
+    _q->theta = _phi;
+    SYNTH(_constrain_phase)(_q);
+    SYNTH(_compute_synth)(_q);
+}
+
+void SYNTH(_adjust_phase)(SYNTH() _q, T _dphi)
+{
+    _q->theta += _dphi;
+    SYNTH(_constrain_phase)(_q);
+}
+
+void SYNTH(_step)(SYNTH() _q)
+{
+    _q->theta += _q->d_theta;
+    SYNTH(_constrain_phase)(_q);
+    SYNTH(_compute_synth)(_q);
+}
+
+// get phase
+T SYNTH(_get_phase)(SYNTH() _q)
+{
+    return _q->theta;
+}
+
+// ge frequency
+T SYNTH(_get_frequency)(SYNTH() _q)
+{
+    return _q->d_theta;
+}
+
+unsigned int SYNTH(_get_length)(SYNTH() _q)
+{
+    return _q->length;
+}
+
+TC SYNTH(_get_current)(SYNTH() _q)
+{
+    return _q->current;
+}
+
+TC SYNTH(_get_half_previous)(SYNTH() _q)
+{
+    return _q->prev_half;
+}
+
+TC SYNTH(_get_half_next)(SYNTH() _q)
+{
+    return _q->next_half;
+}
+
+// pll methods
+
+// reset pll state, retaining base frequency
+void SYNTH(_pll_reset)(SYNTH() _q)
+{
+}
+
+// set pll bandwidth
+void SYNTH(_pll_set_bandwidth)(SYNTH() _q, T _bandwidth)
+{
+    // validate input
+    if (_bandwidth < 0.0f) {
+        fprintf(stderr, "error: synth_pll_set_bandwidth(), bandwidth must be positive\n");
+        exit(1);
+    }
+
+    _q->alpha = _bandwidth;       // frequency proportion
+    _q->beta  = sqrtf(_q->alpha); // phase proportion
+}
+
+void SYNTH(_pll_step)(SYNTH() _q, T _dphi)
+{
+    // increase frequency proportional to error
+    SYNTH(_adjust_frequency)(_q, _dphi * _q->alpha);
+
+    // increase phase proportional to error
+    SYNTH(_adjust_phase)(_q, _dphi * _q->beta);
+
+    SYNTH(_compute_synth)(_q);
+
+    // constrain frequency
+    // SYNTH(_constrain_frequency)(_q);
+}
+
+// mixing functions
+
+void SYNTH(_mix_up)(SYNTH() _q, TC _x, TC * _y)
+{
+    *_y = _x * _q->current;
+}
+
+void SYNTH(_mix_down)(SYNTH() _q, TC _x, TC * _y)
+{
+    *_y = _x * conjf(_q->current);
+}
+
+void SYNTH(_mix_block_up)(SYNTH() _q, TC * _x, TC * _y, unsigned int _n)
+{
+    unsigned int i;
+    for (i = 0; i < _n; i++) {
+        // mix single sample up
+        SYNTH(_mix_up)(_q, _x[i], &_y[i]);
+
+        // step SYNTH phase
+        SYNTH(_step)(_q);
+    }
+}
+
+void SYNTH(_mix_block_down)(SYNTH() _q, TC * _x, TC * _y, unsigned int _n)
+{
+    unsigned int i;
+    for (i = 0; i < _n; i++) {
+        // mix single sample down
+        SYNTH(_mix_down)(_q, _x[i], &_y[i]);
+
+        // step SYNTH phase
+        SYNTH(_step)(_q);
+    }
+}
+
+void SYNTH(_spread)(SYNTH() _q, TC _x, TC * _y)
+{
+    for (unsigned int i = 0; i < _q->length; i++) {
+        SYNTH(_mix_up)(_q, _x, &_y[i]);
+
+        SYNTH(_step)(_q);
+    }
+}
+
+void SYNTH(_despread)(SYNTH() _q, TC * _x, TC * _y)
+{
+    TC despread = 0;
+    T  sum      = 0;
+    for (unsigned int i = 0; i < _q->length; i++) {
+        TC temp;
+        SYNTH(_mix_down)(_q, _x[i], &temp);
+
+        despread += temp;
+        sum += cabsf(_x[i]) * cabsf(_q->current);
+
+        SYNTH(_step)(_q);
+    }
+    *_y = despread / sum;
+}
+
+void SYNTH(_despread_triple)(SYNTH() _q, TC * _x, TC * _early, TC * _punctual, TC * _late)
+{
+    TC despread_early    = 0;
+    TC despread_punctual = 0;
+    TC despread_late     = 0;
+
+    T sum_early    = 0;
+    T sum_punctual = 0;
+    T sum_late     = 0;
+
+    for (unsigned int i = 0; i < _q->length; i++) {
+        despread_early += _x[i] * conjf(_q->prev_half);
+        despread_punctual += _x[i] * conjf(_q->current);
+        despread_late += _x[i] * conjf(_q->next_half);
+
+        sum_early += cabsf(_x[i]) * cabsf(_q->prev_half);
+        sum_punctual += cabsf(_x[i]) * cabsf(_q->current);
+        sum_late += cabsf(_x[i]) * cabsf(_q->next_half);
+
+        SYNTH(_step)(_q);
+    }
+
+    *_early    = despread_early / sum_early;
+    *_punctual = despread_punctual / sum_punctual;
+    *_late     = despread_late / sum_late;
+}
+
+//
+// internal methods
+//
+
+// constrain frequency of SYNTH object to be in (-pi,pi)
+void SYNTH(_constrain_frequency)(SYNTH() _q)
+{
+    if (_q->d_theta > M_PI)
+        _q->d_theta -= 2 * M_PI;
+    else if (_q->d_theta < -M_PI)
+        _q->d_theta += 2 * M_PI;
+}
+
+// constrain phase of SYNTH object to be in (-pi,pi)
+void SYNTH(_constrain_phase)(SYNTH() _q)
+{
+    if (_q->theta > M_PI)
+        _q->theta -= 2 * M_PI;
+    else if (_q->theta < -M_PI)
+        _q->theta += 2 * M_PI;
+}
+
+void SYNTH(_compute_synth)(SYNTH() _q)
+{
+    // assume phase is constrained to be in (-pi,pi)
+
+    // compute index
+    float index = _q->theta * (float)_q->length / (2 * M_PI) + 2.f * (float)_q->length;
+    _q->index   = ((unsigned int)(index + 0.5f)) % _q->length;
+    assert(_q->index < _q->length);
+
+    unsigned int prev_index = (_q->index + _q->length - 1) % _q->length;
+    unsigned int next_index = (_q->index + 1) % _q->length;
+
+    _q->current = _q->tab[_q->index];
+    TC prev     = _q->tab[prev_index];
+    TC next     = _q->tab[next_index];
+
+    _q->prev_half = (_q->current + prev) / 2;
+    _q->next_half = (_q->current + next) / 2;
+}

--- a/src/nco/src/synth.c
+++ b/src/nco/src/synth.c
@@ -228,7 +228,8 @@ void SYNTH(_mix_block_down)(SYNTH() _q, TC * _x, TC * _y, unsigned int _n)
 
 void SYNTH(_spread)(SYNTH() _q, TC _x, TC * _y)
 {
-    for (unsigned int i = 0; i < _q->length; i++) {
+    unsigned int i;
+    for (i = 0; i < _q->length; i++) {
         SYNTH(_mix_up)(_q, _x, &_y[i]);
 
         SYNTH(_step)(_q);
@@ -239,7 +240,8 @@ void SYNTH(_despread)(SYNTH() _q, TC * _x, TC * _y)
 {
     TC despread = 0;
     T  sum      = 0;
-    for (unsigned int i = 0; i < _q->length; i++) {
+    unsigned int i;
+    for (i = 0; i < _q->length; i++) {
         TC temp;
         SYNTH(_mix_down)(_q, _x[i], &temp);
 
@@ -261,7 +263,8 @@ void SYNTH(_despread_triple)(SYNTH() _q, TC * _x, TC * _early, TC * _punctual, T
     T sum_punctual = 0;
     T sum_late     = 0;
 
-    for (unsigned int i = 0; i < _q->length; i++) {
+    unsigned int i;
+    for (i = 0; i < _q->length; i++) {
         despread_early += _x[i] * conjf(_q->prev_half);
         despread_punctual += _x[i] * conjf(_q->current);
         despread_late += _x[i] * conjf(_q->next_half);

--- a/src/nco/src/synth_crcf.c
+++ b/src/nco/src/synth_crcf.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2007 - 2015 Joseph Gaeddert
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+//
+// numerically-controlled synthesizer API, floating point precision
+//
+
+#include "liquid.internal.h"
+
+#define SYNTH(name)   LIQUID_CONCAT(synth_crcf,name)
+#define T           float
+#define TC          liquid_float_complex
+
+#include "synth.c"

--- a/tools/msequence_generator.c
+++ b/tools/msequence_generator.c
@@ -1,0 +1,49 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+#include "liquid.h"
+
+void usage()
+{
+    printf("dsssframesync_example [options]\n");
+    printf("  u/h   : print usage\n");
+    printf("  d     : degree of polynomial, default: 2\n");
+}
+
+
+int main(int argc, char *argv[])
+{
+    unsigned int degree = 2;
+
+    // get options
+    int dopt;
+    while((dopt = getopt(argc,argv,"uhd:")) != EOF){
+        switch (dopt) {
+        case 'u':
+        case 'h': usage();                                       return 0;
+        case 'd': degree        = atol(optarg);                  break;
+        default:
+            exit(-1);
+        }
+    }
+
+    unsigned int maxpoly = (1 << degree) - 1;
+    unsigned int expected_sum = ((maxpoly + 1) / 2) * maxpoly;
+    for (unsigned int poly = 0; poly <= maxpoly; ++poly) {
+        unsigned int g = (poly << 1) + 1;
+        msequence seq = msequence_create(degree, g, 1);
+        unsigned int sum = 0;
+        for (unsigned int i = 0; i < maxpoly; ++i) {
+            sum += msequence_get_state(seq);
+            msequence_advance(seq);
+        }
+        if (sum == expected_sum) {
+            printf("degree %d poly: %#06x\n", degree, g);
+        }
+        msequence_destroy(seq);
+    }
+
+    return 0;
+}

--- a/tools/msequence_generator.c
+++ b/tools/msequence_generator.c
@@ -31,11 +31,13 @@ int main(int argc, char *argv[])
 
     unsigned int maxpoly = (1 << degree) - 1;
     unsigned int expected_sum = ((maxpoly + 1) / 2) * maxpoly;
-    for (unsigned int poly = 0; poly <= maxpoly; ++poly) {
+    unsigned int i;
+    unsigned int poly;
+    for (poly = 0; poly <= maxpoly; ++poly) {
         unsigned int g = (poly << 1) + 1;
         msequence seq = msequence_create(degree, g, 1);
         unsigned int sum = 0;
-        for (unsigned int i = 0; i < maxpoly; ++i) {
+        for (i = 0; i < maxpoly; ++i) {
             sum += msequence_get_state(seq);
             msequence_advance(seq);
         }


### PR DESCRIPTION
This is what I've got so far for DSSS. This PR is probably 90% there for what might be mergeable. I think the big remaining missing pieces are debug printing and functions that can adjust the msequence polys. I didn't actually get around to implementing an early/late gate either, but I've convinced myself this probably doesn't matter for my uses.

Sadly this patch contains some unrelated formatting changes in qdetector. I could back these out pretty easily. I wasn't quite sure what the formatting guidelines were so I used clang-format with a config that seems to mostly match, but the result is that any file I touch might get its formatting re-arranged.

This is working better in my room tests than other modes, but there's still a lot I'm hoping to improve. One thing I'm curious about is how to choose a header poly/starting register state. From what I understand, a bad choice can actually hamper detection if the header "de-correlates" against the preamble. Just in general, detection doesn't perform reliably once line-of-sight is broken. I'm hoping to do some more digging and see if I can come up with some improvements to this process.

The biggest surprise to me here is that error correction seems to be mostly useless in this context. I think if the receiver can synchronize the PN sequence correctly, then it is very likely to come up with the correct bit. If it desynchronizes, there's nothing error correction can do to help it since everything at that point is probably toast.

I was also happy to see that changing all the packet modems to QPSK does seem to decode correctly, though I didn't test it further than that. It might make sense to come up with a flex version that can send mod and poly info in the header.