### PR TITLE
Implement ofdmflexframesync_set_cfo()/ofdmframesync_set_cfo()

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -5140,6 +5140,9 @@ float ofdmflexframesync_get_rssi(ofdmflexframesync _q);
 // query the received carrier offset estimate
 float ofdmflexframesync_get_cfo(ofdmflexframesync _q);
 
+// set the received carrier offset estimate
+void ofdmflexframesync_set_cfo(ofdmflexframesync _q, float _cfo);
+
 // enable/disable debugging
 void ofdmflexframesync_debug_enable(ofdmflexframesync _q);
 void ofdmflexframesync_debug_disable(ofdmflexframesync _q);
@@ -7493,6 +7496,9 @@ void ofdmframesync_execute(ofdmframesync _q,
 // query methods
 float ofdmframesync_get_rssi(ofdmframesync _q); // received signal strength indication
 float ofdmframesync_get_cfo(ofdmframesync _q);  // carrier offset estimate
+
+// set methods
+void ofdmframesync_set_cfo(ofdmframesync _q, float _cfo);  // set carrier offset estimate
 
 // debugging
 void ofdmframesync_debug_enable(ofdmframesync _q);

--- a/src/framing/src/ofdmflexframesync.c
+++ b/src/framing/src/ofdmflexframesync.c
@@ -374,6 +374,16 @@ float ofdmflexframesync_get_cfo(ofdmflexframesync _q)
     return ofdmframesync_get_cfo(_q->fs);
 }
 
+//
+// set methods
+//
+
+// received carrier frequency offset
+void ofdmflexframesync_set_cfo(ofdmflexframesync _q, float _cfo)
+{
+    return ofdmframesync_set_cfo(_q->fs, _cfo);
+}
+
 // 
 // debugging methods
 //

--- a/src/multichannel/src/ofdmframesync.c
+++ b/src/multichannel/src/ofdmframesync.c
@@ -415,6 +415,11 @@ float ofdmframesync_get_cfo(ofdmframesync _q)
     return nco_crcf_get_frequency(_q->nco_rx);
 }
 
+// set receiver carrier frequency offset estimate
+void ofdmframesync_set_cfo(ofdmframesync _q, float _cfo)
+{
+    nco_crcf_set_frequency(_q->nco_rx, _cfo);
+}
 
 //
 // internal methods


### PR DESCRIPTION
This patch implements counter parts of ofdmflexframesync_get_cfo()/ofdmframesync_get_cfo(). This was useful for me to hide liquid-dsp internals from one of open source 3rd parties which tried to dig directly into liquid-dsp internals. Perhaps it could be useful for other people.