### PR TITLE
iirfilt: Add missing SOS API for iirfilt object

### DIFF
--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3053,6 +3053,83 @@ LIQUID_IIRFILT_DEFINE_API(LIQUID_IIRFILT_MANGLE_CCCF,
                           liquid_float_complex,
                           liquid_float_complex)
 
+//
+// iirfiltsos : infinite impulse respone filter (second-order sections)
+//
+#define LIQUID_IIRFILTSOS_MANGLE_RRRF(name)  LIQUID_CONCAT(iirfiltsos_rrrf,name)
+#define LIQUID_IIRFILTSOS_MANGLE_CRCF(name)  LIQUID_CONCAT(iirfiltsos_crcf,name)
+#define LIQUID_IIRFILTSOS_MANGLE_CCCF(name)  LIQUID_CONCAT(iirfiltsos_cccf,name)
+
+#define LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(IIRFILTSOS,TO,TC,TI)  \
+typedef struct IIRFILTSOS(_s) * IIRFILTSOS();                   \
+                                                                \
+/* create 2nd-order infinite impulse reponse filter         */  \
+/*  _b      : feed-forward coefficients [size: _3 x 1]      */  \
+/*  _a      : feed-back coefficients    [size: _3 x 1]      */  \
+IIRFILTSOS() IIRFILTSOS(_create)(TC * _b,                       \
+                                 TC * _a);                      \
+                                                                \
+/* explicitly set 2nd-order IIR filter coefficients         */  \
+/*  _q      : iirfiltsos object                             */  \
+/*  _b      : feed-forward coefficients [size: _3 x 1]      */  \
+/*  _a      : feed-back coefficients    [size: _3 x 1]      */  \
+void IIRFILTSOS(_set_coefficients)(IIRFILTSOS() _q,             \
+                                   TC *         _b,             \
+                                   TC *         _a);            \
+                                                                \
+/* destroy iirfiltsos object, freeing all internal memory   */  \
+void IIRFILTSOS(_destroy)(IIRFILTSOS() _q);                     \
+                                                                \
+/* print iirfiltsos object properties to stdout             */  \
+void IIRFILTSOS(_print)(IIRFILTSOS() _q);                       \
+                                                                \
+/* clear/reset iirfiltsos object internals                  */  \
+void IIRFILTSOS(_reset)(IIRFILTSOS() _q);                       \
+                                                                \
+/* compute filter output                                    */  \
+/*  _q      : iirfiltsos object                             */  \
+/*  _x      : input sample                                  */  \
+/*  _y      : output sample pointer                         */  \
+void IIRFILTSOS(_execute)(IIRFILTSOS() _q,                      \
+                          TI           _x,                      \
+                          TO *         _y);                     \
+                                                                \
+/* compute filter output, direct-form I method              */  \
+/*  _q      : iirfiltsos object                             */  \
+/*  _x      : input sample                                  */  \
+/*  _y      : output sample pointer                         */  \
+void IIRFILTSOS(_execute_df1)(IIRFILTSOS() _q,                  \
+                              TI           _x,                  \
+                              TO *         _y);                 \
+                                                                \
+/* compute filter output, direct-form II method             */  \
+/*  _q      : iirfiltsos object                             */  \
+/*  _x      : input sample                                  */  \
+/*  _y      : output sample pointer                         */  \
+void IIRFILTSOS(_execute_df2)(IIRFILTSOS() _q,                  \
+                              TI           _x,                  \
+                              TO *         _y);                 \
+                                                                \
+/* compute and return group delay of filter object          */  \
+/*  _q      : filter object                                 */  \
+/*  _fc     : frequency to evaluate                         */  \
+float IIRFILTSOS(_groupdelay)(IIRFILTSOS() _q,                  \
+                              float        _fc);                \
+
+LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_RRRF,
+                                      float,
+                                      float,
+                                      float)
+
+LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_CRCF,
+                                      liquid_float_complex,
+                                      float,
+                                      liquid_float_complex)
+
+LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_CCCF,
+                                      liquid_float_complex,
+                                      liquid_float_complex,
+                                      liquid_float_complex)
 
 //
 // FIR Polyphase filter bank

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -3060,7 +3060,7 @@ LIQUID_IIRFILT_DEFINE_API(LIQUID_IIRFILT_MANGLE_CCCF,
 #define LIQUID_IIRFILTSOS_MANGLE_CRCF(name)  LIQUID_CONCAT(iirfiltsos_crcf,name)
 #define LIQUID_IIRFILTSOS_MANGLE_CCCF(name)  LIQUID_CONCAT(iirfiltsos_cccf,name)
 
-#define LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(IIRFILTSOS,TO,TC,TI)  \
+#define LIQUID_IIRFILTSOS_DEFINE_API(IIRFILTSOS,TO,TC,TI)  \
 typedef struct IIRFILTSOS(_s) * IIRFILTSOS();                   \
                                                                 \
 /* create 2nd-order infinite impulse reponse filter         */  \
@@ -3116,17 +3116,17 @@ void IIRFILTSOS(_execute_df2)(IIRFILTSOS() _q,                  \
 float IIRFILTSOS(_groupdelay)(IIRFILTSOS() _q,                  \
                               float        _fc);                \
 
-LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_RRRF,
+LIQUID_IIRFILTSOS_DEFINE_API(LIQUID_IIRFILTSOS_MANGLE_RRRF,
                                       float,
                                       float,
                                       float)
 
-LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_CRCF,
+LIQUID_IIRFILTSOS_DEFINE_API(LIQUID_IIRFILTSOS_MANGLE_CRCF,
                                       liquid_float_complex,
                                       float,
                                       liquid_float_complex)
 
-LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_CCCF,
+LIQUID_IIRFILTSOS_DEFINE_API(LIQUID_IIRFILTSOS_MANGLE_CCCF,
                                       liquid_float_complex,
                                       liquid_float_complex,
                                       liquid_float_complex)

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -815,68 +815,6 @@ LIQUID_FIRFARROW_DEFINE_INTERNAL_API(LIQUID_FIRFARROW_MANGLE_CRCF,
 
 
 
-// 
-// iirfiltsos : infinite impulse respone filter (second-order sections)
-//
-#define LIQUID_IIRFILTSOS_MANGLE_RRRF(name)  LIQUID_CONCAT(iirfiltsos_rrrf,name)
-#define LIQUID_IIRFILTSOS_MANGLE_CRCF(name)  LIQUID_CONCAT(iirfiltsos_crcf,name)
-#define LIQUID_IIRFILTSOS_MANGLE_CCCF(name)  LIQUID_CONCAT(iirfiltsos_cccf,name)
-
-#define LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(IIRFILTSOS,TO,TC,TI)  \
-typedef struct IIRFILTSOS(_s) * IIRFILTSOS();                   \
-                                                                \
-/* create 2nd-order infinite impulse reponse filter         */  \
-/*  _b      : feed-forward coefficients [size: _3 x 1]      */  \
-/*  _a      : feed-back coefficients    [size: _3 x 1]      */  \
-IIRFILTSOS() IIRFILTSOS(_create)(TC * _b,                       \
-                                 TC * _a);                      \
-                                                                \
-/* explicitly set 2nd-order IIR filter coefficients         */  \
-/*  _q      : iirfiltsos object                             */  \
-/*  _b      : feed-forward coefficients [size: _3 x 1]      */  \
-/*  _a      : feed-back coefficients    [size: _3 x 1]      */  \
-void IIRFILTSOS(_set_coefficients)(IIRFILTSOS() _q,             \
-                                   TC *         _b,             \
-                                   TC *         _a);            \
-                                                                \
-/* destroy iirfiltsos object, freeing all internal memory   */  \
-void IIRFILTSOS(_destroy)(IIRFILTSOS() _q);                     \
-                                                                \
-/* print iirfiltsos object properties to stdout             */  \
-void IIRFILTSOS(_print)(IIRFILTSOS() _q);                       \
-                                                                \
-/* clear/reset iirfiltsos object internals                  */  \
-void IIRFILTSOS(_reset)(IIRFILTSOS() _q);                       \
-                                                                \
-/* compute filter output                                    */  \
-/*  _q      : iirfiltsos object                             */  \
-/*  _x      : input sample                                  */  \
-/*  _y      : output sample pointer                         */  \
-void IIRFILTSOS(_execute)(IIRFILTSOS() _q,                      \
-                          TI           _x,                      \
-                          TO *         _y);                     \
-                                                                \
-/* compute filter output, direct-form I method              */  \
-/*  _q      : iirfiltsos object                             */  \
-/*  _x      : input sample                                  */  \
-/*  _y      : output sample pointer                         */  \
-void IIRFILTSOS(_execute_df1)(IIRFILTSOS() _q,                  \
-                              TI           _x,                  \
-                              TO *         _y);                 \
-                                                                \
-/* compute filter output, direct-form II method             */  \
-/*  _q      : iirfiltsos object                             */  \
-/*  _x      : input sample                                  */  \
-/*  _y      : output sample pointer                         */  \
-void IIRFILTSOS(_execute_df2)(IIRFILTSOS() _q,                  \
-                              TI           _x,                  \
-                              TO *         _y);                 \
-                                                                \
-/* compute and return group delay of filter object          */  \
-/*  _q      : filter object                                 */  \
-/*  _fc     : frequency to evaluate                         */  \
-float IIRFILTSOS(_groupdelay)(IIRFILTSOS() _q,                  \
-                              float        _fc);                \
 
 LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_RRRF,
                                       float,

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -814,24 +814,6 @@ LIQUID_FIRFARROW_DEFINE_INTERNAL_API(LIQUID_FIRFARROW_MANGLE_CRCF,
                                      liquid_float_complex)
 
 
-
-
-LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_RRRF,
-                                      float,
-                                      float,
-                                      float)
-
-LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_CRCF,
-                                      liquid_float_complex,
-                                      float,
-                                      liquid_float_complex)
-
-LIQUID_IIRFILTSOS_DEFINE_INTERNAL_API(LIQUID_IIRFILTSOS_MANGLE_CCCF,
-                                      liquid_float_complex,
-                                      liquid_float_complex,
-                                      liquid_float_complex)
-
-
 // firdes : finite impulse response filter design
 
 // Find approximate bandwidth adjustment factor rho based on


### PR DESCRIPTION
Summary: IIRFILT second order section API is missing from external liquid header.
Fixes #204