### PR TITLE
dsssframesync: fix premature return from dsss_framesync_execute

### DIFF
--- a/src/framing/src/dsssframesync.c
+++ b/src/framing/src/dsssframesync.c
@@ -264,26 +264,31 @@ int dsssframesync_set_header_props(dsssframesync _q, dsssframegenprops_s * _prop
     return dsssframesync_set_header_len(_q, _q->header_user_len);
 }
 
+int dsssframesync_execute_sample(dsssframesync _q, float complex _x)
+{
+    switch (_q->state) {
+    case DSSSFRAMESYNC_STATE_DETECTFRAME:
+        // detect frame (look for p/n sequence)
+        return dsssframesync_execute_seekpn(_q, _x);
+    case DSSSFRAMESYNC_STATE_RXPREAMBLE:
+        // receive p/n sequence symbols
+        return dsssframesync_execute_rxpreamble(_q, _x);
+    case DSSSFRAMESYNC_STATE_RXHEADER:
+        // receive header symbols
+        return dsssframesync_execute_rxheader(_q, _x);
+    case DSSSFRAMESYNC_STATE_RXPAYLOAD:
+        // receive payload symbols
+        return dsssframesync_execute_rxpayload(_q, _x);
+    default:
+        return liquid_error(LIQUID_EINT,"dsssframesync_execute(), invalid internal state");
+    }
+}
+
 int dsssframesync_execute(dsssframesync _q, float complex * _x, unsigned int _n)
 {
     unsigned int i;
     for (i = 0; i < _n; i++) {
-        switch (_q->state) {
-        case DSSSFRAMESYNC_STATE_DETECTFRAME:
-            // detect frame (look for p/n sequence)
-            return dsssframesync_execute_seekpn(_q, _x[i]);
-        case DSSSFRAMESYNC_STATE_RXPREAMBLE:
-            // receive p/n sequence symbols
-            return dsssframesync_execute_rxpreamble(_q, _x[i]);
-        case DSSSFRAMESYNC_STATE_RXHEADER:
-            // receive header symbols
-            return dsssframesync_execute_rxheader(_q, _x[i]);
-        case DSSSFRAMESYNC_STATE_RXPAYLOAD:
-            // receive payload symbols
-            return dsssframesync_execute_rxpayload(_q, _x[i]);
-        default:
-            return liquid_error(LIQUID_EINT,"dsssframesync_execute(), invalid internal state");
-        }
+        dsssframesync_execute_sample(_q, _x[i]);
     }
     return LIQUID_OK;
 }
@@ -298,10 +303,8 @@ int dsssframesync_execute_seekpn(dsssframesync _q, float complex _x)
     float complex * v = qdetector_cccf_execute(_q->detector, _x);
 
     // check if frame has been detected
-    printf("seeking pn...\n");
     if (v == NULL)
         return LIQUID_OK;
-    printf("FRAME DETECTED\n");
 
     // get estimates
     _q->tau_hat   = qdetector_cccf_get_tau(_q->detector);


### PR DESCRIPTION
This is the fix for the ```dsssframesync_execute``` function in version 1.4.0 described in issue #114.
