### PR TITLE
Fix SSE2 compilation problem

### DIFF
--- a/scripts/ax_ext.m4
+++ b/scripts/ax_ext.m4
@@ -125,32 +125,32 @@ AC_DEFUN([AX_EXT],
   ])
 
   if [ test "$ax_cv_have_mmx_ext" = yes && test "$ac_cv_header_mmintrin_h" = yes ]; then
-    AC_DEFINE(HAVE_MMX,, [Support MMX instructions])
+    AC_DEFINE(HAVE_MMX,1, [Support MMX instructions])
     AX_CHECK_COMPILE_FLAG(-mmmx, SIMD_FLAGS="$SIMD_FLAGS -mmmx", [])
   fi
 
   if [ test "$ax_cv_have_sse_ext" = yes && test "$ac_cv_header_xmmintrin_h" = yes ]; then
-    AC_DEFINE(HAVE_SSE,, [Support SSE (Streaming SIMD Extensions) instructions])
+    AC_DEFINE(HAVE_SSE,1, [Support SSE (Streaming SIMD Extensions) instructions])
     AX_CHECK_COMPILE_FLAG(-msse, SIMD_FLAGS="$SIMD_FLAGS -msse", [])
   fi
 
   if [ test "$ax_cv_have_sse2_ext" = yes && test "$ac_cv_header_emmintrin_h" = yes ]; then
-    AC_DEFINE(HAVE_SSE2,, [Support SSE2 (Streaming SIMD Extensions 2) instructions])
+    AC_DEFINE(HAVE_SSE2,1, [Support SSE2 (Streaming SIMD Extensions 2) instructions])
     AX_CHECK_COMPILE_FLAG(-msse2, SIMD_FLAGS="$SIMD_FLAGS -msse2", [])
   fi
 
   if [ test "$ax_cv_have_sse3_ext" = yes && test "$ac_cv_header_pmmintrin_h" = yes ]; then
-    AC_DEFINE(HAVE_SSE3,, [Support SSE3 (Streaming SIMD Extensions 3) instructions])
+    AC_DEFINE(HAVE_SSE3,1, [Support SSE3 (Streaming SIMD Extensions 3) instructions])
     AX_CHECK_COMPILE_FLAG(-msse3, SIMD_FLAGS="$SIMD_FLAGS -msse3", [])
   fi
 
   if [ test "$ax_cv_have_ssse3_ext" = yes && test "$ac_cv_header_tmmintrin_h" = yes ]; then
-    AC_DEFINE(HAVE_SSSE3,, [Support SSSE3 (Supplemental Streaming SIMD Extensions 3) instructions])
+    AC_DEFINE(HAVE_SSSE3,1, [Support SSSE3 (Supplemental Streaming SIMD Extensions 3) instructions])
     AX_CHECK_COMPILE_FLAG(-mssse3, SIMD_FLAGS="$SIMD_FLAGS -mssse3", [])
   fi
 
   if [ test "$ax_cv_have_sse41_ext" = yes && test "$ac_cv_header_smmintrin_h" = yes ]; then
-    AC_DEFINE(HAVE_SSE41,, [Support SSE4.1 (Streaming SIMD Extensions 4.1) instructions])
+    AC_DEFINE(HAVE_SSE41,1, [Support SSE4.1 (Streaming SIMD Extensions 4.1) instructions])
     AX_CHECK_COMPILE_FLAG(-msse4.1, SIMD_FLAGS="$SIMD_FLAGS -msse4.1", [])
   fi
 
