### PR TITLE
Removed undesired printf from FIRINTERP(_create_kaiser)

### DIFF
--- a/src/filter/src/firdecim.c
+++ b/src/filter/src/firdecim.c
@@ -118,7 +118,7 @@ FIRDECIM() FIRDECIM(_create_kaiser)(unsigned int _M,
         hc[i] = hf[i];
     
     // return decimator object
-    return FIRDECIM(_create)(_M, hc, 2*_M*_m);
+    return FIRDECIM(_create)(_M, hc, h_len);
 }
 
 // create square-root Nyquist decimator

--- a/src/filter/src/firinterp.c
+++ b/src/filter/src/firinterp.c
@@ -109,7 +109,7 @@ FIRINTERP() FIRINTERP(_create_kaiser)(unsigned int _M,
     TC hc[h_len];
     unsigned int i;
     for (i=0; i<h_len; i++) {
-        printf("%3u : %12.6f\n", i, hf[i]);
+        //printf("%3u : %12.6f\n", i, hf[i]);
         hc[i] = hf[i];
     }
     

--- a/src/filter/src/firinterp.c
+++ b/src/filter/src/firinterp.c
@@ -114,7 +114,7 @@ FIRINTERP() FIRINTERP(_create_kaiser)(unsigned int _M,
     }
     
     // return interpolator object
-    return FIRINTERP(_create)(_M, hc, 2*_M*_m);
+    return FIRINTERP(_create)(_M, hc, h_len);
 }
 
 // create prototype (root-)Nyquist interpolator

--- a/src/modem/src/modem_qpsk.c
+++ b/src/modem/src/modem_qpsk.c
@@ -55,8 +55,8 @@ void MODEM(_modulate_qpsk)(MODEM()      _q,
                            TC *         _y)
 {
     // compute output sample directly from input
-    *_y  = (_sym_in & 0x01 ? -M_SQRT1_2 : M_SQRT1_2) +
-           (_sym_in & 0x02 ? -M_SQRT1_2 : M_SQRT1_2)*_Complex_I;
+    *_y  = (_sym_in & 0x01 ? M_SQRT1_2 : -M_SQRT1_2) +
+           (_sym_in & 0x02 ? M_SQRT1_2 : -M_SQRT1_2)*_Complex_I;
 }
 
 // demodulate QPSK
@@ -65,8 +65,8 @@ void MODEM(_demodulate_qpsk)(MODEM() _q,
                              unsigned int * _sym_out)
 {
     // slice directly to output symbol
-    *_sym_out  = (crealf(_x) > 0 ? 0 : 1) +
-                    (cimagf(_x) > 0 ? 0 : 2);
+    *_sym_out  = (crealf(_x) < 0 ? 0 : 1) +
+                    (cimagf(_x) < 0 ? 0 : 2);
 
     // re-modulate symbol and store state
     MODEM(_modulate_qpsk)(_q, *_sym_out, &_q->x_hat);


### PR DESCRIPTION
Removed a printf in the FIRINTERP(_create_kaiser) function that was probably meant for debugging, but was left enabled at all times.