### PR TITLE
gmskframe: allow specifying BT parameter

### DIFF
--- a/examples/gmskframesync_example.c
+++ b/examples/gmskframesync_example.c
@@ -44,6 +44,9 @@ int main(int argc, char*argv[])
 {
     srand(time(NULL));
 
+    unsigned int k = 2;             // samples/symbol
+    unsigned int m = 3;             // filter delay (symbols)
+    float BT = 0.5f;                // filter bandwidth-time product
     unsigned int payload_len = 40;  // length of payload (bytes)
     crc_scheme check = LIQUID_CRC_32;
     fec_scheme fec0  = LIQUID_FEC_HAMMING128;
@@ -95,9 +98,6 @@ int main(int argc, char*argv[])
 
     unsigned int i;
 
-    // fixed values
-    unsigned int k = 2;
-
     // derived values
     float nstd  = powf(10.0f, noise_floor/20.0f);
     float gamma = powf(10.0f, (SNRdB + noise_floor)/20.0f);
@@ -110,10 +110,10 @@ int main(int argc, char*argv[])
     struct framedata_s fd = {payload, payload_len};
 
     // create frame generator
-    gmskframegen fg = gmskframegen_create();
+    gmskframegen fg = gmskframegen_create(k, m, BT);
 
     // create frame synchronizer
-    gmskframesync fs = gmskframesync_create(callback, (void*)&fd);
+    gmskframesync fs = gmskframesync_create(k, m, BT, callback, (void*)&fd);
     if (debug_enabled)
         gmskframesync_debug_enable(fs);
 

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -5224,7 +5224,12 @@ int fskframesync_debug_export (fskframesync _q, const char * _filename);
 typedef struct gmskframegen_s * gmskframegen;
 
 // create GMSK frame generator
-gmskframegen gmskframegen_create();
+//  _k      :   samples/symbol
+//  _m      :   filter delay (symbols)
+//  _BT     :   excess bandwidth factor
+gmskframegen gmskframegen_create(unsigned int _k,
+                                 unsigned int _m,
+                                 float        _BT);
 int gmskframegen_destroy       (gmskframegen _q);
 int gmskframegen_is_assembled  (gmskframegen _q);
 int gmskframegen_print         (gmskframegen _q);
@@ -5257,9 +5262,15 @@ int gmskframegen_write(gmskframegen          _q,
 typedef struct gmskframesync_s * gmskframesync;
 
 // create GMSK frame synchronizer
+//  _k          :   samples/symbol
+//  _m          :   filter delay (symbols)
+//  _BT         :   excess bandwidth factor
 //  _callback   :   callback function
 //  _userdata   :   user data pointer passed to callback function
-gmskframesync gmskframesync_create(framesync_callback _callback,
+gmskframesync gmskframesync_create(unsigned int       _k,
+                                   unsigned int       _m,
+                                   float              _BT,
+                                   framesync_callback _callback,
                                    void *             _userdata);
 int gmskframesync_destroy(gmskframesync _q);
 int gmskframesync_print(gmskframesync _q);

--- a/src/framing/bench/gmskframesync_benchmark.c
+++ b/src/framing/bench/gmskframesync_benchmark.c
@@ -37,6 +37,9 @@ void benchmark_gmskframesync(struct rusage *     _start,
     unsigned long int i;
 
     // options
+    unsigned int k = 2;                 // samples/symbol
+    unsigned int m = 3;                 // filter delay (symbols)
+    float BT = 0.5f;                    // filter bandwidth-time product
     unsigned int payload_len = 8;       // length of payload (bytes)
     crc_scheme check = LIQUID_CRC_32;   // data validity check
     fec_scheme fec0  = LIQUID_FEC_NONE; // inner forward error correction
@@ -47,7 +50,7 @@ void benchmark_gmskframesync(struct rusage *     _start,
     float nstd  = powf(10.0f, -SNRdB/20.0f);
 
     // create gmskframegen object
-    gmskframegen fg = gmskframegen_create();
+    gmskframegen fg = gmskframegen_create(k, m, BT);
 
     // frame data
     unsigned char header[14];
@@ -59,7 +62,7 @@ void benchmark_gmskframesync(struct rusage *     _start,
         payload[i] = rand() & 0xff;
 
     // create gmskframesync object
-    gmskframesync fs = gmskframesync_create(NULL,NULL);
+    gmskframesync fs = gmskframesync_create(k, m, BT, NULL, NULL);
 
     // generate the frame
     gmskframegen_assemble(fg, header, payload, payload_len, check, fec0, fec1);
@@ -101,7 +104,7 @@ void benchmark_gmskframesync_noise(struct rusage *     _start,
     unsigned long int i;
 
     // create frame synchronizer
-    gmskframesync fs = gmskframesync_create(NULL, NULL);
+    gmskframesync fs = gmskframesync_create(2, 3, 0.5f, NULL, NULL);
 
     // allocate memory for noise buffer and initialize
     unsigned int num_samples = 1024;

--- a/src/framing/src/gmskframegen.c
+++ b/src/framing/src/gmskframegen.c
@@ -89,14 +89,19 @@ struct gmskframegen_s {
 };
 
 // create gmskframegen object
-gmskframegen gmskframegen_create()
+//  _k      :   samples/symbol
+//  _m      :   filter delay (symbols)
+//  _BT     :   excess bandwidth factor
+gmskframegen gmskframegen_create(unsigned int _k,
+                                 unsigned int _m,
+                                 float        _BT)
 {
     gmskframegen q = (gmskframegen) malloc(sizeof(struct gmskframegen_s));
 
     // set internal properties
-    q->k  = 2;      // samples/symbol
-    q->m  = 3;      // filter delay (symbols)
-    q->BT = 0.5f;   // filter bandwidth-time product
+    q->k  = _k;     // samples/symbol
+    q->m  = _m;     // filter delay (symbols)
+    q->BT = _BT;    // filter bandwidth-time product
 
     // internal/derived values
     q->preamble_len = 63;       // number of preamble symbols

--- a/src/framing/src/gmskframesync.c
+++ b/src/framing/src/gmskframesync.c
@@ -156,17 +156,23 @@ struct gmskframesync_s {
 };
 
 // create GMSK frame synchronizer
+//  _k          :   samples/symbol
+//  _m          :   filter delay (symbols)
+//  _BT         :   excess bandwidth factor
 //  _callback   :   callback function
 //  _userdata   :   user data pointer passed to callback function
-gmskframesync gmskframesync_create(framesync_callback _callback,
+gmskframesync gmskframesync_create(unsigned int       _k,
+                                   unsigned int       _m,
+                                   float              _BT,
+                                   framesync_callback _callback,
                                    void *             _userdata)
 {
     gmskframesync q = (gmskframesync) malloc(sizeof(struct gmskframesync_s));
     q->callback = _callback;
     q->userdata = _userdata;
-    q->k        = 2;        // samples/symbol
-    q->m        = 3;        // filter delay (symbols)
-    q->BT       = 0.5f;     // filter bandwidth-time product
+    q->k        = _k;        // samples/symbol
+    q->m        = _m;        // filter delay (symbols)
+    q->BT       = _BT;      // filter bandwidth-time product
 
 #if GMSKFRAMESYNC_PREFILTER
     // create default low-pass Butterworth filter

--- a/src/framing/src/gmskframesync.c
+++ b/src/framing/src/gmskframesync.c
@@ -463,7 +463,7 @@ int gmskframesync_update_symsync(gmskframesync _q,
         sample_available = 1;
 
         // reset timer
-        _q->pfb_timer = 2;  // k samples/symbol
+        _q->pfb_timer = _q->k;  // k samples/symbol
 
         firpfb_rrrf_execute(_q->mf,  _q->pfb_index, &mf_out);
         firpfb_rrrf_execute(_q->dmf, _q->pfb_index, &dmf_out);


### PR DESCRIPTION
EDIT: I also added the ```k``` and ```m``` parameters so that ```gmskframegen_create``` has the same parameters as ```gmskmod_create```.
