### PR TITLE
macOS build: libtool APPLE vs GNU

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -1202,9 +1202,9 @@ else
 	libtool --mode=link $(CC) -static -install_name $@ -o $@ $^ $(LDFLAGS) $(LIBS)
 endif
 
-# gcc -dynamiclib -install_name libliquid.dylib -o libliquid.dylib libmodem.a libutility.a 
+# clang -dylib -install_name libliquid.dylib -o libliquid.dylib libmodem.a libutility.a
 libliquid.dylib: $(objects)
-	$(CC) -dynamiclib ${COVERAGE_FLAGS} -install_name $@ -o $@ $^ $(LDFLAGS) $(LIBS)
+	$(CC) -dylib  ${COVERAGE_FLAGS} -install_name $@ -o $@ $^ $(LDFLAGS) $(LIBS)
 
 #
 # linux, et al

--- a/makefile.in
+++ b/makefile.in
@@ -1194,7 +1194,13 @@ SHARED_LIB	= @SH_LIB@
 # darwin
 #
 libliquid.ar: $(objects)
+ifeq ($(which ${LIBTOOL}), "/usr/bin/libtool")
+	# if it is the Apple libtool
 	${LIBTOOL} -static -o $@ $^
+else
+	# if it is the GNU libtool (built from source)
+	libtool --mode=link $(CC) -static -install_name $@ -o $@ $^ $(LDFLAGS) $(LIBS)
+endif
 
 # gcc -dynamiclib -install_name libliquid.dylib -o libliquid.dylib libmodem.a libutility.a 
 libliquid.dylib: $(objects)


### PR DESCRIPTION
I was building on macOS via spack, which builds from source GNU `libtool` so it is not what the Makefile was expecting (APPLE `libtool`, which has a different user interface and set of options).

I don't have experience with `libtool` and even less about the differences between `libtool` APPLE vs GNU, I just checked the man pages and the documentation, and I came up with the two variants.

This would open to build on OSX using any `libtool` built from source on macOS.

Looking online it seems that also MacPort/Homebrew can provide the GNU `libtool`, but they install it with a different name (i.e. `glibtool`). For the moment this use case is not addressed, but if in the future there will be the need, it will be enough to manage the selection of the correct `${LIBTOOL}` name in the `case darwin` section.