@@ -160,7 +160,7 @@ AC_DEFUN([AX_EXT],
   fi
 
   if [ test "$ax_cv_have_avx_ext" = yes && test "$ac_cv_header_immintrin_h" = yes ]; then
-    AC_DEFINE(HAVE_AVX,,[Support AVX (Advanced Vector Extensions) instructions])
+    AC_DEFINE(HAVE_AVX,1,[Support AVX (Advanced Vector Extensions) instructions])
     AX_CHECK_COMPILE_FLAG(-mavx, SIMD_FLAGS="$SIMD_FLAGS -mavx", [])
   fi
 

--- a/src/dotprod/src/dotprod_cccf.mmx.c
+++ b/src/dotprod/src/dotprod_cccf.mmx.c
@@ -33,19 +33,19 @@
 // include proper SIMD extensions for x86 platforms
 // NOTE: these pre-processor macros are defined in config.h
 
-#if HAVE_MMINTRIN_H
+#if HAVE_MMX && HAVE_MMINTRIN_H
 #include <mmintrin.h>   // MMX
 #endif
 
-#if HAVE_XMMINTRIN_H
+#if HAVE_SSE && HAVE_XMMINTRIN_H
 #include <xmmintrin.h>  // SSE
 #endif
 
-#if HAVE_EMMINTRIN_H
+#if HAVE_SSE2 && HAVE_EMMINTRIN_H
 #include <emmintrin.h>  // SSE2
 #endif
 
-#if HAVE_PMMINTRIN_H
+#if HAVE_SSE3 && HAVE_PMMINTRIN_H
 #include <pmmintrin.h>  // SSE3
 #endif
 
@@ -219,7 +219,7 @@ void dotprod_cccf_execute_mmx(dotprod_cccf    _q,
     // aligned output array
     float w[4] __attribute__((aligned(16))) = {0,0,0,0};
 
-#if HAVE_PMMINTRIN_H
+#if HAVE_SSE3 && HAVE_PMMINTRIN_H
     // SSE3
     __m128 s;   // dot product
     __m128 sum = _mm_setzero_ps(); // load zeros into sum register
@@ -250,7 +250,7 @@ void dotprod_cccf_execute_mmx(dotprod_cccf    _q,
         // shuffle values
         cq = _mm_shuffle_ps( cq, cq, _MM_SHUFFLE(2,3,0,1) );
         
-#if HAVE_PMMINTRIN_H
+#if HAVE_SSE3 && HAVE_PMMINTRIN_H
         // SSE3: combine using addsub_ps()
         s = _mm_addsub_ps( ci, cq );
 
@@ -271,7 +271,7 @@ void dotprod_cccf_execute_mmx(dotprod_cccf    _q,
 #endif
     }
 
-#if HAVE_PMMINTRIN_H
+#if HAVE_SSE3 && HAVE_PMMINTRIN_H
     // unload packed array
     _mm_store_ps(w, sum);
 #endif

--- a/src/dotprod/src/dotprod_rrrf.mmx.c
+++ b/src/dotprod/src/dotprod_rrrf.mmx.c
@@ -34,19 +34,19 @@
 // include proper SIMD extensions for x86 platforms
 // NOTE: these pre-processor macros are defined in config.h
 
-#if HAVE_MMINTRIN_H
+#if HAVE_MMX && HAVE_MMINTRIN_H
 #include <mmintrin.h>   // MMX
 #endif
 
-#if HAVE_XMMINTRIN_H
+#if HAVE_SSE && HAVE_XMMINTRIN_H
 #include <xmmintrin.h>  // SSE
 #endif
 
-#if HAVE_EMMINTRIN_H
+#if HAVE_SSE2 && HAVE_EMMINTRIN_H
 #include <emmintrin.h>  // SSE2
 #endif
 
-#if HAVE_PMMINTRIN_H
+#if HAVE_SSE3 && HAVE_PMMINTRIN_H
 #include <pmmintrin.h>  // SSE3
 #endif
 
@@ -197,7 +197,7 @@ void dotprod_rrrf_execute_mmx(dotprod_rrrf _q,
     // aligned output array
     float w[4] __attribute__((aligned(16)));
 
-#if HAVE_PMMINTRIN_H
+#if HAVE_SSE3 && HAVE_PMMINTRIN_H
     // fold down into single value
     __m128 z = _mm_setzero_ps();
     sum = _mm_hadd_ps(sum, z);
@@ -275,7 +275,7 @@ void dotprod_rrrf_execute_mmx4(dotprod_rrrf _q,
     // aligned output array
     float w[4] __attribute__((aligned(16)));
 
-#if HAVE_PMMINTRIN_H
+#if HAVE_SSE3 && HAVE_PMMINTRIN_H
     // SSE3: fold down to single value using _mm_hadd_ps()
     __m128 z = _mm_setzero_ps();
     sum0 = _mm_hadd_ps(sum0, z);

--- a/src/dotprod/src/sumsq.mmx.c
+++ b/src/dotprod/src/sumsq.mmx.c
@@ -33,19 +33,19 @@
 // include proper SIMD extensions for x86 platforms
 // NOTE: these pre-processor macros are defined in config.h
 
-#if HAVE_MMINTRIN_H
+#if HAVE_MMX && HAVE_MMINTRIN_H
 #include <mmintrin.h>   // MMX
 #endif
 
-#if HAVE_XMMINTRIN_H
+#if HAVE_SSE && HAVE_XMMINTRIN_H
 #include <xmmintrin.h>  // SSE
 #endif
 
-#if HAVE_EMMINTRIN_H
+#if HAVE_SSE2 && HAVE_EMMINTRIN_H
 #include <emmintrin.h>  // SSE2
 #endif
 
-#if HAVE_PMMINTRIN_H
+#if HAVE_SSE3 && HAVE_PMMINTRIN_H
 #include <pmmintrin.h>  // SSE3
 #endif
 
@@ -79,7 +79,7 @@ float liquid_sumsqf(float *      _v,
     // aligned output array
     float w[4] __attribute__((aligned(16)));
 
-#if HAVE_PMMINTRIN_H
+#if HAVE_SSE3 && HAVE_PMMINTRIN_H
     // fold down into single value
     __m128 z = _mm_setzero_ps();
     sum = _mm_hadd_ps(sum, z);


### PR DESCRIPTION
Summary: This patch ties inclusion of X86 SIMD intrinsic
headers with the type of insturction set determined by compiler.
It also avoids compilation problems when liquid is forced
compiled with an older architecture even when support
for new ones is available on host platform.
	modified:   scripts/ax_ext.m4
	modified:   src/dotprod/src/dotprod_cccf.mmx.c
	modified:   src/dotprod/src/dotprod_rrrf.mmx.c
	modified:   src/dotprod/src/sumsq.mmx.c

Fixes #137 