### PR TITLE
iirdes: fix number of zeroes in the docs

### DIFF
--- a/src/filter/src/cheby2.c
+++ b/src/filter/src/cheby2.c
@@ -40,7 +40,7 @@
 // end of the array.
 //  _n      :   filter order
 //  _ep     :   epsilon, related to stop-band ripple
-//  _za     :   output analog zeros [length: floor(_n/2)]
+//  _za     :   output analog zeros [length: 2*floor(_n/2)]
 //  _pa     :   output analog poles [length: _n]
 //  _ka     :   output analog gain
 int cheby2_azpkf(unsigned int           _n,


### PR DESCRIPTION
The number of analog zeros that this function outputs is 2*L; fix the documentation to match that.