### PR TITLE
Fix spelling

### DIFF
--- a/HISTORY
+++ b/HISTORY
@@ -107,7 +107,7 @@
     - adding new spwaterfall family of objects for generating waterfall plot
       and automatically down-size as input sample size grows
   * sequence
-    - fixed issue with order of operations causing inconsitent behavior across
+    - fixed issue with order of operations causing inconsistent behavior across
       different platforms
 
 ## Major improvements for v1.3.0 ##

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Seriously, I won't be offended.
 ### Run all test scripts ###
 
 Source code validation is a critical step in any software library,
-particulary for verifying the portability of code to different
+particularly for verifying the portability of code to different
 processors and platforms. Packaged with liquid-dsp are a number of
 automatic test scripts to validate the correctness of the source code.
 The test scripts are located under each module's `tests/` directory and

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,7 +70,7 @@ This directory contains all the examples for interfacing the liquid modules.
     This example demonstrates the interface to the compand function
     (compression, expansion).  The compander is typically used with the
     quantizer to increase the dynamic range of the converter, particularly for
-    low-level signals.  The transfer function is computed (emperically) and
+    low-level signals.  The transfer function is computed (empirically) and
     printed to the screen.
 
  * `complementary_codes_example.c`:
@@ -326,7 +326,7 @@ This directory contains all the examples for interfacing the liquid modules.
  * `freqmodem_example.c`:
 
  * `fskmodem_example.c`:
-    This example demostrates the M-ary frequency-shift keying
+    This example demonstrates the M-ary frequency-shift keying
     (MFSK) modem in liquid. A message signal is modulated and the
     resulting signal is recovered using a demodulator object.
 
@@ -343,7 +343,7 @@ This directory contains all the examples for interfacing the liquid modules.
     mean-squared error sense.
 
  * `iirdes_analog_example.c`:
-    Tests infinite impulse reponse (IIR) analog filter design. While this
+    Tests infinite impulse response (IIR) analog filter design. While this
     example seems purely academic as IIR filters used in liquid are all
     digital, it is important to realize that they are all derived from their
     analog counterparts. This example serves to check the response of the
@@ -354,7 +354,7 @@ This directory contains all the examples for interfacing the liquid modules.
               `iirfilt_crcf_example.c`
 
  * `iirdes_example.c`:
-    Tests infinite impulse reponse (IIR) digital filter design.
+    Tests infinite impulse response (IIR) digital filter design.
 
     SEE ALSO: `iirdes_analog_example.c`
               `iirfilt_crcf_example.c`
@@ -420,7 +420,7 @@ This directory contains all the examples for interfacing the liquid modules.
     SEE ALSO: `modem_example.c`
 
  * `modem_example.c`:
-    This example demonstates the digital modulator/demodulator (modem) object.
+    This example demonstrates the digital modulator/demodulator (modem) object.
     Data symbols are modulated into complex samples which are then demodulated
     without noise or phase offsets.  The user may select the modulation scheme
     via the command-line interface.
@@ -428,11 +428,11 @@ This directory contains all the examples for interfacing the liquid modules.
     SEE ALSO: `modem_arb_example.c`
 
  * `modem_soft_example.c`:
-    This example demonstates soft demodulation of linear
+    This example demonstrates soft demodulation of linear
     modulation schemes.
 
  * `modular_arithmetic_example.c`:
-    This example demonstates some modular arithmetic functions.
+    This example demonstrates some modular arithmetic functions.
 
  * `msequence_example.c`:
     This example demonstrates the auto-correlation properties of a

--- a/examples/bpacketsync_example.c
+++ b/examples/bpacketsync_example.c
@@ -113,7 +113,7 @@ int main(int argc, char*argv[]) {
     // initialize arrays
     unsigned char msg_org[n];   // original message
     unsigned char msg_enc[k];   // encoded message
-    unsigned char msg_rec[k+1]; // recieved message
+    unsigned char msg_rec[k+1]; // received message
     unsigned char msg_dec[n];   // decoded message
 
     // create packet synchronizer

--- a/examples/compand_example.c
+++ b/examples/compand_example.c
@@ -4,7 +4,7 @@
 // This example demonstrates the interface to the compand function
 // (compression, expansion).  The compander is typically used with the
 // quantizer to increase the dynamic range of the converter, particularly for
-// low-level signals.  The transfer function is computed (emperically) and
+// low-level signals.  The transfer function is computed (empirically) and
 // printed to the screen.
 //
 

--- a/examples/cpfskmodem_example.c
+++ b/examples/cpfskmodem_example.c
@@ -1,7 +1,7 @@
 // 
 // cpfskmodem_example.c
 //
-// This example demostrates the continuous phase frequency-shift keying
+// This example demonstrates the continuous phase frequency-shift keying
 // (CP-FSK) modem in liquid. A message signal is modulated and the
 // resulting signal is recovered using a demodulator object.
 //

--- a/examples/cpfskmodem_psd_example.c
+++ b/examples/cpfskmodem_psd_example.c
@@ -3,7 +3,7 @@
 //
 // This example demonstrates the differences in power spectral
 // density (PSD) for different continuous-phase frequency-shift
-// keying (CP-FSK) modems in liquid. Idential bit streams are fed
+// keying (CP-FSK) modems in liquid. Identical bit streams are fed
 // into modulators with different pulse-shaping filters and the
 // resulting PSDs are computed and logged to a file.
 //

--- a/examples/eqlms_cccf_blind_example.c
+++ b/examples/eqlms_cccf_blind_example.c
@@ -152,14 +152,14 @@ int main(int argc, char*argv[])
     }
 
     // push through equalizer
-    // create equalizer, intialized with square-root Nyquist filter
+    // create equalizer, initialized with square-root Nyquist filter
     eqlms_cccf eq = eqlms_cccf_create_rnyquist(LIQUID_FIRFILT_RRC, k, p, beta, 0.0f);
     eqlms_cccf_set_bw(eq, mu);
 
     // get initialized weights
     eqlms_cccf_copy_coefficients(eq, hp);
 
-    // filtered error vector magnitude (emperical RMS error)
+    // filtered error vector magnitude (empirical RMS error)
     float evm_hat = 0.03f;
 
     // nco/pll for phase recovery
@@ -169,7 +169,7 @@ int main(int argc, char*argv[])
     float complex d_hat = 0.0f;
     unsigned int num_symbols_rx = 0;
     for (i=0; i<num_samples; i++) {
-        // print filtered evm (emperical rms error)
+        // print filtered evm (empirical rms error)
         if ( ((i+1)%50)==0 )
             printf("%4u : rms error = %12.8f dB\n", i+1, 10*log10(evm_hat));
 

--- a/examples/eqlms_cccf_decisiondirected_example.c
+++ b/examples/eqlms_cccf_decisiondirected_example.c
@@ -150,19 +150,19 @@ int main(int argc, char*argv[])
     }
 
     // push through equalizer
-    // create equalizer, intialized with square-root Nyquist filter
+    // create equalizer, initialized with square-root Nyquist filter
     eqlms_cccf eq = eqlms_cccf_create_rnyquist(LIQUID_FIRFILT_RRC, k, p, beta, 0.0f);
     eqlms_cccf_set_bw(eq, mu);
 
     // get initialized weights
     eqlms_cccf_copy_coefficients(eq, hp);
 
-    // filtered error vector magnitude (emperical RMS error)
+    // filtered error vector magnitude (empirical RMS error)
     float evm_hat = 0.03f;
 
     float complex d_hat = 0.0f;
     for (i=0; i<num_samples; i++) {
-        // print filtered evm (emperical rms error)
+        // print filtered evm (empirical rms error)
         if ( ((i+1)%50)==0 )
             printf("%4u : rms error = %12.8f dB\n", i+1, 10*log10(evm_hat));
 

--- a/examples/firdecim_crcf_example.c
+++ b/examples/firdecim_crcf_example.c
@@ -79,7 +79,7 @@ int main(int argc, char*argv[]) {
         x[i] *= (i < w_len) ? liquid_hamming(i,w_len) : 0;
     }
 
-    // create deimator object adn set scale
+    // create decimator object and set scale
     firdecim_crcf decim = firdecim_crcf_create_kaiser(M, m, As);
     firdecim_crcf_set_scale(decim, 1.0f/(float)M);
 

--- a/examples/fskmodem_example.c
+++ b/examples/fskmodem_example.c
@@ -1,7 +1,7 @@
 // 
 // fskmodem_example.c
 //
-// This example demostrates the M-ary frequency-shift keying
+// This example demonstrates the M-ary frequency-shift keying
 // (MFSK) modem in liquid. A message signal is modulated and the
 // resulting signal is recovered using a demodulator object.
 //
@@ -73,7 +73,7 @@ int main(int argc, char*argv[])
         fprintf(stderr,"errors: %s, modulation size (M=%u) exceeds maximum (1024)\n", __FILE__, M);
         exit(1);
     } else if (bandwidth <= 0.0f || bandwidth >= 0.5f) {
-        fprintf(stderr,"errors: %s, bandwidht must be in (0,0.5)\n", __FILE__);
+        fprintf(stderr,"errors: %s, bandwidth must be in (0,0.5)\n", __FILE__);
         exit(1);
     }
 

--- a/examples/fskmodem_waterfall_example.c
+++ b/examples/fskmodem_waterfall_example.c
@@ -1,7 +1,7 @@
 // 
 // fskmodem_waterfall_example.c
 //
-// This example demostrates the M-ary frequency-shift keying
+// This example demonstrates the M-ary frequency-shift keying
 // (MFSK) modem in liquid by showing the resulting spectral
 // waterfall.
 //
@@ -66,7 +66,7 @@ int main(int argc, char*argv[])
         fprintf(stderr,"errors: %s, modulation size (M=%u) exceeds maximum (1024)\n", __FILE__, M);
         exit(1);
     } else if (bandwidth <= 0.0f || bandwidth >= 0.5f) {
-        fprintf(stderr,"errors: %s, bandwidht must be in (0,0.5)\n", __FILE__);
+        fprintf(stderr,"errors: %s, bandwidth must be in (0,0.5)\n", __FILE__);
         exit(1);
     }
 

