### PR TITLE
fft: add fft_malloc/fft_free API for FFTW aligned memory

### DIFF
--- a/bench/fftbench.c
+++ b/bench/fftbench.c
@@ -476,8 +476,8 @@ void benchmark_fftw(struct rusage *      _start,
                     struct benchmark_s * _benchmark)
 {
     // initialize arrays, plan
-    float complex * x = (float complex *) malloc((_benchmark->nfft)*sizeof(float complex));
-    float complex * y = (float complex *) malloc((_benchmark->nfft)*sizeof(float complex));
+    float complex * x = (float complex *) fftwf_malloc((_benchmark->nfft)*sizeof(float complex));
+    float complex * y = (float complex *) fftwf_malloc((_benchmark->nfft)*sizeof(float complex));
     fftwf_plan q = fftwf_plan_dft_1d(_benchmark->nfft,
                                      x, y,
                                      //_benchmark->direction,
@@ -508,8 +508,8 @@ void benchmark_fftw(struct rusage *      _start,
     _benchmark->num_trials = num_iterations * 4;
 
     fftwf_destroy_plan(q);
-    free(x);
-    free(y);
+    fftwf_free(x);
+    fftwf_free(y);
 }
 
 void benchmark_print_to_file(FILE * _fid,

--- a/examples/fft_example.c
+++ b/examples/fft_example.c
@@ -42,9 +42,9 @@ int main(int argc, char*argv[])
     }
 
     // allocate memory arrays
-    float complex * x = (float complex*) malloc(nfft*sizeof(float complex));
-    float complex * y = (float complex*) malloc(nfft*sizeof(float complex));
-    float complex * z = (float complex*) malloc(nfft*sizeof(float complex));
+    float complex * x = (float complex*) fft_malloc(nfft*sizeof(float complex));
+    float complex * y = (float complex*) fft_malloc(nfft*sizeof(float complex));
+    float complex * z = (float complex*) fft_malloc(nfft*sizeof(float complex));
 
     // initialize input
     unsigned int i;
@@ -94,9 +94,9 @@ int main(int argc, char*argv[])
     printf("rmse = %12.4e\n", rmse);
 
     // free allocated memory
-    free(x);
-    free(y);
-    free(z);
+    fft_free(x);
+    fft_free(y);
+    fft_free(z);
 
     printf("done.\n");
     return 0;

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -1550,6 +1550,20 @@ typedef enum {
 /* Fast Fourier Transform (FFT) and inverse (plan) object               */  \
 typedef struct FFT(plan_s) * FFT(plan);                                     \
                                                                             \
+/* Allocate a one-dimensional array similar to the ordinary malloc. The */  \
+/* implementation may internally align the allocated memory to support  */  \
+/* some optimizations. Use the result as the input or output array      */  \
+/* argument to one of the fft_create* methods. As with the ordinary     */  \
+/* malloc, the result must be typecast to the proper type. Memory       */  \
+/* allocated by this function must be deallocated by fft_free and not   */  \
+/* by the ordinary free.                                                */  \
+/*  _n      :   array size                                              */  \
+void * FFT(_malloc)(unsigned int _n);                                       \
+                                                                            \
+/* Free the one-dimensional array allocated by fft_malloc.              */  \
+/*  _x      :   pointer to array                                        */  \
+void FFT(_free)(void * _x);                                                 \
+                                                                            \
 /* Create regular complex one-dimensional transform                     */  \
 /*  _n      :   transform size                                          */  \
 /*  _x      :   pointer to input array,  [size: _n x 1]                 */  \

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -749,6 +749,8 @@ LIQUID_FFT_DEFINE_INTERNAL_API(LIQUID_FFT_MANGLE_FLOAT, float, liquid_float_comp
 #   define FFT_DIR_FORWARD      FFTW_FORWARD
 #   define FFT_DIR_BACKWARD     FFTW_BACKWARD
 #   define FFT_METHOD           FFTW_ESTIMATE
+#   define FFT_MALLOC           fftwf_malloc
+#   define FFT_FREE             fftwf_free
 #else
 #   define FFT_PLAN             fftplan
 #   define FFT_CREATE_PLAN      fft_create_plan
@@ -757,6 +759,8 @@ LIQUID_FFT_DEFINE_INTERNAL_API(LIQUID_FFT_MANGLE_FLOAT, float, liquid_float_comp
 #   define FFT_DIR_FORWARD      LIQUID_FFT_FORWARD
 #   define FFT_DIR_BACKWARD     LIQUID_FFT_BACKWARD
 #   define FFT_METHOD           0
+#   define FFT_MALLOC           malloc
+#   define FFT_FREE             free
 #endif
 
 

--- a/sandbox/fskcorr_test.c
+++ b/sandbox/fskcorr_test.c
@@ -57,10 +57,10 @@ int main(int argc, char*argv[])
     float xcorr_norm = liquid_sumsqf(buf_mf, p*n);
 
     // allocate memory arrays
-    float complex * buf_0 = (float complex*) malloc(M*sizeof(float complex));
-    float complex * buf_1 = (float complex*) malloc(M*sizeof(float complex));
-    float complex * buf_2 = (float complex*) malloc(M*sizeof(float complex));
-    float complex * buf_3 = (float complex*) malloc(M*sizeof(float complex));
+    float complex * buf_0 = (float complex*) fft_malloc(M*sizeof(float complex));
+    float complex * buf_1 = (float complex*) fft_malloc(M*sizeof(float complex));
+    float complex * buf_2 = (float complex*) fft_malloc(M*sizeof(float complex));
+    float complex * buf_3 = (float complex*) fft_malloc(M*sizeof(float complex));
     windowcf buf_rx = windowcf_create(M);
 
     // create fft plans
@@ -165,10 +165,10 @@ int main(int argc, char*argv[])
     fclose(fid);
     printf("results written to fskcorr_test.m\n");
 
-    free(buf_0);
-    free(buf_1);
-    free(buf_2);
-    free(buf_3);
+    fft_free(buf_0);
+    fft_free(buf_1);
+    fft_free(buf_2);
+    fft_free(buf_3);
     fft_destroy_plan(fft);
     fft_destroy_plan(ifft);
     windowcf_destroy(buf_rx);

--- a/src/fft/bench/fft_runbench.c
+++ b/src/fft/bench/fft_runbench.c
@@ -37,8 +37,8 @@ void fft_runbench(struct rusage *     _start,
                   int                 _direction)
 {
     // initialize arrays, plan
-    float complex * x = (float complex *) malloc(_nfft*sizeof(float complex));
-    float complex * y = (float complex *) malloc(_nfft*sizeof(float complex));
+    float complex * x = (float complex *) fft_malloc(_nfft*sizeof(float complex));
+    float complex * y = (float complex *) fft_malloc(_nfft*sizeof(float complex));
     int _method = 0;
     fftplan q = fft_create_plan(_nfft, x, y, _direction, _method);
     
@@ -64,7 +64,7 @@ void fft_runbench(struct rusage *     _start,
     *_num_iterations *= 4;
 
     fft_destroy_plan(q);
-    free(x);
-    free(y);
+    fft_free(x);
+    fft_free(y);
 }
 

--- a/src/fft/src/fft_common.proto.c
+++ b/src/fft/src/fft_common.proto.c
@@ -100,6 +100,20 @@ struct FFT(plan_s)
     } data;
 };
 
+// allocate one-dimensional array 
+//  _n      :   array size
+void * FFT(_malloc)(unsigned int _n)
+{
+    return FFT_MALLOC(_n);
+}
+
+// allocate one-dimensional array allocated by fft_malloc
+//  _x      :   pointer to array
+void FFT(_free)(void * _x)
+{
+    FFT_FREE(_x);
+}
+
 // create FFT plan, regular complex one-dimensional transform
 //  _nfft   :   FFT size
 //  _x      :   input array [size: _nfft x 1]

--- a/src/fft/src/fft_mixed_radix.proto.c
+++ b/src/fft/src/fft_mixed_radix.proto.c
@@ -73,8 +73,8 @@ FFT(plan) FFT(_create_plan_mixed_radix)(unsigned int _nfft,
 
     // allocate memory for buffers
     unsigned int t_len = Q > P ? Q : P;
-    q->data.mixedradix.t0 = (TC *) malloc(t_len * sizeof(TC));
-    q->data.mixedradix.t1 = (TC *) malloc(t_len * sizeof(TC));
+    q->data.mixedradix.t0 = (TC *) FFT_MALLOC(t_len * sizeof(TC));
+    q->data.mixedradix.t1 = (TC *) FFT_MALLOC(t_len * sizeof(TC));
 
     // allocate memory for input buffers
     q->data.mixedradix.x = (TC *) malloc(q->nfft * sizeof(TC));
@@ -112,8 +112,8 @@ int FFT(_destroy_plan_mixed_radix)(FFT(plan) _q)
     FFT(_destroy_plan)(_q->data.mixedradix.fft_Q);
 
     // free data specific to mixed-radix transforms
-    free(_q->data.mixedradix.t0);
-    free(_q->data.mixedradix.t1);
+    FFT_FREE(_q->data.mixedradix.t0);
+    FFT_FREE(_q->data.mixedradix.t1);
     free(_q->data.mixedradix.x);
     free(_q->data.mixedradix.twiddle);
 

--- a/src/fft/src/fft_rader.proto.c
+++ b/src/fft/src/fft_rader.proto.c
@@ -64,8 +64,8 @@ FFT(plan) FFT(_create_plan_rader)(unsigned int _nfft,
     q->execute   = FFT(_execute_rader);
 
     // allocate memory for sub-transforms
-    q->data.rader.x_prime = (TC*)malloc((q->nfft-1)*sizeof(TC));
-    q->data.rader.X_prime = (TC*)malloc((q->nfft-1)*sizeof(TC));
+    q->data.rader.x_prime = (TC*) FFT_MALLOC((q->nfft-1)*sizeof(TC));
+    q->data.rader.X_prime = (TC*) FFT_MALLOC((q->nfft-1)*sizeof(TC));
 
     // create sub-FFT of size nfft-1
     q->data.rader.fft = FFT(_create_plan)(q->nfft-1,
@@ -110,10 +110,10 @@ FFT(plan) FFT(_create_plan_rader)(unsigned int _nfft,
 int FFT(_destroy_plan_rader)(FFT(plan) _q)
 {
     // free data specific to Rader's algorithm
-    free(_q->data.rader.seq);       // sequence
-    free(_q->data.rader.R);         // pre-computed transform of exp(j*2*pi*seq)
-    free(_q->data.rader.x_prime);   // sub-transform input array
-    free(_q->data.rader.X_prime);   // sub-transform output array
+    free(_q->data.rader.seq);           // sequence
+    free(_q->data.rader.R);             // pre-computed transform of exp(j*2*pi*seq)
+    FFT_FREE(_q->data.rader.x_prime);   // sub-transform input array
+    FFT_FREE(_q->data.rader.X_prime);   // sub-transform output array
 
     FFT(_destroy_plan)(_q->data.rader.fft);
     FFT(_destroy_plan)(_q->data.rader.ifft);

--- a/src/fft/src/fft_rader2.proto.c
+++ b/src/fft/src/fft_rader2.proto.c
@@ -129,8 +129,8 @@ FFT(plan) FFT(_create_plan_rader2)(unsigned int _nfft,
     // assert(nfft_prime > 2*nfft-4)
 
     // allocate memory for sub-transforms
-    q->data.rader2.x_prime = (TC*)malloc((q->data.rader2.nfft_prime)*sizeof(TC));
-    q->data.rader2.X_prime = (TC*)malloc((q->data.rader2.nfft_prime)*sizeof(TC));
+    q->data.rader2.x_prime = (TC*) FFT_MALLOC((q->data.rader2.nfft_prime)*sizeof(TC));
+    q->data.rader2.X_prime = (TC*) FFT_MALLOC((q->data.rader2.nfft_prime)*sizeof(TC));
 
     // create sub-FFT of size nfft-1
     q->data.rader2.fft = FFT(_create_plan)(q->data.rader2.nfft_prime,
@@ -166,11 +166,11 @@ FFT(plan) FFT(_create_plan_rader2)(unsigned int _nfft,
 int FFT(_destroy_plan_rader2)(FFT(plan) _q)
 {
     // free data specific to Rader's algorithm
-    free(_q->data.rader2.seq);      // sequence
-    free(_q->data.rader2.R);        // pre-computed transform of exp(j*2*pi*seq)
+    free(_q->data.rader2.seq);          // sequence
+    free(_q->data.rader2.R);            // pre-computed transform of exp(j*2*pi*seq)
 
-    free(_q->data.rader2.x_prime);   // sub-transform input array
-    free(_q->data.rader2.X_prime);   // sub-transform output array
+    FFT_FREE(_q->data.rader2.x_prime);  // sub-transform input array
+    FFT_FREE(_q->data.rader2.X_prime);  // sub-transform output array
 
     FFT(_destroy_plan)(_q->data.rader2.fft);
     FFT(_destroy_plan)(_q->data.rader2.ifft);

--- a/src/fft/src/spgram.proto.c
+++ b/src/fft/src/spgram.proto.c
@@ -110,8 +110,8 @@ SPGRAM() SPGRAM(_create)(unsigned int _nfft,
     SPGRAM(_set_alpha)(q, -1.0f);
 
     // create FFT arrays, object
-    q->buf_time = (TC*) malloc((q->nfft)*sizeof(TC));
-    q->buf_freq = (TC*) malloc((q->nfft)*sizeof(TC));
+    q->buf_time = (TC*) FFT_MALLOC((q->nfft)*sizeof(TC));
+    q->buf_freq = (TC*) FFT_MALLOC((q->nfft)*sizeof(TC));
     q->psd      = (T *) malloc((q->nfft)*sizeof(T ));
     q->fft      = FFT_CREATE_PLAN(q->nfft, q->buf_time, q->buf_freq, FFT_DIR_FORWARD, FFT_METHOD);
 
@@ -186,8 +186,8 @@ SPGRAM() SPGRAM(_copy)(SPGRAM() q_orig)
     q_copy->buffer = WINDOW(_copy)(q_orig->buffer);
 
     // create FFT arrays, object
-    q_copy->buf_time = (TC*) malloc((q_copy->nfft)*sizeof(TC));
-    q_copy->buf_freq = (TC*) malloc((q_copy->nfft)*sizeof(TC));
+    q_copy->buf_time = (TC*) FFT_MALLOC((q_copy->nfft)*sizeof(TC));
+    q_copy->buf_freq = (TC*) FFT_MALLOC((q_copy->nfft)*sizeof(TC));
     q_copy->psd      = (T *) malloc((q_copy->nfft)*sizeof(T ));
     q_copy->fft      = FFT_CREATE_PLAN(q_copy->nfft, q_copy->buf_time, q_copy->buf_freq, FFT_DIR_FORWARD, FFT_METHOD);
 
@@ -214,8 +214,8 @@ int SPGRAM(_destroy)(SPGRAM() _q)
         return liquid_error(LIQUID_EIOBJ,"spgram%s_destroy(), invalid null pointer passed",EXTENSION);
 
     // free allocated memory
-    free(_q->buf_time);
-    free(_q->buf_freq);
+    FFT_FREE(_q->buf_time);
+    FFT_FREE(_q->buf_freq);
     free(_q->w);
     free(_q->psd);
     WINDOW(_destroy)(_q->buffer);

--- a/src/filter/src/fftfilt.proto.c
+++ b/src/filter/src/fftfilt.proto.c
@@ -72,10 +72,10 @@ FFTFILT() FFTFILT(_create)(TC *         _h,
     memmove(q->h, _h, _h_len*sizeof(TC));
 
     // allocate internal memory arrays
-    q->time_buf = (float complex *) malloc((2*q->n)* sizeof(float complex)); // time buffer
-    q->freq_buf = (float complex *) malloc((2*q->n)* sizeof(float complex)); // frequency buffer
-    q->H        = (float complex *) malloc((2*q->n)* sizeof(float complex)); // FFT{ h }
-    q->w        = (float complex *) malloc((  q->n)* sizeof(float complex)); // delay buffer
+    q->time_buf = (float complex *) FFT_MALLOC((2*q->n)* sizeof(float complex)); // time buffer
+    q->freq_buf = (float complex *) FFT_MALLOC((2*q->n)* sizeof(float complex)); // frequency buffer
+    q->H        = (float complex *) malloc((2*q->n)* sizeof(float complex));     // FFT{ h }
+    q->w        = (float complex *) malloc((  q->n)* sizeof(float complex));     // delay buffer
 
     // create internal FFT objects
     q->fft  = FFT_CREATE_PLAN(2*q->n, q->time_buf, q->freq_buf, FFT_DIR_FORWARD,  FFT_METHOD);
@@ -113,11 +113,15 @@ FFTFILT() FFTFILT(_copy)(FFTFILT() q_orig)
     // copy filter coefficients
     q_copy->h = (TC *) liquid_malloc_copy(q_orig->h, q_orig->h_len, sizeof(TC));
 
+    // allocate FFT buffers
+    q_copy->time_buf = (float complex*) FFT_MALLOC((2*q_orig->n) * sizeof(float complex));
+    q_copy->freq_buf = (float complex*) FFT_MALLOC((2*q_orig->n) * sizeof(float complex));
+
     // copy buffers
-    q_copy->time_buf = (float complex*) liquid_malloc_copy(q_orig->time_buf, 2*q_orig->n, sizeof(float complex));
-    q_copy->freq_buf = (float complex*) liquid_malloc_copy(q_orig->freq_buf, 2*q_orig->n, sizeof(float complex));
-    q_copy->H        = (float complex*) liquid_malloc_copy(q_orig->H,        2*q_orig->n, sizeof(float complex));
-    q_copy->w        = (float complex*) liquid_malloc_copy(q_orig->w,          q_orig->n, sizeof(float complex));
+    memmove(q_copy->time_buf, q_orig->time_buf, (2*q_orig->n) * sizeof(float complex));
+    memmove(q_copy->freq_buf, q_orig->freq_buf, (2*q_orig->n) * sizeof(float complex));
+    q_copy->H = (float complex*) liquid_malloc_copy(q_orig->H, 2*q_orig->n, sizeof(float complex));
+    q_copy->w = (float complex*) liquid_malloc_copy(q_orig->w,   q_orig->n, sizeof(float complex));
 
     // create internal FFT objects and return
     q_copy->fft  = FFT_CREATE_PLAN(2*q_copy->n, q_copy->time_buf, q_copy->freq_buf, FFT_DIR_FORWARD,  FFT_METHOD);
@@ -130,8 +134,8 @@ int FFTFILT(_destroy)(FFTFILT() _q)
 {
     // free internal arrays
     free(_q->h);                // filter coefficients
-    free(_q->time_buf);         // buffer (time domain)
-    free(_q->freq_buf);         // buffer (frequency domain)
+    FFT_FREE(_q->time_buf);     // buffer (time domain)
+    FFT_FREE(_q->freq_buf);     // buffer (frequency domain)
     free(_q->H);                // frequency response of filter coefficients
     free(_q->w);                // output window buffer
 

--- a/src/filter/src/firdespm_halfband.c
+++ b/src/filter/src/firdespm_halfband.c
@@ -101,8 +101,8 @@ int liquid_firdespm_halfband_ft(unsigned int _m, float _ft, float * _h)
     q.nfft = 1200;
     while (q.nfft < 20*q.m)
         q.nfft <<= 1;
-    q.buf_time = (float complex*)malloc(q.nfft*sizeof(float complex));
-    q.buf_freq = (float complex*)malloc(q.nfft*sizeof(float complex));
+    q.buf_time = (float complex*) fft_malloc(q.nfft*sizeof(float complex));
+    q.buf_freq = (float complex*) fft_malloc(q.nfft*sizeof(float complex));
     q.fft      = fft_create_plan(q.nfft, q.buf_time, q.buf_freq, LIQUID_FFT_FORWARD, 0);
 
     // compute indices of stop-band analysis
@@ -126,8 +126,8 @@ int liquid_firdespm_halfband_ft(unsigned int _m, float _ft, float * _h)
     // destroy objects
     free(q.h);
     fft_destroy_plan(q.fft);
-    free(q.buf_time);
-    free(q.buf_freq);
+    fft_free(q.buf_time);
+    fft_free(q.buf_freq);
 
     //
     return LIQUID_OK;

--- a/src/framing/src/qdetector_cccf.c
+++ b/src/framing/src/qdetector_cccf.c
@@ -98,10 +98,10 @@ qdetector_cccf qdetector_cccf_create(float complex * _s,
 
     // prepare transforms
     q->nfft       = 1 << liquid_nextpow2( (unsigned int)( 2 * q->s_len ) ); // NOTE: must be even
-    q->buf_time_0 = (float complex*) malloc(q->nfft * sizeof(float complex));
-    q->buf_freq_0 = (float complex*) malloc(q->nfft * sizeof(float complex));
-    q->buf_freq_1 = (float complex*) malloc(q->nfft * sizeof(float complex));
-    q->buf_time_1 = (float complex*) malloc(q->nfft * sizeof(float complex));
+    q->buf_time_0 = (float complex*) FFT_MALLOC(q->nfft * sizeof(float complex));
+    q->buf_freq_0 = (float complex*) FFT_MALLOC(q->nfft * sizeof(float complex));
+    q->buf_freq_1 = (float complex*) FFT_MALLOC(q->nfft * sizeof(float complex));
+    q->buf_time_1 = (float complex*) FFT_MALLOC(q->nfft * sizeof(float complex));
 
     q->fft  = FFT_CREATE_PLAN(q->nfft, q->buf_time_0, q->buf_freq_0, FFT_DIR_FORWARD,  0);
     q->ifft = FFT_CREATE_PLAN(q->nfft, q->buf_freq_1, q->buf_time_1, FFT_DIR_BACKWARD, 0);
@@ -303,12 +303,12 @@ qdetector_cccf qdetector_cccf_copy(qdetector_cccf q_orig)
 int qdetector_cccf_destroy(qdetector_cccf _q)
 {
     // free allocated arrays
-    free(_q->s         );
-    free(_q->S         );
-    free(_q->buf_time_0);
-    free(_q->buf_freq_0);
-    free(_q->buf_freq_1);
-    free(_q->buf_time_1);
+    free(_q->s);
+    free(_q->S);
+    FFT_FREE(_q->buf_time_0);
+    FFT_FREE(_q->buf_freq_0);
+    FFT_FREE(_q->buf_freq_1);
+    FFT_FREE(_q->buf_time_1);
 
     // destroy objects
     FFT_DESTROY_PLAN(_q->fft);

--- a/src/framing/src/qpilotsync.c
+++ b/src/framing/src/qpilotsync.c
@@ -95,8 +95,8 @@ qpilotsync qpilotsync_create(unsigned int _payload_len,
 
     // compute fft size and create transform objects
     q->nfft = 1 << liquid_nextpow2(q->num_pilots + (q->num_pilots>>1));
-    q->buf_time = (float complex*) malloc(q->nfft*sizeof(float complex));
-    q->buf_freq = (float complex*) malloc(q->nfft*sizeof(float complex));
+    q->buf_time = (float complex*) FFT_MALLOC(q->nfft*sizeof(float complex));
+    q->buf_freq = (float complex*) FFT_MALLOC(q->nfft*sizeof(float complex));
     q->fft      = FFT_CREATE_PLAN(q->nfft, q->buf_time, q->buf_freq, FFT_DIR_FORWARD, 0);
 
     // reset and return pointer to main object
@@ -134,8 +134,8 @@ int qpilotsync_destroy(qpilotsync _q)
 {
     // free arrays
     free(_q->pilots);
-    free(_q->buf_time);
-    free(_q->buf_freq);
+    FFT_FREE(_q->buf_time);
+    FFT_FREE(_q->buf_freq);
 
     // destroy objects
     FFT_DESTROY_PLAN(_q->fft);

--- a/src/modem/src/fskdem.c
+++ b/src/modem/src/fskdem.c
@@ -131,8 +131,8 @@ fskdem fskdem_create(unsigned int _m,
     }
 
     // allocate memory for transform
-    q->buf_time = (float complex*) malloc(q->K * sizeof(float complex));
-    q->buf_freq = (float complex*) malloc(q->K * sizeof(float complex));
+    q->buf_time = (float complex*) FFT_MALLOC(q->K * sizeof(float complex));
+    q->buf_freq = (float complex*) FFT_MALLOC(q->K * sizeof(float complex));
     q->fft = FFT_CREATE_PLAN(q->K, q->buf_time, q->buf_freq, FFT_DIR_FORWARD, 0);
 
     // reset modem object
@@ -154,9 +154,13 @@ fskdem fskdem_copy(fskdem q_orig)
     memmove(q_copy, q_orig, sizeof(struct fskdem_s));
 
     // allocate memory for transform
-    q_copy->buf_time = (float complex*) liquid_malloc_copy(q_orig->buf_time, q_copy->K, sizeof(float complex));
-    q_copy->buf_freq = (float complex*) liquid_malloc_copy(q_orig->buf_freq, q_copy->K, sizeof(float complex));
+    q_copy->buf_time = (float complex*) FFT_MALLOC(q_copy->K * sizeof(float complex));
+    q_copy->buf_freq = (float complex*) FFT_MALLOC(q_copy->K * sizeof(float complex));
     q_copy->fft = FFT_CREATE_PLAN(q_copy->K, q_copy->buf_time, q_copy->buf_freq, FFT_DIR_FORWARD, 0);
+
+    // copy internal time and frequency buffers
+    memmove(q_copy->buf_time, q_orig->buf_time, q_copy->K * sizeof(float complex));
+    memmove(q_copy->buf_freq, q_orig->buf_freq, q_copy->K * sizeof(float complex));
 
     // copy demodulation map
     q_copy->demod_map = (unsigned int*)liquid_malloc_copy(q_orig->demod_map, q_copy->M, sizeof(float complex));
@@ -170,8 +174,8 @@ int fskdem_destroy(fskdem _q)
 {
     // free allocated arrays
     free(_q->demod_map);
-    free(_q->buf_time);
-    free(_q->buf_freq);
+    FFT_FREE(_q->buf_time);
+    FFT_FREE(_q->buf_freq);
     FFT_DESTROY_PLAN(_q->fft);
 
     // free main object memory

--- a/src/multichannel/src/firpfbch.proto.c
+++ b/src/multichannel/src/firpfbch.proto.c
@@ -120,9 +120,8 @@ FIRPFBCH() FIRPFBCH(_create)(int          _type,
     }
 
     // allocate memory for buffers
-    // TODO : use fftw_malloc if HAVE_FFTW3_H
-    q->x = (T*) malloc((q->num_channels)*sizeof(T));
-    q->X = (T*) malloc((q->num_channels)*sizeof(T));
+    q->x = (T*) FFT_MALLOC((q->num_channels)*sizeof(T));
+    q->X = (T*) FFT_MALLOC((q->num_channels)*sizeof(T));
 
     // create fft plan
     if (q->type == LIQUID_ANALYZER)
@@ -260,8 +259,8 @@ int FIRPFBCH(_destroy)(FIRPFBCH() _q)
 
     // free additional arrays
     free(_q->h);
-    free(_q->x);
-    free(_q->X);
+    FFT_FREE(_q->x);
+    FFT_FREE(_q->X);
 
     // free main object memory
     free(_q);

--- a/src/multichannel/src/firpfbch2.proto.c
+++ b/src/multichannel/src/firpfbch2.proto.c
@@ -32,6 +32,8 @@
 #include <string.h>
 #include <math.h>
 
+#include "liquid.internal.h"
+
 // firpfbch2 object structure definition
 struct FIRPFBCH2(_s) {
     int          type;  // synthesis/analysis
@@ -105,9 +107,8 @@ FIRPFBCH2() FIRPFBCH2(_create)(int          _type,
     }
 
     // create FFT plan (inverse transform)
-    // TODO : use fftw_malloc if HAVE_FFTW3_H
-    q->X = (T*) malloc((q->M)*sizeof(T));   // IFFT input
-    q->x = (T*) malloc((q->M)*sizeof(T));   // IFFT output
+    q->X = (T*) FFT_MALLOC((q->M)*sizeof(T));   // IFFT input
+    q->x = (T*) FFT_MALLOC((q->M)*sizeof(T));   // IFFT output
     q->ifft = FFT_CREATE_PLAN(q->M, q->X, q->x, FFT_DIR_BACKWARD, FFT_METHOD);
 
     // create buffer objects
@@ -192,9 +193,8 @@ FIRPFBCH2() FIRPFBCH2(_copy)(FIRPFBCH2() q_orig)
         q_copy->dp[i] = DOTPROD(_copy)(q_orig->dp[i]);
 
     // create FFT plan (inverse transform)
-    // TODO : use fftw_malloc if HAVE_FFTW3_H
-    q_copy->X = (T*) malloc((q_copy->M)*sizeof(T));   // IFFT input
-    q_copy->x = (T*) malloc((q_copy->M)*sizeof(T));   // IFFT output
+    q_copy->X = (T*) FFT_MALLOC((q_copy->M)*sizeof(T));   // IFFT input
+    q_copy->x = (T*) FFT_MALLOC((q_copy->M)*sizeof(T));   // IFFT output
     q_copy->ifft = FFT_CREATE_PLAN(q_copy->M, q_copy->X, q_copy->x, FFT_DIR_BACKWARD, FFT_METHOD);
 
     // create and copy buffer objects
@@ -220,8 +220,8 @@ int FIRPFBCH2(_destroy)(FIRPFBCH2() _q)
 
     // free transform object and arrays
     FFT_DESTROY_PLAN(_q->ifft);
-    free(_q->X);
-    free(_q->x);
+    FFT_FREE(_q->X);
+    FFT_FREE(_q->x);
     
     // free window objects (buffers)
     for (i=0; i<_q->M; i++) {

--- a/src/multichannel/src/firpfbchr.proto.c
+++ b/src/multichannel/src/firpfbchr.proto.c
@@ -32,6 +32,8 @@
 #include <string.h>
 #include <math.h>
 
+#include "liquid.internal.h"
+
 // firpfbchr object structure definition
 struct FIRPFBCHR(_s) {
     unsigned int M;     // number of channels
@@ -100,9 +102,8 @@ FIRPFBCHR() FIRPFBCHR(_create)(unsigned int _chans,
     }
 
     // create FFT plan (inverse transform)
-    // TODO : use fftw_malloc if HAVE_FFTW3_H
-    q->X = (T*) malloc((q->M)*sizeof(T));   // IFFT input
-    q->x = (T*) malloc((q->M)*sizeof(T));   // IFFT output
+    q->X = (T*) FFT_MALLOC((q->M)*sizeof(T));   // IFFT input
+    q->x = (T*) FFT_MALLOC((q->M)*sizeof(T));   // IFFT output
     q->ifft = FFT_CREATE_PLAN(q->M, q->X, q->x, FFT_DIR_BACKWARD, FFT_METHOD);
 
     // create buffer objects
@@ -176,8 +177,8 @@ int FIRPFBCHR(_destroy)(FIRPFBCHR() _q)
 
     // free transform object and arrays
     FFT_DESTROY_PLAN(_q->ifft);
-    free(_q->X);
-    free(_q->x);
+    FFT_FREE(_q->X);
+    FFT_FREE(_q->x);
     
     // free window objects (buffers)
     for (i=0; i<_q->M; i++)

--- a/src/multichannel/src/ofdmframegen.c
+++ b/src/multichannel/src/ofdmframegen.c
@@ -34,10 +34,6 @@
 
 #include "liquid.internal.h"
 
-#if HAVE_FFTW3_H
-#   include <fftw3.h>
-#endif
-
 #define DEBUG_OFDMFRAMEGEN            1
 
 struct ofdmframegen_s {
@@ -125,8 +121,8 @@ ofdmframegen ofdmframegen_create(unsigned int    _M,
     unsigned int i;
 
     // allocate memory for transform objects
-    q->X = (float complex*) malloc((q->M)*sizeof(float complex));
-    q->x = (float complex*) malloc((q->M)*sizeof(float complex));
+    q->X = (float complex*) FFT_MALLOC((q->M)*sizeof(float complex));
+    q->x = (float complex*) FFT_MALLOC((q->M)*sizeof(float complex));
     q->ifft = FFT_CREATE_PLAN(q->M, q->X, q->x, FFT_DIR_BACKWARD, FFT_METHOD);
 
     // allocate memory for PLCP arrays
@@ -169,8 +165,8 @@ int ofdmframegen_destroy(ofdmframegen _q)
     free(_q->p);
 
     // free transform array memory
-    free(_q->X);
-    free(_q->x);
+    FFT_FREE(_q->X);
+    FFT_FREE(_q->x);
     FFT_DESTROY_PLAN(_q->ifft);
 
     // free tapering window and transition buffer

--- a/src/multichannel/src/ofdmframesync.c
+++ b/src/multichannel/src/ofdmframesync.c
@@ -180,8 +180,8 @@ ofdmframesync ofdmframesync_create(unsigned int           _M,
         return liquid_error_config("ofdmframesync_create(), must have at least two pilot subcarriers");
 
     // create transform object
-    q->X = (float complex*) malloc((q->M)*sizeof(float complex));
-    q->x = (float complex*) malloc((q->M)*sizeof(float complex));
+    q->X = (float complex*) FFT_MALLOC((q->M)*sizeof(float complex));
+    q->x = (float complex*) FFT_MALLOC((q->M)*sizeof(float complex));
     q->fft = FFT_CREATE_PLAN(q->M, q->x, q->X, FFT_DIR_FORWARD, FFT_METHOD);
  
     // create input buffer the length of the transform
@@ -284,8 +284,8 @@ int ofdmframesync_destroy(ofdmframesync _q)
 
     // free transform object
     windowcf_destroy(_q->input_buffer);
-    free(_q->X);
-    free(_q->x);
+    FFT_FREE(_q->X);
+    FFT_FREE(_q->x);
     FFT_DESTROY_PLAN(_q->fft);
 
     // clean up PLCP arrays


### PR DESCRIPTION
 * add fft_malloc/fft_free wrapper methods to API
 * add FFT_MALLOC/FFT_FREE macros to internal API that use FFTW's fftwf_malloc/fftwf_free aligned memory methods if HAVE_FFTW3_H and not using --enable-fftoverrride
 * use new macros inside objects that use FFTs internally