### PR TITLE
altivec fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -195,7 +195,7 @@ else
                        src/dotprod/src/dotprod_rrrf.av.o \
                        src/dotprod/src/dotprod_crcf.av.o \
                        src/dotprod/src/sumsq.o"
-        ARCH_OPTION="-fno-common -faltivec";;
+        ARCH_OPTION="-fno-common -maltivec";;
     armv1*|armv2*|armv3*|armv4*|armv5*|armv6*)
         # assume neon instructions are NOT available
         MLIBS_DOTPROD="src/dotprod/src/dotprod_cccf.o \

--- a/src/dotprod/src/dotprod_crcf.av.c
+++ b/src/dotprod/src/dotprod_crcf.av.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <altivec.h>
 
 #include "liquid.internal.h"
 
@@ -168,8 +169,8 @@ void dotprod_crcf_execute(dotprod_crcf    _q,
     union { vector float v; float w[4];} s;
     unsigned int nblocks;
 
-    ar = (vector float*)( (int)_x & ~15);
-    al = ((int)_x & 15)/sizeof(float);
+    ar = (vector float*)( (uintptr_t)_x & ~15);
+    al = ((uintptr_t)_x & 15)/sizeof(float);
 
     d = (vector float*)_q->h[al];
 
@@ -179,7 +180,7 @@ void dotprod_crcf_execute(dotprod_crcf    _q,
     // split into four vectors each with four 32-bit
     // partial sums.  Effectively each loop iteration
     // operates on 16 input samples at a time.
-    s0 = s1 = s2 = s3 = (vector float)(0);
+    s0 = s1 = s2 = s3 = (vector float){0,0,0,0};
     while (nblocks >= 4) {
         s0 = vec_madd(ar[nblocks-1],d[nblocks-1],s0);
         s1 = vec_madd(ar[nblocks-2],d[nblocks-2],s1);
@@ -200,7 +201,7 @@ void dotprod_crcf_execute(dotprod_crcf    _q,
     // move the result into the union s (effetively,
     // this loads the four 32-bit values in s0 into
     // the array w).
-    s.v = vec_add(s0,(vector float)(0));
+    s.v = vec_add(s0,(vector float){0,0,0,0});
 
     // sum the resulting array
     //*_r = s.w[0] + s.w[1] + s.w[2] + s.w[3];

--- a/src/dotprod/src/dotprod_rrrf.av.c
+++ b/src/dotprod/src/dotprod_rrrf.av.c
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <altivec.h>
 
 #include "liquid.internal.h"
 
@@ -163,8 +164,8 @@ void dotprod_rrrf_execute(dotprod_rrrf _q,
     union { vector float v; float w[4];} s;
     unsigned int nblocks;
 
-    ar = (vector float*)( (int)_x & ~15);
-    al = ((int)_x & 15)/sizeof(float);
+    ar = (vector float*)( (uintptr_t)_x & ~15);
+    al = ((uintptr_t)_x & 15)/sizeof(float);
 
     d = (vector float*)_q->h[al];
 
@@ -173,7 +174,7 @@ void dotprod_rrrf_execute(dotprod_rrrf _q,
     // split into four vectors each with four 32-bit
     // partial sums.  Effectively each loop iteration
     // operates on 16 input samples at a time.
-    s0 = s1 = s2 = s3 = (vector float)(0);
+    s0 = s1 = s2 = s3 = (vector float){0,0,0,0};
     while (nblocks >= 4) {
         s0 = vec_madd(ar[nblocks-1],d[nblocks-1],s0);
         s1 = vec_madd(ar[nblocks-2],d[nblocks-2],s1);
@@ -194,7 +195,7 @@ void dotprod_rrrf_execute(dotprod_rrrf _q,
     // move the result into the union s (effetively,
     // this loads the four 32-bit values in s0 into
     // the array w).
-    s.v = vec_add(s0,(vector float)(0));
+    s.v = vec_add(s0,(vector float){0,0,0,0});
 
     // sum the resulting array
     *_r = s.w[0] + s.w[1] + s.w[2] + s.w[3];


### PR DESCRIPTION
- include altivec.h
- fix typecasting
- fix initialization

Passes test suite on Fedora ppc64 and ppc64le.