--- a/examples/iirdes_analog_example.c
+++ b/examples/iirdes_analog_example.c
@@ -1,7 +1,7 @@
 //
 // iirdes_analog_example.c
 //
-// Tests infinite impulse reponse (IIR) analog filter design.
+// Tests infinite impulse response (IIR) analog filter design.
 // While this example seems purely academic as IIR filters
 // used in liquid are all digital, it is important to realize
 // that they are all derived from their analog counterparts.
@@ -100,7 +100,7 @@ int main(int argc, char*argv[]) {
         exit(1);
     }
 
-    // number of analaog poles/zeros
+    // number of analog poles/zeros
     unsigned int npa = order;
     unsigned int nza = 0;
 

--- a/examples/iirdes_example.c
+++ b/examples/iirdes_example.c
@@ -1,7 +1,7 @@
 // 
 // iirdes_example.c
 //
-// Tests infinite impulse reponse (IIR) digital filter design.
+// Tests infinite impulse response (IIR) digital filter design.
 // SEE ALSO: iirdes_analog_example.c
 //           iir_filter_crcf_example.c
 //

--- a/examples/modem_example.c
+++ b/examples/modem_example.c
@@ -1,4 +1,4 @@
-// This example demonstates the digital modulator/demodulator
+// This example demonstrates the digital modulator/demodulator
 // (modem) object.  Data symbols are modulated into complex
 // samples which are then demodulated without noise or phase
 // offsets.  The user may select the modulation scheme via

--- a/examples/modular_arithmetic_example.c
+++ b/examples/modular_arithmetic_example.c
@@ -1,7 +1,7 @@
 //
 // modular_arithmetic_example.c
 //
-// This example demonstates some modular arithmetic functions.
+// This example demonstrates some modular arithmetic functions.
 //
 
 #include <stdio.h>

