### PR TITLE
firdes: Make fractional delay consistent

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -2068,16 +2068,16 @@ void liquid_firdes_gmsktx(unsigned int _k, unsigned int _m, float _beta, float _
 void liquid_firdes_gmskrx(unsigned int _k, unsigned int _m, float _beta, float _dt, float * _h);
 
 // Design flipped exponential Nyquist/root-Nyquist filters
-void liquid_firdes_fexp( unsigned int _k, unsigned int _m, float _beta, float _dt, float * _h);
-void liquid_firdes_rfexp(unsigned int _k, unsigned int _m, float _beta, float _dt, float * _h);
+void liquid_firdes_fexp( unsigned int _k, unsigned int _m, float _beta, float * _h);
+void liquid_firdes_rfexp(unsigned int _k, unsigned int _m, float _beta, float * _h);
 
 // Design flipped hyperbolic secand Nyquist/root-Nyquist filters
-void liquid_firdes_fsech( unsigned int _k, unsigned int _m, float _beta, float _dt, float * _h);
-void liquid_firdes_rfsech(unsigned int _k, unsigned int _m, float _beta, float _dt, float * _h);
+void liquid_firdes_fsech( unsigned int _k, unsigned int _m, float _beta, float * _h);
+void liquid_firdes_rfsech(unsigned int _k, unsigned int _m, float _beta, float * _h);
 
 // Design flipped arc-hyperbolic secand Nyquist/root-Nyquist filters
-void liquid_firdes_farcsech( unsigned int _k, unsigned int _m, float _beta, float _dt, float * _h);
-void liquid_firdes_rfarcsech(unsigned int _k, unsigned int _m, float _beta, float _dt, float * _h);
+void liquid_firdes_farcsech( unsigned int _k, unsigned int _m, float _beta, float * _h);
+void liquid_firdes_rfarcsech(unsigned int _k, unsigned int _m, float _beta, float * _h);
 
 // Compute group delay for an FIR filter
 //  _h      : filter coefficients array

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -957,7 +957,6 @@ void liquid_firdes_fnyquist(liquid_firfilt_type _type,
                             unsigned int        _k,
                             unsigned int        _m,
                             float               _beta,
-                            float               _dt,
                             float *             _h);
 
 // flipped exponential frequency response

--- a/src/filter/src/firdes.c
+++ b/src/filter/src/firdes.c
@@ -376,13 +376,13 @@ void liquid_firdes_prototype(liquid_firfilt_type _type,
         liquid_firdes_rcos(_k, _m, _beta, _dt, _h);
         break;
     case LIQUID_FIRFILT_FEXP:
-        liquid_firdes_fexp(_k, _m, _beta, _dt, _h);
+        liquid_firdes_fexp(_k, _m, _beta, _h);
         break;
     case LIQUID_FIRFILT_FSECH:
-        liquid_firdes_fsech(_k, _m, _beta, _dt, _h);
+        liquid_firdes_fsech(_k, _m, _beta, _h);
         break;
     case LIQUID_FIRFILT_FARCSECH:
-        liquid_firdes_farcsech(_k, _m, _beta, _dt, _h);
+        liquid_firdes_farcsech(_k, _m, _beta, _h);
         break;
 
     // root-Nyquist filter prototypes
@@ -406,13 +406,13 @@ void liquid_firdes_prototype(liquid_firfilt_type _type,
         liquid_firdes_gmskrx(_k, _m, _beta, _dt, _h);
         break;
     case LIQUID_FIRFILT_RFEXP:
-        liquid_firdes_rfexp(_k, _m, _beta, _dt, _h);
+        liquid_firdes_rfexp(_k, _m, _beta, _h);
         break;
     case LIQUID_FIRFILT_RFSECH:
-        liquid_firdes_rfsech(_k, _m, _beta, _dt, _h);
+        liquid_firdes_rfsech(_k, _m, _beta, _h);
         break;
     case LIQUID_FIRFILT_RFARCSECH:
-        liquid_firdes_rfarcsech(_k, _m, _beta, _dt, _h);
+        liquid_firdes_rfarcsech(_k, _m, _beta, _h);
         break;
     default:
         fprintf(stderr,"error: liquid_firdes_prototype(), invalid root-Nyquist filter type '%d'\n", _type);

--- a/src/filter/src/fnyquist.c
+++ b/src/filter/src/fnyquist.c
@@ -41,14 +41,12 @@
 //  _k      : samples/symbol
 //  _m      : symbol delay
 //  _beta   : rolloff factor (0 < beta <= 1)
-//  _dt     : fractional sample delay
 //  _h      : output coefficient buffer (length: 2*k*m+1)
 void liquid_firdes_fnyquist(liquid_firfilt_type _type,
                             int                 _root,
                             unsigned int        _k,
                             unsigned int        _m,
                             float               _beta,
-                            float               _dt,
                             float *             _h)
 {
     // validate input
@@ -105,32 +103,28 @@ void liquid_firdes_fnyquist(liquid_firfilt_type _type,
 //  _k      : samples/symbol
 //  _m      : symbol delay
 //  _beta   : rolloff factor (0 < beta <= 1)
-//  _dt     : fractional sample delay
 //  _h      : output coefficient buffer (length: 2*k*m+1)
 void liquid_firdes_fexp(unsigned int _k,
                         unsigned int _m,
                         float _beta,
-                        float _dt,
                         float * _h)
 {
     // compute resonse using generic function
-    liquid_firdes_fnyquist(LIQUID_FIRFILT_FEXP, 0, _k, _m, _beta, _dt, _h);
+    liquid_firdes_fnyquist(LIQUID_FIRFILT_FEXP, 0, _k, _m, _beta, _h);
 }
 
 // Design fexp square-root Nyquist filter
 //  _k      : samples/symbol
 //  _m      : symbol delay
 //  _beta   : rolloff factor (0 < beta <= 1)
-//  _dt     : fractional sample delay
 //  _h      : output coefficient buffer (length: 2*k*m+1)
 void liquid_firdes_rfexp(unsigned int _k,
                          unsigned int _m,
                          float _beta,
-                         float _dt,
                          float * _h)
 {
     // compute resonse using generic function
-    liquid_firdes_fnyquist(LIQUID_FIRFILT_FEXP, 1, _k, _m, _beta, _dt, _h);
+    liquid_firdes_fnyquist(LIQUID_FIRFILT_FEXP, 1, _k, _m, _beta, _h);
 }
 
 // flipped exponential frequency response
@@ -181,32 +175,28 @@ void liquid_firdes_fexp_freqresponse(unsigned int _k,
 //  _k      : samples/symbol
 //  _m      : symbol delay
 //  _beta   : rolloff factor (0 < beta <= 1)
-//  _dt     : fractional sample delay
 //  _h      : output coefficient buffer (length: 2*k*m+1)
 void liquid_firdes_fsech(unsigned int _k,
                          unsigned int _m,
                          float _beta,
-                         float _dt,
                          float * _h)
 {
     // compute resonse using generic function
-    liquid_firdes_fnyquist(LIQUID_FIRFILT_FSECH, 0, _k, _m, _beta, _dt, _h);
+    liquid_firdes_fnyquist(LIQUID_FIRFILT_FSECH, 0, _k, _m, _beta, _h);
 }
 
 // Design fsech square-root Nyquist filter
 //  _k      : samples/symbol
 //  _m      : symbol delay
 //  _beta   : rolloff factor (0 < beta <= 1)
-//  _dt     : fractional sample delay
 //  _h      : output coefficient buffer (length: 2*k*m+1)
 void liquid_firdes_rfsech(unsigned int _k,
                           unsigned int _m,
                           float _beta,
-                          float _dt,
                           float * _h)
 {
     // compute resonse using generic function
-    liquid_firdes_fnyquist(LIQUID_FIRFILT_FSECH, 1, _k, _m, _beta, _dt, _h);
+    liquid_firdes_fnyquist(LIQUID_FIRFILT_FSECH, 1, _k, _m, _beta, _h);
 }
 
 // flipped exponential frequency response
@@ -257,32 +247,28 @@ void liquid_firdes_fsech_freqresponse(unsigned int _k,
 //  _k      : samples/symbol
 //  _m      : symbol delay
 //  _beta   : rolloff factor (0 < beta <= 1)
-//  _dt     : fractional sample delay
 //  _h      : output coefficient buffer (length: 2*k*m+1)
 void liquid_firdes_farcsech(unsigned int _k,
                             unsigned int _m,
                             float _beta,
-                            float _dt,
                             float * _h)
 {
     // compute resonse using generic function
-    liquid_firdes_fnyquist(LIQUID_FIRFILT_FARCSECH, 0, _k, _m, _beta, _dt, _h);
+    liquid_firdes_fnyquist(LIQUID_FIRFILT_FARCSECH, 0, _k, _m, _beta, _h);
 }
 
 // Design farcsech square-root Nyquist filter
 //  _k      : samples/symbol
 //  _m      : symbol delay
 //  _beta   : rolloff factor (0 < beta <= 1)
-//  _dt     : fractional sample delay
 //  _h      : output coefficient buffer (length: 2*k*m+1)
 void liquid_firdes_rfarcsech(unsigned int _k,
                              unsigned int _m,
                              float _beta,
-                             float _dt,
                              float * _h)
 {
     // compute resonse using generic function
-    liquid_firdes_fnyquist(LIQUID_FIRFILT_FARCSECH, 1, _k, _m, _beta, _dt, _h);
+    liquid_firdes_fnyquist(LIQUID_FIRFILT_FARCSECH, 1, _k, _m, _beta, _h);
 }
 
 // hyperbolic arc-secant

--- a/src/filter/src/rcos.c
+++ b/src/filter/src/rcos.c
@@ -51,6 +51,9 @@ void liquid_firdes_rcos(unsigned int _k,
     } else if ( (_beta < 0.0f) || (_beta > 1.0f) ) {
         fprintf(stderr,"error: liquid_firdes_rcos(): beta must be in [0,1]\n");
         exit(1);
+    } else if ( (_dt < -0.5f) || (_dt > 0.5f) ) {
+        fprintf(stderr, "error: liquid_firdes_rcos(): fractional delay must be in [-0.5, 0.5]\n");
+        exit(1);
     } else;
 
     unsigned int n;

--- a/src/filter/src/rrcos.c
+++ b/src/filter/src/rrcos.c
@@ -49,6 +49,9 @@ void liquid_firdes_rrcos(unsigned int _k,
     } else if ( (_beta < 0.0f) || (_beta > 1.0f) ) {
         fprintf(stderr,"error: liquid_firdes_rrcos(): beta must be in [0,1]\n");
         exit(1);
+    } else if ( (_dt < -0.5f) || (_dt > 0.5f) ) {
+        fprintf(stderr, "error: liquid_firdes_rrcos(): fractional delay must be in [-0.5, 0.5]\n");
+        exit(1);
     } else;
 
     unsigned int n;


### PR DESCRIPTION
Summary: Flipped Nyquist filters do not use fractional sample
delay, removed it from API and usage to avoid confusion. Also
updated error checking on root and raised cosine filters to
check for the correct range [-0.5, 0.5]

Fixes # 196