### PR TITLE
filt: Update delay in farrow filt object

### DIFF
--- a/src/filter/src/firfarrow.c
+++ b/src/filter/src/firfarrow.c
@@ -211,6 +211,9 @@ void FIRFARROW(_set_delay)(FIRFARROW() _q,
 
         //printf("  h[%3u] = %12.8f\n", i, _q->h[i]);
     }
+
+    // Update delay in filter object
+    _q->mu = _mu;
 }
 
 // execute firfarrow internal dot product


### PR DESCRIPTION
`firfarrow_xxxf_set_delay` API of farrow fir filter object does not update the nominal delay

Fixes #182 