--- a/examples/packetizer_example.c
+++ b/examples/packetizer_example.c
@@ -90,7 +90,7 @@ int main(int argc, char*argv[]) {
     // initialize arrays
     unsigned char msg_org[n];   // original message
     unsigned char msg_enc[k];   // encoded message
-    unsigned char msg_rec[k];   // recieved message
+    unsigned char msg_rec[k];   // received message
     unsigned char msg_dec[n];   // decoded message
     int crc_pass;
 

--- a/examples/packetizer_soft_example.c
+++ b/examples/packetizer_soft_example.c
@@ -89,7 +89,7 @@ int main(int argc, char*argv[]) {
     // initialize arrays
     unsigned char msg_org[n];   // original message
     unsigned char msg_enc[k];   // encoded message
-    unsigned char msg_rec[8*k]; // recieved message (soft bits)
+    unsigned char msg_rec[8*k]; // received message (soft bits)
     unsigned char msg_dec[n];   // decoded message
     int crc_pass;
 

--- a/examples/qpilotsync_example.c
+++ b/examples/qpilotsync_example.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
         frame_rx[i] *= gain;
     }
 
-    // recieve frame
+    // receive frame
     qpilotsync_execute(ps, frame_rx, payload_rx);
 
     // demodulate

--- a/examples/resamp2_cccf_example.c
+++ b/examples/resamp2_cccf_example.c
@@ -40,7 +40,7 @@ int main() {
         iirfilt_crcf_execute(lowpass, 4*randnf(), &v);
         float complex x_pos = v * cexpf(_Complex_I*2*M_PI*0.073f*i);
 
-        // compsite
+        // composite
         x[i] = (x_neg + x_pos) * liquid_hamming(i,num_samples);
     }
     iirfilt_crcf_destroy(lowpass);

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -284,7 +284,7 @@ float AGC(_get_gain)(AGC() _q);                                             \
 int AGC(_set_gain)(AGC() _q,                                                \
                    float _gain);                                            \
                                                                             \
-/* Get the ouput scaling applied to each sample (linear).               */  \
+/* Get the output scaling applied to each sample (linear).               */  \
 float AGC(_get_scale)(AGC() _q);                                            \
                                                                             \
 /* Set the agc object's output scaling (linear). Note that this does    */  \
@@ -1769,7 +1769,7 @@ int SPGRAM(_get_psd)(SPGRAM() _q,                                           \
                      T *      _psd);                                        \
                                                                             \
 /* Export stand-alone gnuplot file for plotting output spectrum,        */  \
-/* returning 0 on sucess, anything other than 0 for failure             */  \
+/* returning 0 on success, anything other than 0 for failure             */  \
 /*  _q        : spgram object                                           */  \
 /*  _filename : input buffer, [size: _n x 1]                            */  \
 int SPGRAM(_export_gnuplot)(SPGRAM()     _q,                                \
@@ -3336,7 +3336,7 @@ IIRFILT() IIRFILT(_create)(TC *         _b,                                 \
                            TC *         _a,                                 \
                            unsigned int _na);                               \
                                                                             \
-/* Create IIR filter using 2nd-order secitons from external             */  \
+/* Create IIR filter using 2nd-order sections from external             */  \
 /* coefficients.                                                        */  \
 /*  _b      : feed-forward coefficients, [size: _nsos x 3]              */  \
 /*  _a      : feed-back coefficients,    [size: _nsos x 3]              */  \
@@ -3402,7 +3402,7 @@ int IIRFILT(_print)(IIRFILT() _q);                                          \
 /* Reset iirfilt object internals                                       */  \
 int IIRFILT(_reset)(IIRFILT() _q);                                          \
                                                                             \
-/* Compute filter output given a signle input sample                    */  \
+/* Compute filter output given a single input sample                    */  \
 /*  _q      : iirfilt object                                            */  \
 /*  _x      : input sample                                              */  \
 /*  _y      : output sample pointer                                     */  \
@@ -3462,7 +3462,7 @@ LIQUID_IIRFILT_DEFINE_API(LIQUID_IIRFILT_MANGLE_CCCF,
                           liquid_float_complex)
 
 //
-// iirfiltsos : infinite impulse respone filter (second-order sections)
+// iirfiltsos : infinite impulse response filter (second-order sections)
 //
 #define LIQUID_IIRFILTSOS_MANGLE_RRRF(name)  LIQUID_CONCAT(iirfiltsos_rrrf,name)
 #define LIQUID_IIRFILTSOS_MANGLE_CRCF(name)  LIQUID_CONCAT(iirfiltsos_crcf,name)
@@ -3470,13 +3470,13 @@ LIQUID_IIRFILT_DEFINE_API(LIQUID_IIRFILT_MANGLE_CCCF,
 
 #define LIQUID_IIRFILTSOS_DEFINE_API(IIRFILTSOS,TO,TC,TI)                   \
                                                                             \
-/* Infinite impulse respone filter primitive using second-order         */  \
+/* Infinite impulse response filter primitive using second-order        */  \
 /* sections                                                             */  \
 typedef struct IIRFILTSOS(_s) * IIRFILTSOS();                               \
                                                                             \
-/* create 2nd-order infinite impulse reponse filter                     */  \
-/*  _b      : feed-forward coefficients, [size: 3 x 1]                  */  \
-/*  _a      : feed-back coefficients, [size: 3 x 1]                     */  \
+/* create 2nd-order infinite impulse response filter                     */  \
+/*  _b      : feed-forward coefficients [size: _3 x 1]                  */  \
+/*  _a      : feed-back coefficients    [size: _3 x 1]                  */  \
 IIRFILTSOS() IIRFILTSOS(_create)(TC * _b,                                   \
                                  TC * _a);                                  \
                                                                             \
@@ -3988,7 +3988,7 @@ FIRDECIM() FIRDECIM(_copy)(FIRDECIM() _q);                                  \
 /* Destroy decimator object, freeing all internal memory                */  \
 int FIRDECIM(_destroy)(FIRDECIM() _q);                                      \
                                                                             \
-/* Print decimator object propreties to stdout                          */  \
+/* Print decimator object properties to stdout                          */  \
 int FIRDECIM(_print)(FIRDECIM() _q);                                        \
                                                                             \
 /* Reset decimator object internal state                                */  \
@@ -4299,7 +4299,7 @@ LIQUID_RESAMP2_DEFINE_API(LIQUID_RESAMP2_MANGLE_CCCF,
 /* Rational rate resampler, implemented as a polyphase filterbank       */  \
 typedef struct RRESAMP(_s) * RRESAMP();                                     \
                                                                             \
-/* Create rational-rate resampler object from external coeffcients to   */  \
+/* Create rational-rate resampler object from external coefficients to   */  \
 /* resample at an exact rate \(P/Q\) = interp/decim.                    */  \
 /* Note that to preserve the input filter coefficients, the greatest    */  \
 /* common divisor (gcd) is not removed internally from interp and decim */  \
@@ -4419,7 +4419,7 @@ void RRESAMP(_write)(RRESAMP() _q,                                          \
 /* respectively) passed when the object was created, even if they       */  \
 /* share a common divisor.                                              */  \
 /* Internally the rational resampler reduces \(P\) and \(Q\)            */  \
-/* by their greatest commmon denominator to reduce processing;          */  \
+/* by their greatest common denominator to reduce processing;          */  \
 /* however sometimes it is convenient to create the object based on     */  \
 /* expected output/input block sizes. This expectation is preserved.    */  \
 /* So if an object is created with an interpolation rate \(P=80\)       */  \
@@ -4559,7 +4559,7 @@ unsigned int RESAMP(_get_num_output)(RESAMP()     _q,                       \
                                                                             \
 /* Execute arbitrary resampler on a single input sample and store the   */  \
 /* resulting samples in the output array. The number of output samples  */  \
-/* is depenent upon the resampling rate but will be at most             */  \
+/* is dependent upon the resampling rate but will be at most             */  \
 /* \( \lceil{ r \rceil} \) samples.                                     */  \
 /*  _q              : resamp object                                     */  \
 /*  _x              : single input sample                               */  \
@@ -4572,7 +4572,7 @@ int RESAMP(_execute)(RESAMP()       _q,                                     \
                                                                             \
 /* Execute arbitrary resampler on a block of input samples and store    */  \
 /* the resulting samples in the output array. The number of output      */  \
-/* samples is depenent upon the resampling rate and the number of input */  \
+/* samples is dependent upon the resampling rate and the number of input */  \
 /* samples but will be at most \( \lceil{ r n_x \rceil} \) samples.     */  \
 /*  _q              : resamp object                                     */  \
 /*  _x              : input buffer, [size: _nx x 1]                     */  \
@@ -7876,7 +7876,7 @@ int MODEM(_modulate)(MODEM()      _q,                                       \
 /* This is performed efficiently by taking advantage of symmetry on     */  \
 /* most modulation types.                                               */  \
 /* For example, square and rectangular quadrature amplitude modulation  */  \
-/* with gray coding can use a bisection search indepdently on its       */  \
+/* with gray coding can use a bisection search independently on its       */  \
 /* in-phase and quadrature channels.                                    */  \
 /* Arbitrary modulation schemes are relatively slow, however, for large */  \
 /* modulation types as the demodulator must compute the distance        */  \
@@ -8336,7 +8336,7 @@ FIRPFBCH() FIRPFBCH(_create)(int          _type,                            \
 /*  _type   : type (LIQUID_ANALYZER | LIQUID_SYNTHESIZER)               */  \
 /*  _M      : number of channels                                        */  \
 /*  _m      : filter delay (symbols)                                    */  \
-/*  _As     : stop-band attentuation [dB]                               */  \
+/*  _As     : stop-band attenuation [dB]                               */  \
 FIRPFBCH() FIRPFBCH(_create_kaiser)(int          _type,                     \
                                     unsigned int _M,                        \
                                     unsigned int _m,                        \
@@ -9393,7 +9393,7 @@ unsigned int bsequence_index(bsequence _bs, unsigned int _i);
 
 // Complementary codes
 
-// intialize two sequences to complementary codes.  sequences must
+// initialize two sequences to complementary codes.  sequences must
 // be of length at least 8 and a power of 2 (e.g. 8, 16, 32, 64,...)
 //  _a      :   sequence 'a' (bsequence object)
 //  _b      :   sequence 'b' (bsequence object)
@@ -9563,16 +9563,16 @@ int liquid_rbshift(unsigned char * _src,
                    unsigned int _n,
                    unsigned int _b);
 
-// circularly shift array to the left _b bits
-//  _src        :   source address, [size: _n x 1]
+// circular shift array to the left _b bits
+//  _src        :   source address [size: _n x 1]
 //  _n          :   input data array size
 //  _b          :   number of bits to shift
 int liquid_lbcircshift(unsigned char * _src,
                        unsigned int _n,
                        unsigned int _b);
 
-// circularly shift array to the right _b bits
-//  _src        :   source address, [size: _n x 1]
+// circular shift array to the right _b bits
+//  _src        :   source address [size: _n x 1]
 //  _n          :   input data array size
 //  _b          :   number of bits to shift
 int liquid_rbcircshift(unsigned char * _src,

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -284,7 +284,7 @@ float AGC(_get_gain)(AGC() _q);                                             \
 int AGC(_set_gain)(AGC() _q,                                                \
                    float _gain);                                            \
                                                                             \
-/* Get the output scaling applied to each sample (linear).               */  \
+/* Get the output scaling applied to each sample (linear).              */  \
 float AGC(_get_scale)(AGC() _q);                                            \
                                                                             \
 /* Set the agc object's output scaling (linear). Note that this does    */  \
@@ -1769,7 +1769,7 @@ int SPGRAM(_get_psd)(SPGRAM() _q,                                           \
                      T *      _psd);                                        \
                                                                             \
 /* Export stand-alone gnuplot file for plotting output spectrum,        */  \
-/* returning 0 on success, anything other than 0 for failure             */  \
+/* returning 0 on success, anything other than 0 for failure            */  \
 /*  _q        : spgram object                                           */  \
 /*  _filename : input buffer, [size: _n x 1]                            */  \
 int SPGRAM(_export_gnuplot)(SPGRAM()     _q,                                \
@@ -3474,7 +3474,7 @@ LIQUID_IIRFILT_DEFINE_API(LIQUID_IIRFILT_MANGLE_CCCF,
 /* sections                                                             */  \
 typedef struct IIRFILTSOS(_s) * IIRFILTSOS();                               \
                                                                             \
-/* create 2nd-order infinite impulse response filter                     */  \
+/* create 2nd-order infinite impulse response filter                    */  \
 /*  _b      : feed-forward coefficients [size: _3 x 1]                  */  \
 /*  _a      : feed-back coefficients    [size: _3 x 1]                  */  \
 IIRFILTSOS() IIRFILTSOS(_create)(TC * _b,                                   \
@@ -4299,7 +4299,7 @@ LIQUID_RESAMP2_DEFINE_API(LIQUID_RESAMP2_MANGLE_CCCF,
 /* Rational rate resampler, implemented as a polyphase filterbank       */  \
 typedef struct RRESAMP(_s) * RRESAMP();                                     \
                                                                             \
-/* Create rational-rate resampler object from external coefficients to   */  \
+/* Create rational-rate resampler object from external coefficients to  */  \
 /* resample at an exact rate \(P/Q\) = interp/decim.                    */  \
 /* Note that to preserve the input filter coefficients, the greatest    */  \
 /* common divisor (gcd) is not removed internally from interp and decim */  \
@@ -4419,7 +4419,7 @@ void RRESAMP(_write)(RRESAMP() _q,                                          \
 /* respectively) passed when the object was created, even if they       */  \
 /* share a common divisor.                                              */  \
 /* Internally the rational resampler reduces \(P\) and \(Q\)            */  \
-/* by their greatest common denominator to reduce processing;          */  \
+/* by their greatest common denominator to reduce processing;           */  \
 /* however sometimes it is convenient to create the object based on     */  \
 /* expected output/input block sizes. This expectation is preserved.    */  \
 /* So if an object is created with an interpolation rate \(P=80\)       */  \
@@ -4559,7 +4559,7 @@ unsigned int RESAMP(_get_num_output)(RESAMP()     _q,                       \
                                                                             \
 /* Execute arbitrary resampler on a single input sample and store the   */  \
 /* resulting samples in the output array. The number of output samples  */  \
-/* is dependent upon the resampling rate but will be at most             */  \
+/* is dependent upon the resampling rate but will be at most            */  \
 /* \( \lceil{ r \rceil} \) samples.                                     */  \
 /*  _q              : resamp object                                     */  \
 /*  _x              : single input sample                               */  \
@@ -7876,7 +7876,7 @@ int MODEM(_modulate)(MODEM()      _q,                                       \
 /* This is performed efficiently by taking advantage of symmetry on     */  \
 /* most modulation types.                                               */  \
 /* For example, square and rectangular quadrature amplitude modulation  */  \
-/* with gray coding can use a bisection search independently on its       */  \
+/* with gray coding can use a bisection search independently on its     */  \
 /* in-phase and quadrature channels.                                    */  \
 /* Arbitrary modulation schemes are relatively slow, however, for large */  \
 /* modulation types as the demodulator must compute the distance        */  \

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -1391,7 +1391,7 @@ int MODEM(_demodulate_linear_array)(T              _v,          \
                                     T *            _res);       \
                                                                 \
 /* Demodulate a linear symbol constellation using           */  \
-/* referenced lookup table                                 */  \
+/* referenced lookup table                                  */  \
 /*  _v      :   input value             */                      \
 /*  _m      :   bits per symbol         */                      \
 /*  _ref    :   array of thresholds     */                      \

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -765,14 +765,14 @@ LIQUID_FFT_DEFINE_INTERNAL_API(LIQUID_FFT_MANGLE_FLOAT, float, liquid_float_comp
 // MODULE : filter
 //
 
-// esimate required filter length given transition bandwidth and
+// estimate required filter length given transition bandwidth and
 // stop-band attenuation (algorithm from [Vaidyanathan:1993])
 //  _df     :   transition bandwidth (0 < _df < 0.5)
 //  _as     :   stop-band attenuation [dB] (_as > 0)
 float estimate_req_filter_len_Kaiser(float _df,
                                      float _as);
 
-// esimate required filter length given transition bandwidth and
+// estimate required filter length given transition bandwidth and
 // stop-band attenuation (algorithm from [Herrmann:1973])
 //  _df     :   transition bandwidth (0 < _df < 0.5)
 //  _as     :   stop-band attenuation [dB] (_as > 0)
@@ -783,7 +783,7 @@ float estimate_req_filter_len_Herrmann(float _df,
 // firdes : finite impulse response filter design
 
 // Find approximate bandwidth adjustment factor rho based on
-// filter delay and desired excess bandwdith factor.
+// filter delay and desired excess bandwidth factor.
 //
 //  _m      :   filter delay (symbols)
 //  _beta   :   filter excess bandwidth factor (0,1)
@@ -1391,7 +1391,7 @@ int MODEM(_demodulate_linear_array)(T              _v,          \
                                     T *            _res);       \
                                                                 \
 /* Demodulate a linear symbol constellation using           */  \
-/* refereneced lookup table                                 */  \
+/* referenced lookup table                                 */  \
 /*  _v      :   input value             */                      \
 /*  _m      :   bits per symbol         */                      \
 /*  _ref    :   array of thresholds     */                      \

--- a/makefile.in
+++ b/makefile.in
@@ -1267,7 +1267,7 @@ all: ${ARCHIVE_LIB} ${SHARED_LIB}
 ## TARGET : help      - print list of targets
 ##
 
-# look for all occurences of '## TARGET : ' and print rest of line to screen
+# look for all occurrences of '## TARGET : ' and print rest of line to screen
 help:
 	@echo "Targets for liquid-dsp makefile:"
 	@$(GREP) -E "^## TARGET : " [Mm]akefile | $(SED) 's/## TARGET : /  /'
@@ -1341,7 +1341,7 @@ autotest_include.h : scripts/autoscript $(autotest_sources) $(include_headers)
 
 # autotest objects
 # NOTE: by default, gcc compiles any file with a '.h' extension as a 'pre-compiled
-#       header' so we need to explicity tell it to compile as a c source file with
+#       header' so we need to explicitly tell it to compile as a c source file with
 #       the '-x c' flag
 autotest_obj = $(patsubst %.c,%.o,$(autotest_sources))
 $(autotest_obj) $(autotest_extra_obj) autotest/autotest.o : %.o : %.c $(include_headers) autotest/autotest.h
@@ -1439,7 +1439,7 @@ benchmark_include.h : scripts/autoscript $(benchmark_sources) $(include_headers)
 
 # benchmark objects
 # NOTE: by default, gcc compiles any file with a '.h' extension as a 'pre-compiled
-#       header' so we need to explicity tell it to compile as a c source file with
+#       header' so we need to explicitly tell it to compile as a c source file with
 #       the '-x c' flag
 benchmark_obj = $(patsubst %.c,%.o,$(benchmark_sources))
 $(benchmark_obj) : %.o : %.c $(include_headers)

--- a/sandbox/fec_spc2216_test.c
+++ b/sandbox/fec_spc2216_test.c
@@ -526,7 +526,7 @@ void spc2216_pack(unsigned char * _m,
                   unsigned char * _pc,
                   unsigned char * _v)
 {
-    // copy input message to begining of encoded vector
+    // copy input message to beginning of encoded vector
     memmove(_v, _m, 32*sizeof(unsigned char));
 
     // pack row parities
@@ -554,7 +554,7 @@ void spc2216_unpack(unsigned char * _v,
                     unsigned char * _pc,
                     unsigned char * _m)
 {
-    // copy input message to begining of encoded vector
+    // copy input message to beginning of encoded vector
     memmove(_m, _v, 32*sizeof(unsigned char));
 
     // unpack row parities

--- a/sandbox/fft_dual_radix_test.c
+++ b/sandbox/fft_dual_radix_test.c
@@ -134,7 +134,7 @@ int main(int argc, char*argv[]) {
 #endif
     }
 
-    // multipy by twiddle factors
+    // multiply by twiddle factors
     // NOTE: this can be combined with previous step
     printf("multiplying twiddles...\n");
     for (i=0; i<q; i++) {

--- a/sandbox/firdes_fexp_test.c
+++ b/sandbox/firdes_fexp_test.c
@@ -89,7 +89,7 @@ int main(int argc, char*argv[]) {
 
     // arrays
     float ht[h_len];         // transmit filter coefficients
-    float hr[h_len];         // recieve filter coefficients
+    float hr[h_len];         // receive filter coefficients
 
     //
     // start of filter design procedure

--- a/sandbox/firdes_gmskrx_test.c
+++ b/sandbox/firdes_gmskrx_test.c
@@ -65,7 +65,7 @@ int main(int argc, char*argv[]) {
 
     // arrays
     float ht[h_len];         // transmit filter coefficients
-    float hr[h_len];         // recieve filter coefficients
+    float hr[h_len];         // receive filter coefficients
 
     // design transmit filter
     liquid_firdes_gmsktx(k,m,BT,0.0f,ht);
@@ -127,7 +127,7 @@ int main(int argc, char*argv[]) {
         printf("G_prime(%3u) = %12.8f + j*%12.8f;\n", i+1, crealf(G_prime[i]), cimagf(G_prime[i]));
 #endif
 
-    // find minimum of reponses
+    // find minimum of responses
     float H_tx_min = 0.0f;
     float H_prime_min = 0.0f;
     float G_prime_min = 0.0f;
@@ -139,7 +139,7 @@ int main(int argc, char*argv[]) {
 
     // compute 'prototype' response, removing minima, and add correction factor
     for (i=0; i<h_len; i++) {
-        // compute response necessary to yeild prototype response (not exact, but close)
+        // compute response necessary to yield prototype response (not exact, but close)
         H_hat[i] = crealf(H_prime[i] - H_prime_min + delta) / crealf(H_tx[i] - H_tx_min + delta);
 
         // include additional term to add stop-band suppression

--- a/sandbox/firpfbch_analysis_test.c
+++ b/sandbox/firpfbch_analysis_test.c
@@ -49,7 +49,7 @@ int main() {
             x[j] = randnf() * cexpf(_Complex_I*randf()*2*M_PI);
 
         // 
-        // analyzer 0 : run individual sample exection
+        // analyzer 0 : run individual sample execution
         //
 
         // push samples into channelizer 1

--- a/sandbox/fskmodem_test.c
+++ b/sandbox/fskmodem_test.c
@@ -1,7 +1,7 @@
 // 
 // fskmodem_test.c
 //
-// This example demostrates the M-ary frequency-shift keying
+// This example demonstrates the M-ary frequency-shift keying
 // (MFSK) modem in liquid. A message signal is modulated and the
 // resulting signal is recovered using a demodulator object.
 //
@@ -83,7 +83,7 @@ int main(int argc, char*argv[])
         fprintf(stderr,"errors: %s, modulation size (M=%u) exceeds maximum (1024)\n", __FILE__, M);
         exit(1);
     } else if (bandwidth <= 0.0f || bandwidth >= 0.5f) {
-        fprintf(stderr,"errors: %s, bandwidht must be in (0,0.5)\n", __FILE__);
+        fprintf(stderr,"errors: %s, bandwidth must be in (0,0.5)\n", __FILE__);
         exit(1);
     }
 

--- a/sandbox/gmskmodem_coherent_test.c
+++ b/sandbox/gmskmodem_coherent_test.c
@@ -1,7 +1,7 @@
 // 
 // gmskmodem_coherent_test.c
 //
-// This example demostrates the continuous phase frequency-shift keying
+// This example demonstrates the continuous phase frequency-shift keying
 // (CP-FSK) modem in liquid. A message signal is modulated and the
 // resulting signal is recovered using a demodulator object.
 //

--- a/sandbox/iirdes_test.c
+++ b/sandbox/iirdes_test.c
@@ -1,6 +1,6 @@
 // iirdes_example.c
 //
-// Tests infinite impulse reponse (IIR) filter design.
+// Tests infinite impulse response (IIR) filter design.
 //
 
 #include <stdlib.h>
@@ -129,7 +129,7 @@ int main(int argc, char*argv[]) {
     }
 
 
-    // number of analaog poles/zeros
+    // number of analog poles/zeros
     unsigned int npa = n;
     unsigned int nza;
 
@@ -259,7 +259,7 @@ int main(int argc, char*argv[]) {
         float complex zd1[2*n];
         float complex pd1[2*n];
 
-        // run zeros, poles trasform
+        // run zeros, poles transform
         iirdes_dzpk_lp2bp(zd, pd,   // low-pass prototype zeros, poles
                           n,        // filter order
                           f0,       // center frequency
@@ -269,7 +269,7 @@ int main(int argc, char*argv[]) {
         memmove(zd, zd1, 2*n*sizeof(float complex));
         memmove(pd, pd1, 2*n*sizeof(float complex));
 
-        // update paramteres : n -> 2*n
+        // update parameters : n -> 2*n
         r = 0;
         L = n;
         n = 2*n;

--- a/sandbox/iirfilt_intdiff_test.c
+++ b/sandbox/iirfilt_intdiff_test.c
@@ -1,6 +1,6 @@
 // iirfilt_intdiff_test
 //
-// Tests infinite impulse reponse (IIR) integrator and differentiator
+// Tests infinite impulse response (IIR) integrator and differentiator
 // filters. The filters are each order 8 and have a near-integer group
 // delay of 7 samples. The magnitude response of the ideal is on the
 // order of -140 dB error.

--- a/sandbox/modem_demodulate_soft_gentab.c
+++ b/sandbox/modem_demodulate_soft_gentab.c
@@ -26,7 +26,7 @@ void print_bitstring(unsigned int _x,
 //  _p          :   size of table
 //  _r          :   received sample
 //  _s          :   hard demodulator output
-//  _soft_bits  :   soft bit ouput (approximate log-likelihood ratio)
+//  _soft_bits  :   soft bit output (approximate log-likelihood ratio)
 void modemcf_demodulate_soft_tab(modemcf _q,
                                float complex * _c,
                                unsigned int * _cp,
@@ -316,7 +316,7 @@ int main(int argc, char*argv[])
 //  _p          :   size of table
 //  _r          :   received sample
 //  _s          :   hard demodulator output
-//  _soft_bits  :   soft bit ouput (approximate log-likelihood ratio)
+//  _soft_bits  :   soft bit output (approximate log-likelihood ratio)
 void modemcf_demodulate_soft_tab(modemcf _q,
                                float complex * _c,
                                unsigned int * _cp,

--- a/src/agc/src/agc.proto.c
+++ b/src/agc/src/agc.proto.c
@@ -169,7 +169,7 @@ int AGC(_execute)(AGC() _q,
     // clamp to 120 dB gain
     _q->g = (_q->g > 1e6f) ? 1e6f : _q->g;
 
-    // udpate squelch mode appropriately
+    // update squelch mode appropriately
     AGC(_squelch_update_mode)(_q);
 
     // apply output scale

--- a/src/agc/tests/agc_crcf_autotest.c
+++ b/src/agc/tests/agc_crcf_autotest.c
@@ -26,7 +26,7 @@
 // Test DC gain control
 void autotest_agc_crcf_dc_gain_control()
 {
-    // set paramaters
+    // set parameters
     float gamma = 0.1f;     // nominal signal level
     float bt    = 0.1f;     // bandwidth-time product
     float tol   = 0.001f;   // error tolerance
@@ -57,7 +57,7 @@ void autotest_agc_crcf_dc_gain_control()
 // test gain control on DC input with separate scale
 void autotest_agc_crcf_scale()
 {
-    // set paramaters
+    // set parameters
     float scale = 4.0f;     // output scale (independent of AGC loop)
     float tol   = 0.001f;   // error tolerance
 
@@ -84,7 +84,7 @@ void autotest_agc_crcf_scale()
 // Test AC gain control
 void autotest_agc_crcf_ac_gain_control()
 {
-    // set paramaters
+    // set parameters
     float gamma = 0.1f;             // nominal signal level
     float bt    = 0.1f;             // bandwidth-time product
     float tol   = 0.001f;           // error tolerance
@@ -115,7 +115,7 @@ void autotest_agc_crcf_ac_gain_control()
 // Test RSSI on sinusoidal input
 void autotest_agc_crcf_rssi_sinusoid()
 {
-    // set paramaters
+    // set parameters
     float gamma = 0.3f;         // nominal signal level
     float bt    = 0.05f;        // agc bandwidth
     float tol   = 0.001f;       // error tolerance
@@ -153,7 +153,7 @@ void autotest_agc_crcf_rssi_sinusoid()
 // Test RSSI on noise input
 void autotest_agc_crcf_rssi_noise()
 {
-    // set paramaters
+    // set parameters
     float gamma = -30.0f;   // nominal signal level [dB]
     float bt    =  2e-3f;   // agc bandwidth
     float tol   =  1.0f;    // error tolerance [dB]
@@ -248,7 +248,7 @@ void autotest_agc_crcf_squelch()
 // test lock state control
 void autotest_agc_crcf_lock()
 {
-    // set paramaters
+    // set parameters
     float gamma = 0.1f;     // nominal signal level
     float tol   = 0.01f;    // error tolerance
 

--- a/src/buffer/src/cbuffer.proto.c
+++ b/src/buffer/src/cbuffer.proto.c
@@ -104,7 +104,7 @@ CBUFFER() CBUFFER(_copy)(CBUFFER() q_orig)
     CBUFFER() q_copy = (CBUFFER()) malloc(sizeof(struct CBUFFER(_s)));
     memmove(q_copy, q_orig, sizeof(struct CBUFFER(_s)));
 
-    // allocte and copy full memory array
+    // allocate and copy full memory array
     q_copy->v = (T*) malloc((q_copy->num_allocated)*sizeof(T));
     memmove(q_copy->v, q_orig->v, q_copy->num_allocated*sizeof(T));
 

--- a/src/buffer/src/wdelay.proto.c
+++ b/src/buffer/src/wdelay.proto.c
@@ -45,7 +45,7 @@ WDELAY() WDELAY(_create)(unsigned int _delay)
     // set internal values
     q->delay = _delay;
 
-    // allocte memory
+    // allocate memory
     q->v = (T*) malloc((q->delay+1)*sizeof(T));
     q->read_index = 0;
 
@@ -94,7 +94,7 @@ WDELAY() WDELAY(_copy)(WDELAY() q_orig)
     WDELAY() q_copy = (WDELAY()) malloc(sizeof(struct WDELAY(_s)));
     memmove(q_copy, q_orig, sizeof(struct WDELAY(_s)));
 
-    // allocte and copy full memory array
+    // allocate and copy full memory array
     q_copy->v = (T*) malloc((q_copy->delay+1)*sizeof(T));
     memmove(q_copy->v, q_orig->v, (q_copy->delay+1)*sizeof(T));
 

--- a/src/buffer/src/window.proto.c
+++ b/src/buffer/src/window.proto.c
@@ -60,7 +60,7 @@ WINDOW() WINDOW(_create)(unsigned int _n)
     // number of elements to allocate to memory
     q->num_allocated = q->n + q->len - 1;
 
-    // allocte memory
+    // allocate memory
     q->v = (T*) malloc((q->num_allocated)*sizeof(T));
     q->read_index = 0;
 
@@ -118,7 +118,7 @@ WINDOW() WINDOW(_copy)(WINDOW() q_orig)
     WINDOW() q_copy = (WINDOW()) malloc(sizeof(struct WINDOW(_s)));
     memmove(q_copy, q_orig, sizeof(struct WINDOW(_s)));
 
-    // allocte and copy full memory array
+    // allocate and copy full memory array
     q_copy->v = (T*) liquid_malloc_copy(q_copy->v, q_copy->num_allocated, sizeof(T));
 
     // return new object

--- a/src/dotprod/tests/dotprod_cccf_autotest.c
+++ b/src/dotprod/tests/dotprod_cccf_autotest.c
@@ -24,7 +24,7 @@
 #include "liquid.internal.h"
 
 // 
-// AUTOTEST: compare structured result to oridinal computation
+// AUTOTEST: compare structured result to ordinal computation
 //
 
 // 

--- a/src/dotprod/tests/dotprod_crcf_autotest.c
+++ b/src/dotprod/tests/dotprod_crcf_autotest.c
@@ -129,7 +129,7 @@ void autotest_dotprod_crcf_rand02()
 }
 
 // 
-// AUTOTEST: compare structured result to oridinal computation
+// AUTOTEST: compare structured result to ordinal computation
 //
 
 // helper function (compare structured object to ordinal computation)

--- a/src/dotprod/tests/dotprod_rrrf_autotest.c
+++ b/src/dotprod/tests/dotprod_rrrf_autotest.c
@@ -178,7 +178,7 @@ void autotest_dotprod_rrrf_struct_align()
     // create dotprod object
     dotprod_rrrf dp = dotprod_rrrf_create(h,16);
 
-    // test data mis-alignment conditions
+    // test data misalignment conditions
     float x_buffer[20];
     float * x_hat;
     unsigned int i;
@@ -343,7 +343,7 @@ void autotest_dotprod_rrrf_struct_lengths()
 }
 
 // 
-// AUTOTEST: compare structured result to oridinal computation
+// AUTOTEST: compare structured result to ordinal computation
 //
 
 // helper function (compare structured object to ordinal computation)

--- a/src/equalization/tests/eqlms_cccf_autotest.c
+++ b/src/equalization/tests/eqlms_cccf_autotest.c
@@ -130,7 +130,7 @@ void autotest_eqlms_00() { testbench_eqlms(2,7, 0.3,   0,7,0.3,800,     0,LIQUID
 void autotest_eqlms_01() { testbench_eqlms(2,7, 0.3,   0,7,0.3,800,     1,LIQUID_MODEM_QPSK); }
 void autotest_eqlms_02() { testbench_eqlms(2,7, 0.3,   0,7,0.3,800,     2,LIQUID_MODEM_QPSK); }
 
-// test different initializaiton methods:  k,m,beta,init,p, mu,  n,update,mod scheme
+// test different initialization methods:  k,m,beta,init,p, mu,  n,update,mod scheme
 void autotest_eqlms_03() { testbench_eqlms(2,7, 0.3,   0,7,0.3,800,     0,LIQUID_MODEM_QAM16); }
 void autotest_eqlms_04() { testbench_eqlms(2,7, 0.3,   1,7,0.3,800,     0,LIQUID_MODEM_QAM16); }
 void autotest_eqlms_05() { testbench_eqlms(2,7, 0.3,   2,7,0.3,800,     0,LIQUID_MODEM_QAM16); }

--- a/src/fec/bench/crc_benchmark.c
+++ b/src/fec/bench/crc_benchmark.c
@@ -51,7 +51,7 @@ void crc_bench(struct rusage *_start,
     unsigned char msg[_n];
     unsigned int key = 0;
 
-    // initialze message
+    // initialize message
     for (i=0; i<_n; i++)
         msg[i] = rand() & 0xff;
 

--- a/src/fec/bench/fec_decode_benchmark.c
+++ b/src/fec/bench/fec_decode_benchmark.c
@@ -118,7 +118,7 @@ void fec_decode_bench(
     unsigned char msg_enc[n_enc];   // decoded message
     unsigned char msg_dec[_n];      // decoded message
 
-    // initialze message
+    // initialize message
     unsigned long int i;
     for (i=0; i<_n; i++)
         msg[i] = rand() & 0xff;

--- a/src/fec/bench/fec_encode_benchmark.c
+++ b/src/fec/bench/fec_encode_benchmark.c
@@ -114,7 +114,7 @@ void fec_encode_bench(
     unsigned char msg[_n];          // original message
     unsigned char msg_enc[n_enc];   // encoded message
 
-    // initialze message
+    // initialize message
     unsigned long int i;
     for (i=0; i<_n; i++) {
         msg[i] = rand() & 0xff;

--- a/src/fec/bench/fecsoft_decode_benchmark.c
+++ b/src/fec/bench/fecsoft_decode_benchmark.c
@@ -121,7 +121,7 @@ void fecsoft_decode_bench(
     unsigned char msg_soft[8*n_enc];// encoded message (soft bits)
     unsigned char msg_dec[_n];      // decoded message
 
-    // initialze message
+    // initialize message
     unsigned long int i;
     for (i=0; i<_n; i++)
         msg[i] = rand() & 0xff;

--- a/src/fec/bench/sumproduct_benchmark.c
+++ b/src/fec/bench/sumproduct_benchmark.c
@@ -143,7 +143,7 @@ void sumproduct_generate(unsigned int    _m,
         }
     }
 
-    // initialze matrices
+    // initialize matrices
     for (i=0; i<_m; i++) {
         for (j=0; j<_m; j++) {
             // G = [I(m) P]^T

--- a/src/fec/src/fec_conv.c
+++ b/src/fec/src/fec_conv.c
@@ -145,7 +145,7 @@ int fec_conv_decode_hard(fec _q,
     unsigned int num_written;
     liquid_unpack_bytes(_msg_enc,               // encoded message (bytes)
                         _q->num_enc_bytes,      // encoded message length (#bytes)
-                        _q->enc_bits,           // encoded messsage (bits)
+                        _q->enc_bits,           // encoded message (bits)
                         _q->num_enc_bytes*8,    // encoded message length (#bits)
                         &num_written);
 

--- a/src/fec/src/fec_conv_punctured.c
+++ b/src/fec/src/fec_conv_punctured.c
@@ -172,7 +172,7 @@ int fec_conv_punctured_decode_hard(fec             _q,
     unsigned int num_enc_bits = num_dec_bits * _q->R;
     unsigned int i,r;
     unsigned int n=0;   // input byte index
-    unsigned int k=0;   // intput bit index (0<=k<8)
+    unsigned int k=0;   // input bit index (0<=k<8)
     unsigned int p=0;   // puncturing matrix column index
     unsigned char bit;
     unsigned char byte_in = _msg_enc[n];

--- a/src/fec/src/fec_golay2412.c
+++ b/src/fec/src/fec_golay2412.c
@@ -223,7 +223,7 @@ unsigned int fec_golay2412_decode_symbol(unsigned int _sym_enc)
     // step 8: compute estimated transmitted message: v_hat = r + e_hat
     v_hat = _sym_enc ^ e_hat;
 #if DEBUG_FEC_GOLAY2412
-    printf("r (recevied vector):            "); liquid_print_bitstring(_sym_enc,24); printf("\n");
+    printf("r (received vector):            "); liquid_print_bitstring(_sym_enc,24); printf("\n");
     printf("e-hat (estimated error vector): "); liquid_print_bitstring(e_hat,24);    printf("\n");
     printf("v-hat (estimated tx vector):    "); liquid_print_bitstring(v_hat,24);    printf("\n");
 #endif

--- a/src/fec/src/fec_rs.c
+++ b/src/fec/src/fec_rs.c
@@ -92,7 +92,7 @@ int fec_rs_encode(fec             _q,
 {
     // validate input
     if (_dec_msg_len == 0)
-        return liquid_error(LIQUID_EICONFIG,"fec_rs_encode(), input lenght must be > 0");
+        return liquid_error(LIQUID_EICONFIG,"fec_rs_encode(), input length must be > 0");
 
     // re-allocate resources if necessary
     fec_rs_setlength(_q, _dec_msg_len);
@@ -138,7 +138,7 @@ int fec_rs_decode(fec             _q,
 {
     // validate input
     if (_dec_msg_len == 0)
-        return liquid_error(LIQUID_EICONFIG,"fec_rs_encode(), input lenght must be > 0");
+        return liquid_error(LIQUID_EICONFIG,"fec_rs_encode(), input length must be > 0");
 
     // re-allocate resources if necessary
     fec_rs_setlength(_q, _dec_msg_len);
@@ -185,7 +185,7 @@ int fec_rs_decode(fec             _q,
 
 // Set dec_msg_len, re-allocating resources as necessary.  Effectively, it
 // divides the input message into several blocks and allows the decoder to
-// pad each block appropraitely.
+// pad each block appropriately.
 //
 // For example : if we are using the 8-bit code,
 //      nroots  = 32

--- a/src/fec/src/fec_secded2216.c
+++ b/src/fec/src/fec_secded2216.c
@@ -306,7 +306,7 @@ int fec_secded2216_decode(fec             _q,
 
     // if input length isn't divisible by 2, decode last several bytes
     if (r) {
-        // one 22-bit symbol (encoded), with last byte artifically
+        // one 22-bit symbol (encoded), with last byte artificially
         // set to '00000000'
         unsigned char v[3] = {_msg_enc[j+0], _msg_enc[j+1], 0x00};
 

--- a/src/fec/src/fec_secded3932.c
+++ b/src/fec/src/fec_secded3932.c
@@ -340,7 +340,7 @@ int fec_secded3932_decode(fec             _q,
         // decode symbol
         fec_secded3932_decode_symbol(v, m_hat);
 
-        // copy non-zero bytes to output (ignore zeros artifically
+        // copy non-zero bytes to output (ignore zeros artificially
         // inserted at receiver)
         for (n=0; n<r; n++)
             _msg_dec[i+n] = m_hat[n];

--- a/src/fec/src/packetizer.c
+++ b/src/fec/src/packetizer.c
@@ -111,7 +111,7 @@ unsigned int packetizer_compute_dec_msg_len(unsigned int _k,
 
 // create packetizer object
 //
-//  _n      :   number of uncoded intput bytes
+//  _n      :   number of uncoded input bytes
 //  _crc    :   error-detecting scheme
 //  _fec0   :   inner forward error-correction code
 //  _fec1   :   outer forward error-correction code
@@ -167,7 +167,7 @@ packetizer packetizer_create(unsigned int _n,
 // re-create packetizer object
 //
 //  _p      :   initialz packetizer object
-//  _n      :   number of uncoded intput bytes
+//  _n      :   number of uncoded input bytes
 //  _crc    :   error-detecting scheme
 //  _fec0   :   inner forward error-correction code
 //  _fec1   :   outer forward error-correction code

--- a/src/fec/tests/fec_autotest.c
+++ b/src/fec/tests/fec_autotest.c
@@ -61,7 +61,7 @@ void fec_test_codec(fec_scheme _fs, unsigned int _n, void * _opts)
     unsigned char msg_enc[n_enc];   // encoded message
     unsigned char msg_dec[_n];      // decoded message
 
-    // initialze message
+    // initialize message
     unsigned int i;
     for (i=0; i<_n; i++) {
         msg[i] = rand() & 0xff;

--- a/src/fec/tests/fec_copy_autotest.c
+++ b/src/fec/tests/fec_copy_autotest.c
@@ -65,7 +65,7 @@ void fec_test_copy(fec_scheme _fs)
     unsigned char msg_dec_0[n_dec]; // decoded message (orig)
     unsigned char msg_dec_1[n_dec]; // decoded message (copy)
 
-    // initialze random message bits
+    // initialize random message bits
     unsigned int i;
     for (i=0; i<n_dec; i++)
         msg_org[i] = rand() & 0xff;

--- a/src/fec/tests/fec_soft_autotest.c
+++ b/src/fec/tests/fec_soft_autotest.c
@@ -65,7 +65,7 @@ void fec_test_soft_codec(fec_scheme _fs,
     unsigned char msg_soft[8*n_enc];    // encoded message (soft bits)
     unsigned char msg_dec[_n];          // decoded message
 
-    // initialze message
+    // initialize message
     unsigned int i;
     for (i=0; i<_n; i++) {
         msg[i] = rand() & 0xff;

--- a/src/fft/src/fft_utilities.c
+++ b/src/fft/src/fft_utilities.c
@@ -48,7 +48,7 @@ liquid_fft_method liquid_fft_estimate_method(unsigned int _nfft)
         // use radix-2 algorithm
         return LIQUID_FFT_METHOD_RADIX2;
 #else
-        // acutally, prefer Cooley-Tukey algorithm
+        // actually, prefer Cooley-Tukey algorithm
         return LIQUID_FFT_METHOD_MIXED_RADIX;
 #endif
 

--- a/src/fft/src/spwaterfall.proto.c
+++ b/src/fft/src/spwaterfall.proto.c
@@ -421,7 +421,7 @@ int SPWATERFALL(_export_bin)(SPWATERFALL() _q,
     }
     
     // write output spectral estimate
-    // TODO: force converstion from type 'T' to type 'float'
+    // TODO: force conversion from type 'T' to type 'float'
     uint64_t total_samples = SPGRAM(_get_num_samples_total)(_q->periodogram);
     for (i=0; i<_q->index_time; i++) {
         float n = (float)i / (float)(_q->index_time) * (float)total_samples;

--- a/src/filter/src/dds.proto.c
+++ b/src/filter/src/dds.proto.c
@@ -77,7 +77,7 @@ DDS() DDS(_create)(unsigned int _num_stages,
     if (_bw <= 0.0f || _bw >= 1.0f)
         return liquid_error_config("dds_%s_create(), bandwidth %12.4e is out of range (0,1)", EXTENSION_FULL, _bw);
     if (_as < 0.0f)
-        return liquid_error_config("dds_%s_create(), stop-band suppresion %12.4e must be greater than zero", EXTENSION_FULL, _as);
+        return liquid_error_config("dds_%s_create(), stop-band suppression %12.4e must be greater than zero", EXTENSION_FULL, _as);
 
     // create object
     DDS() q = (DDS()) malloc(sizeof(struct DDS(_s)));

--- a/src/filter/src/firdes.c
+++ b/src/filter/src/firdes.c
@@ -69,7 +69,7 @@ const char * liquid_firfilt_type_str[LIQUID_FIRFILT_NUM_TYPES][2] = {
     {"rfarcsech","root flipped arc-hyperbolic secant"},
 };
 
-// esimate required filter length given transition bandwidth and
+// estimate required filter length given transition bandwidth and
 // stop-band attenuation
 //  _df     :   transition bandwidth (0 < _df < 0.5)
 //  _as     :   stopband suppression level [dB] (_as > 0)
@@ -180,7 +180,7 @@ float estimate_req_filter_df(float        _as,
 }
 
 
-// esimate required filter length given transition bandwidth and
+// estimate required filter length given transition bandwidth and
 // stop-band attenuation (algorithm from [Vaidyanathan:1993])
 //  _df     :   transition bandwidth (0 < _df < 0.5)
 //  _as     :   stop-band attenuation [dB] (as > 0)
@@ -200,7 +200,7 @@ float estimate_req_filter_len_Kaiser(float _df,
 }
 
 
-// esimate required filter length given transition bandwidth and
+// estimate required filter length given transition bandwidth and
 // stop-band attenuation (algorithm from [Herrmann:1973])
 //  _df     :   transition bandwidth (0 < _df < 0.5)
 //  _as     :   stop-band attenuation [dB] (as > 0)

--- a/src/filter/src/firdespm.c
+++ b/src/filter/src/firdespm.c
@@ -334,7 +334,7 @@ firdespm firdespm_create_callback(unsigned int          _h_len,
     // validate input
     unsigned int i;
     int bands_valid = 1;
-    // ensure bands are withing [0,0.5]
+    // ensure bands are within [0,0.5]
     for (i=0; i<2*_num_bands; i++)
         bands_valid &= _bands[i] >= 0.0 && _bands[i] <= 0.5;
     // ensure bands are non-decreasing

--- a/src/filter/src/fnyquist.c
+++ b/src/filter/src/fnyquist.c
@@ -109,7 +109,7 @@ int liquid_firdes_fexp(unsigned int _k,
                        float _dt,
                        float * _h)
 {
-    // compute resonse using generic function
+    // compute response using generic function
     return liquid_firdes_fnyquist(LIQUID_FIRFILT_FEXP, 0, _k, _m, _beta, _dt, _h);
 }
 
@@ -125,7 +125,7 @@ int liquid_firdes_rfexp(unsigned int _k,
                         float _dt,
                         float * _h)
 {
-    // compute resonse using generic function
+    // compute response using generic function
     return liquid_firdes_fnyquist(LIQUID_FIRFILT_FEXP, 1, _k, _m, _beta, _dt, _h);
 }
 
@@ -186,7 +186,7 @@ int liquid_firdes_fsech(unsigned int _k,
                         float _dt,
                         float * _h)
 {
-    // compute resonse using generic function
+    // compute response using generic function
     return liquid_firdes_fnyquist(LIQUID_FIRFILT_FSECH, 0, _k, _m, _beta, _dt, _h);
 }
 
@@ -202,7 +202,7 @@ int liquid_firdes_rfsech(unsigned int _k,
                          float _dt,
                          float * _h)
 {
-    // compute resonse using generic function
+    // compute response using generic function
     return liquid_firdes_fnyquist(LIQUID_FIRFILT_FSECH, 1, _k, _m, _beta, _dt, _h);
 }
 
@@ -263,7 +263,7 @@ int liquid_firdes_farcsech(unsigned int _k,
                            float _dt,
                            float * _h)
 {
-    // compute resonse using generic function
+    // compute response using generic function
     return liquid_firdes_fnyquist(LIQUID_FIRFILT_FARCSECH, 0, _k, _m, _beta, _dt, _h);
 }
 
@@ -279,7 +279,7 @@ int liquid_firdes_rfarcsech(unsigned int _k,
                             float _dt,
                             float * _h)
 {
-    // compute resonse using generic function
+    // compute response using generic function
     return liquid_firdes_fnyquist(LIQUID_FIRFILT_FARCSECH, 1, _k, _m, _beta, _dt, _h);
 }
 

--- a/src/filter/src/gmsk.c
+++ b/src/filter/src/gmsk.c
@@ -113,7 +113,7 @@ int liquid_firdes_gmskrx(unsigned int _k,
 
     // arrays
     float ht[h_len];         // transmit filter coefficients
-    float hr[h_len];         // recieve filter coefficients
+    float hr[h_len];         // receive filter coefficients
 
     // design transmit filter
     liquid_firdes_gmsktx(k,m,BT,0.0f,ht);
@@ -156,7 +156,7 @@ int liquid_firdes_gmskrx(unsigned int _k,
     fft_run(h_len, g_prime, G_prime, LIQUID_FFT_FORWARD, 0);
     fft_run(h_len, h_tx,    H_tx,    LIQUID_FFT_FORWARD, 0);
 
-    // find minimum of reponses
+    // find minimum of responses
     float H_tx_min = 0.0f;
     float H_prime_min = 0.0f;
     float G_prime_min = 0.0f;
@@ -168,7 +168,7 @@ int liquid_firdes_gmskrx(unsigned int _k,
 
     // compute 'prototype' response, removing minima, and add correction factor
     for (i=0; i<h_len; i++) {
-        // compute response necessary to yeild prototype response (not exact, but close)
+        // compute response necessary to yield prototype response (not exact, but close)
         H_hat[i] = crealf(H_prime[i] - H_prime_min + delta) / crealf(H_tx[i] - H_tx_min + delta);
 
         // include additional term to add stop-band suppression

--- a/src/filter/src/iirdes.c
+++ b/src/filter/src/iirdes.c
@@ -596,7 +596,7 @@ int liquid_iirdes(liquid_iirdes_filtertype _ftype,
     if (_n == 0)
         return liquid_error(LIQUID_EICONFIG,"liquid_iirdes(), filter order must be > 0");
 
-    // number of analaog poles/zeros
+    // number of analog poles/zeros
     unsigned int npa = _n;
     unsigned int nza;
 
@@ -713,7 +713,7 @@ int liquid_iirdes(liquid_iirdes_filtertype _ftype,
         float complex zd1[2*_n];
         float complex pd1[2*_n];
 
-        // run zeros, poles low-pass -> band-pass trasform
+        // run zeros, poles low-pass -> band-pass transform
         iirdes_dzpk_lp2bp(zd, pd,   // low-pass prototype zeros, poles
                           _n,       // filter order
                           _f0,      // center frequency
@@ -723,7 +723,7 @@ int liquid_iirdes(liquid_iirdes_filtertype _ftype,
         memmove(zd, zd1, 2*_n*sizeof(float complex));
         memmove(pd, pd1, 2*_n*sizeof(float complex));
 
-        // update paramters; filter order doubles which changes the
+        // update parameters; filter order doubles which changes the
         // number of second-order sections and forces there to never
         // be any remainder (r=0 always).
         _n =  2*_n;     // _n is now even

--- a/src/filter/src/msresamp.proto.c
+++ b/src/filter/src/msresamp.proto.c
@@ -291,7 +291,7 @@ unsigned int MSRESAMP(_get_num_output)(MSRESAMP()   _q,
         return n * (1 << _q->num_halfband_stages);
     } else {
         // compute number of outputs from half-band decimation stage
-        // NOTE: this compensates for the number of samples already bufferes
+        // NOTE: this compensates for the number of samples already buffers
         unsigned int n = (_q->buffer_index+_num_input) >> _q->num_halfband_stages;
 
         return RESAMP(_get_num_output)(_q->arbitrary_resamp,n);

--- a/src/filter/src/resamp.fixed.proto.c
+++ b/src/filter/src/resamp.fixed.proto.c
@@ -21,7 +21,7 @@
  */
 
 //
-// Arbitrary resampler (fixed-point phase verions)
+// Arbitrary resampler (fixed-point phase versions)
 //
 
 #include <stdio.h>

--- a/src/filter/src/resamp.proto.c
+++ b/src/filter/src/resamp.proto.c
@@ -49,7 +49,7 @@ struct RESAMP(_s) {
     float fc;           // filter cutoff frequency
 
     // resampling properties/states
-    float rate;         // resampling rate (ouput/input)
+    float rate;         // resampling rate (output/input)
     float del;          // fractional delay step
 
     // floating-point phase

--- a/src/filter/src/rkaiser.c
+++ b/src/filter/src/rkaiser.c
@@ -140,7 +140,7 @@ int liquid_firdes_arkaiser(unsigned int _k,
 }
 
 // Find approximate bandwidth adjustment factor rho based on
-// filter delay and desired excess bandwdith factor.
+// filter delay and desired excess bandwidth factor.
 //
 //  _m      :   filter delay (symbols)
 //  _beta   :   filter excess bandwidth factor (0,1)

--- a/src/filter/tests/resamp2_crcf_autotest.c
+++ b/src/filter/tests/resamp2_crcf_autotest.c
@@ -177,7 +177,7 @@ void testbench_resamp2_crcf_filter(unsigned int _m, float _as)
 
     // get impulse response
     unsigned int h_len = 4*_m+1;
-    float complex h_0[h_len];   // low-frequency reponse
+    float complex h_0[h_len];   // low-frequency response
     float complex h_1[h_len];   // high-frequency response
     unsigned int i;
     for (i=0; i<h_len; i++)

--- a/src/framing/src/bpacketgen.c
+++ b/src/framing/src/bpacketgen.c
@@ -44,7 +44,7 @@ struct bpacketgen_s {
     fec_scheme fec1;                // payload fec (outer)
     
     // derived values
-    unsigned int enc_msg_len;       // encoded mesage length
+    unsigned int enc_msg_len;       // encoded message length
     unsigned int header_len;        // header length (12 bytes encoded)
     unsigned int packet_len;        // total packet length
 

--- a/src/framing/src/bpacketsync.c
+++ b/src/framing/src/bpacketsync.c
@@ -47,7 +47,7 @@ struct bpacketsync_s {
     fec_scheme fec1;                // payload fec (outer)
     
     // derived values
-    unsigned int enc_msg_len;       // encoded mesage length
+    unsigned int enc_msg_len;       // encoded message length
     unsigned int header_len;        // header length (12 bytes encoded)
     unsigned int packet_len;        // total packet length
 

--- a/src/framing/src/gmskframesync.c
+++ b/src/framing/src/gmskframesync.c
@@ -459,7 +459,7 @@ int gmskframesync_update_symsync(gmskframesync _q,
         // compute actual filterbank index
         _q->pfb_index = roundf(_q->pfb_soft);
 
-        // contrain index to be in [0, npfb-1]
+        // constrain index to be in [0, npfb-1]
         while (_q->pfb_index < 0) {
             _q->pfb_index += _q->npfb;
             _q->pfb_soft  += _q->npfb;

--- a/src/framing/src/ofdmflexframesync.c
+++ b/src/framing/src/ofdmflexframesync.c
@@ -200,7 +200,7 @@ ofdmflexframesync ofdmflexframesync_create(unsigned int       _M,
     q->fec0         = LIQUID_FEC_NONE;
     q->fec1         = LIQUID_FEC_NONE;
 
-    // create payload objects (initally QPSK, etc but overridden by received properties)
+    // create payload objects (initially QPSK, etc but overridden by received properties)
     q->mod_payload = modemcf_create(q->ms_payload);
     q->payload_soft = 0;
     q->p_payload   = packetizer_create(q->payload_len, q->check, q->fec0, q->fec1);

--- a/src/framing/src/qsource.proto.c
+++ b/src/framing/src/qsource.proto.c
@@ -337,7 +337,7 @@ int QSOURCE(_print)(QSOURCE() _q)
 }
 
 // reset object internals
-// NOTE: placeholder for future funcitonality
+// NOTE: placeholder for future functionality
 int QSOURCE(_reset)(QSOURCE() _q)
 {
     return LIQUID_OK;

--- a/src/framing/tests/qdetector_cccf_autotest.c
+++ b/src/framing/tests/qdetector_cccf_autotest.c
@@ -291,7 +291,7 @@ void qdetector_cccf_runtest_gmsk(unsigned int _sequence_len)
         AUTOTEST_FAIL("frame not detected");
     else {
         // check signal level estimate
-        // TODO: check discrepency with short sequences
+        // TODO: check discrepancy with short sequences
         //CONTEND_DELTA( gamma_hat, gamma, 0.05f );
 
         // check timing offset estimate

--- a/src/framing/tests/qpilotsync_autotest.c
+++ b/src/framing/tests/qpilotsync_autotest.c
@@ -85,7 +85,7 @@ void qpilotsync_test(modulation_scheme _ms,
         frame_rx[i] *= _gamma;
     }
 
-    // recieve frame
+    // receive frame
     qpilotsync_execute(ps, frame_rx, payload_rx);
 
     // demodulate

--- a/src/math/src/poly.findroots.c
+++ b/src/math/src/poly.findroots.c
@@ -52,7 +52,7 @@ int liquid_poly_findroots_durandkerner(double *         _p,
     double r0[num_roots];
     double r1[num_roots];
 
-    // find intial magnitude
+    // find initial magnitude
     float g     = 0.0f;
     float gmax  = 0.0f;
     for (i=0; i<_k; i++) {

--- a/src/matrix/src/smatrix.proto.c
+++ b/src/matrix/src/smatrix.proto.c
@@ -266,7 +266,7 @@ int SMATRIX(_clear)(SMATRIX() _q)
         }
     }
 
-    // clear colum entries
+    // clear column entries
     for (j=0; j<_q->N; j++) {
         for (i=0; i<_q->num_nlist[j]; i++) {
             _q->nvals[j][i] = 0;

--- a/src/matrix/tests/smatrixf_autotest.c
+++ b/src/matrix/tests/smatrixf_autotest.c
@@ -70,7 +70,7 @@ void autotest_smatrixf_mul()
 {
     float tol = 1e-6f;
 
-    // intialize matrices
+    // initialize matrices
     smatrixf a = smatrixf_create(4, 5);
     smatrixf b = smatrixf_create(5, 3);
     smatrixf c = smatrixf_create(4, 3);

--- a/src/matrix/tests/smatrixi_autotest.c
+++ b/src/matrix/tests/smatrixi_autotest.c
@@ -67,7 +67,7 @@ void autotest_smatrixi_vmul()
 // test sparse integer matrix multiplication
 void autotest_smatrixi_mul()
 {
-    // intialize matrices
+    // initialize matrices
     smatrixi a = smatrixi_create(4, 5);
     smatrixi b = smatrixi_create(5, 3);
     smatrixi c = smatrixi_create(4, 3);

--- a/src/modem/src/cpfskmod.c
+++ b/src/modem/src/cpfskmod.c
@@ -123,7 +123,7 @@ cpfskmod cpfskmod_create(unsigned int _bps,
         q->symbol_delay = 1;
         break;
     case LIQUID_CPFSK_RCOS_PARTIAL:
-        // TODO: adjust reponse based on 'm'
+        // TODO: adjust response based on 'm'
         q->ht_len = 3*q->k;
         q->symbol_delay = 2;
         break;

--- a/src/modem/src/gmskdem.c
+++ b/src/modem/src/gmskdem.c
@@ -206,7 +206,7 @@ int gmskdem_set_eq_bw(gmskdem _q,
 {
     // validate input
     if (_bw < 0.0f || _bw > 0.5f)
-        return liquid_error(LIQUID_EICONFIG,"gmskdem_set_eq_bw(), bandwith must be in [0,0.5]");
+        return liquid_error(LIQUID_EICONFIG,"gmskdem_set_eq_bw(), bandwidth must be in [0,0.5]");
 
 #if GMSKDEM_USE_EQUALIZER
     // set internal equalizer bandwidth

--- a/src/modem/src/modem_common.proto.c
+++ b/src/modem/src/modem_common.proto.c
@@ -212,7 +212,7 @@ MODEM() MODEM(_create)(modulation_scheme _scheme)
         return liquid_error_config("modem%s_create(), unknown/unsupported modulation scheme : %u",EXTENSION,_scheme);
     }
 
-    // should never get to this point, but adding return statment
+    // should never get to this point, but adding return statement
     // to keep compiler happy
     return NULL;
 }
@@ -477,7 +477,7 @@ void print_bitstring_demod_soft(unsigned int _x,
 //  _q          :   demodulator object
 //  _r          :   received sample
 //  _s          :   hard demodulator output
-//  _soft_bits  :   soft bit ouput (approximate log-likelihood ratio)
+//  _soft_bits  :   soft bit output (approximate log-likelihood ratio)
 int MODEM(_demodulate_soft_table)(MODEM() _q,
                                   TC _r,
                                   unsigned int * _s,
@@ -605,7 +605,7 @@ int MODEM(_demodulate_linear_array)(T              _v,
     return LIQUID_OK;
 }
 
-// Demodulate a linear symbol constellation using refereneced lookup table
+// Demodulate a linear symbol constellation using referenced lookup table
 //  _v      :   input value
 //  _m      :   bits per symbol
 //  _ref    :   array of thresholds

--- a/src/modem/src/modem_utilities.c
+++ b/src/modem/src/modem_utilities.c
@@ -35,7 +35,7 @@ const struct modulation_type_s modulation_types[LIQUID_MODEM_NUM_SCHEMES] = {
     // name       fullname        scheme          bps
 
     // unknown
-    {"unknown",   "unkown",       LIQUID_MODEM_UNKNOWN, 0},
+    {"unknown",   "unknown",       LIQUID_MODEM_UNKNOWN, 0},
 
     // phase-shift keying
     {"psk2",      "phase-shift keying (2)",   LIQUID_MODEM_PSK2,  1},

--- a/src/modem/src/modemcf.c
+++ b/src/modem/src/modemcf.c
@@ -58,7 +58,7 @@
 #include "modem_sqam32.proto.c"
 #include "modem_sqam128.proto.c"
 
-// arbitary modems
+// arbitrary modems
 #include "modem_arb.proto.c"
 
 // analog modems

--- a/src/multichannel/src/firpfbch.proto.c
+++ b/src/multichannel/src/firpfbch.proto.c
@@ -142,7 +142,7 @@ FIRPFBCH() FIRPFBCH(_create)(int          _type,
 //  _type   : channelizer type (LIQUID_ANALYZER | LIQUID_SYNTHESIZER)
 //  _M      : number of channels
 //  _m      : filter delay (symbols)
-//  _as     : stop-band attentuation [dB]
+//  _as     : stop-band attenuation [dB]
 FIRPFBCH() FIRPFBCH(_create_kaiser)(int          _type,
                                     unsigned int _M,
                                     unsigned int _m,

--- a/src/multichannel/src/ofdmframesync.c
+++ b/src/multichannel/src/ofdmframesync.c
@@ -442,7 +442,7 @@ int ofdmframesync_execute_seekplcp(ofdmframesync _q)
 
     // estimate gain
     unsigned int i;
-    // start with a reasonbly small number to avoid divide-by-zero warning
+    // start with a reasonably small number to avoid divide-by-zero warning
     float g = 1.0e-9f;
     for (i=_q->cp_len; i<_q->M + _q->cp_len; i++) {
         // compute |rc[i]|^2 efficiently

--- a/src/multichannel/tests/ofdmframesync_autotest.c
+++ b/src/multichannel/tests/ofdmframesync_autotest.c
@@ -56,7 +56,7 @@ int ofdmframesync_autotest_callback(float complex * _X,
 
 // Helper function to keep code base small
 //  _num_subcarriers    :   number of subcarriers
-//  _cp_len             :   cyclic prefix lenght
+//  _cp_len             :   cyclic prefix length
 //  _taper_len          :   taper length
 void ofdmframesync_acquire_test(unsigned int _num_subcarriers,
                                 unsigned int _cp_len,
@@ -64,7 +64,7 @@ void ofdmframesync_acquire_test(unsigned int _num_subcarriers,
 {
     // options
     unsigned int M         = _num_subcarriers;  // number of subcarriers
-    unsigned int cp_len    = _cp_len;           // cyclic prefix lenght
+    unsigned int cp_len    = _cp_len;           // cyclic prefix length
     unsigned int taper_len = _taper_len;        // taper length
     float tol              = 1e-2f;             // error tolerance
 

--- a/src/quantization/tests/quantize_autotest.c
+++ b/src/quantization/tests/quantize_autotest.c
@@ -45,7 +45,7 @@ void autotest_quantize_float_n8() {
         if (liquid_autotest_verbose)
             printf("%8.4f > 0x%2.2x > %8.4f\n", x, q, x_hat);
 
-        // ensure original value is recovered withing tolerance
+        // ensure original value is recovered within tolerance
         CONTEND_DELTA(x,x_hat,tol);
 
         x += dx;

--- a/src/sequence/src/bsequence.c
+++ b/src/sequence/src/bsequence.c
@@ -71,7 +71,7 @@ bsequence bsequence_create(unsigned int _num_bits)
         bs->bit_mask_msb |=  1;
     }
 
-    // initialze array with zeros
+    // initialize array with zeros
     bs->s = (unsigned int*) malloc( bs->s_len * sizeof(unsigned int) );
     bsequence_reset(bs);
 
@@ -284,7 +284,7 @@ unsigned int bsequence_index(bsequence _bs,
     return (_bs->s[k] >> d.rem ) & 1;
 }
 
-// intialize two sequences to complementary codes.  sequences must
+// initialize two sequences to complementary codes.  sequences must
 // be of length at least 8 and a power of 2 (e.g. 8, 16, 32, 64,...)
 int bsequence_create_ccodes(bsequence _qa, bsequence _qb)
 {

--- a/src/utility/src/bshift_array.c
+++ b/src/utility/src/bshift_array.c
@@ -71,7 +71,7 @@ int liquid_rbshift(unsigned char * _src,
 }
 
  
-// circularly shift array to the left _b bits
+// circular shift array to the left _b bits
 //  _src        :   source address [size: _n x 1]
 //  _n          :   input data array size
 //  _b          :   number of bits to shift
@@ -114,7 +114,7 @@ int liquid_lbcircshift(unsigned char * _src,
 }
 
  
-// circularly shift array to the right _b bits
+// circular shift array to the right _b bits
 //  _src        :   source address [size: _n x 1]
 //  _n          :   input data array size
 //  _b          :   number of bits to shift


### PR DESCRIPTION
This PR fixes some strings output with printf and some comments.
Fixed with:
codespell --ignore-words-list=hist,nd --skip=scripts --summary --write-changes --interactive 2