### PR TITLE
filter: Fix stack overflow in Farrow

### DIFF
--- a/src/filter/src/firfarrow.c
+++ b/src/filter/src/firfarrow.c
@@ -312,7 +312,7 @@ void FIRFARROW(_genpoly)(FIRFARROW() _q)
     float x, mu, h0, h1;
     float mu_vect[_q->Q+1];
     float hp_vect[_q->Q+1];
-    float p[_q->Q];
+    float p[_q->Q+1];
     float beta = kaiser_beta_As(_q->As);
     for (i=0; i<_q->h_len; i++) {
 #if FIRFARROW_DEBUG


### PR DESCRIPTION
Summary: Increase size of polynomial array by one to avoid
random aborts. Caught with clang sanitizers -fsanitize=address

Fixes #246 