### PR TITLE
build: set soname version for libliquid.so

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -260,7 +260,7 @@ darwin*)
     AC_PROG_LIBTOOL
 
     AR_LIB=libliquid.ar
-    SH_LIB=libliquid.dylib
+    SH_LIB=libliquid.${PACKAGE_VERSION}.dylib
     REBIND=""
     ;;
 *)
@@ -270,7 +270,7 @@ darwin*)
     AC_PROG_AR
 
     AR_LIB=libliquid.a
-    SH_LIB=libliquid.so
+    SH_LIB=libliquid.so.${PACKAGE_VERSION::-2}
     REBIND=ldconfig
     ;;
 esac

--- a/makefile.in
+++ b/makefile.in
@@ -1258,7 +1258,7 @@ libliquid.a: $(objects)
 	${AR} r $@ $^
 	${RANLIB} $@
 
-libliquid.so: libliquid.a
+@SH_LIB@: libliquid.a
 	$(CC) $(CFLAGS) $(LDFLAGS) -shared -Xlinker -soname=$@ -o $@ -Wl,-whole-archive $^ -Wl,-no-whole-archive $(LIBS)
 
 # static archive and library objects


### PR DESCRIPTION
Set soname version to avoid Yocto QA error on non-symlink .so
This also improves library version requirements for consuming
applications.

Signed-off-by: Liam Beguin <lvb@xiphos.com>