### PR TITLE
Fix what I think was causing errors with the SSE4.1 dotprod

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ else
             # SSE4.1/2 extensions
             MLIBS_DOTPROD="src/dotprod/src/dotprod_cccf.mmx.o \
                            src/dotprod/src/dotprod_crcf.mmx.o \
-                           src/dotprod/src/dotprod_rrrf.mmx.o \
+                           src/dotprod/src/dotprod_rrrf.sse4.o \
                            src/dotprod/src/sumsq.mmx.o"
             ARCH_OPTION='-msse4.1'
         elif [ test "$ax_cv_have_sse3_ext" = yes && test "$ac_cv_header_pmmintrin_h" = yes ]; then

--- a/src/dotprod/src/dotprod_rrrf.sse4.c
+++ b/src/dotprod/src/dotprod_rrrf.sse4.c
@@ -104,8 +104,9 @@ struct dotprod_rrrf_s {
     float * h;          // coefficients array
 };
 
-dotprod_rrrf dotprod_rrrf_create(float *      _h,
-                                 unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
+                                     unsigned int _n,
+                                     int          _rev)
 {
     dotprod_rrrf q = (dotprod_rrrf)malloc(sizeof(struct dotprod_rrrf_s));
     q->n = _n;
@@ -114,10 +115,24 @@ dotprod_rrrf dotprod_rrrf_create(float *      _h,
     q->h = (float*) _mm_malloc( q->n*sizeof(float), 16);
 
     // set coefficients
-    memmove(q->h, _h, _n*sizeof(float));
+    unsigned int i;
+    for (i=0; i<q->n; i++)
+        q->h[i] = _h[_rev ? q->n-i-1 : i];
 
     // return object
     return q;
+}
+
+dotprod_rrrf dotprod_rrrf_create(float *      _h,
+                                 unsigned int _n)
+{
+    return dotprod_rrrf_create_opt(_h, _n, 0);
+}
+
+dotprod_rrrf dotprod_rrrf_create_rev(float *      _h,
+                                     unsigned int _n)
+{
+    return dotprod_rrrf_create_opt(_h, _n, 1);
 }
 
 // re-create the structured dotprod object
@@ -128,6 +143,16 @@ dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
     return dotprod_rrrf_create(_h,_n);
+}
+
+// re-create the structured dotprod object, coefficients reversed
+dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf _q,
+                                       float *      _h,
+                                       unsigned int _n)
+{
+    // completely destroy and re-create dotprod object
+    dotprod_rrrf_destroy(_q);
+    return dotprod_rrrf_create_rev(_h,_n);
 }
 
 dotprod_rrrf dotprod_rrrf_copy(dotprod_rrrf q_orig)

--- a/src/dotprod/src/dotprod_rrrf.sse4.c
+++ b/src/dotprod/src/dotprod_rrrf.sse4.c
@@ -200,7 +200,7 @@ int dotprod_rrrf_execute_sse4(dotprod_rrrf _q,
         h = _mm_load_ps(&_q->h[i]);
 
         // compute dot product
-        s = _mm_dp_ps(v, h, 0xffffffff);
+        s = _mm_dp_ps(v, h, 0xff);
         
         // parallel addition
         sum = _mm_add_ps( sum, s );
@@ -251,10 +251,10 @@ int dotprod_rrrf_execute_sse4u(dotprod_rrrf _q,
         h3 = _mm_load_ps(&_q->h[4*i+12]);
 
         // compute dot products
-        s0 = _mm_dp_ps(v0, h0, 0xffffffff);
-        s1 = _mm_dp_ps(v1, h1, 0xffffffff);
-        s2 = _mm_dp_ps(v2, h2, 0xffffffff);
-        s3 = _mm_dp_ps(v3, h3, 0xffffffff);
+        s0 = _mm_dp_ps(v0, h0, 0xff);
+        s1 = _mm_dp_ps(v1, h1, 0xff);
+        s2 = _mm_dp_ps(v2, h2, 0xff);
+        s3 = _mm_dp_ps(v3, h3, 0xff);
         
         // parallel addition
         // FIXME: these additions are by far the limiting factor


### PR DESCRIPTION
Fix what I think was causing said errors (imm8 is supposed to be 8-bits, not 32-bits)

This reverts commit c99e7d878e16901a9f376b317ddb3b3bb75c8ed0.