### PR TITLE
build: don't include directories in symlink targets

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -1286,8 +1286,8 @@ install: all
 	mkdir -p $(DESTDIR)$(libdir)
 	install -m 644 -p ${ARCHIVE_LIB} ${SHARED_LIB} $(DESTDIR)$(libdir)
 	install -m 644 -p include/liquid.h $(DESTDIR)$(prefix)/include/liquid/liquid.${VERSION}.h
-	ln -sf $(DESTDIR)$(libdir)/libliquid.${VERSION}.${SH_LIB} $(DESTDIR)$(libdir)/libliquid.${SH_LIB}
-	ln -sf $(DESTDIR)$(prefix)/include/liquid/liquid.${VERSION}.h $(DESTDIR)$(prefix)/include/liquid/liquid.h
+	ln -sf libliquid.${VERSION}.${SH_LIB} $(DESTDIR)$(libdir)/libliquid.${SH_LIB}
+	ln -sf liquid.${VERSION}.h $(DESTDIR)$(prefix)/include/liquid/liquid.h
 	@echo ""
 	@echo "---------------------------------------------------------"
 	@echo "  liquid-dsp was successfully installed.     "


### PR DESCRIPTION
When DESTDIR is used, the target of the symlinks is incorrect -- but the symlinks are pointing to a file in the same directory, so there's no need to include the directory at all.