### PR TITLE
Fix SONAME not set in shared library

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -47,6 +47,7 @@ VERSION		:= @PACKAGE_VERSION@
 BUGREPORT	:= @PACKAGE_BUGREPORT@
 AR_LIB		:= @AR_LIB@
 SH_LIB		:= @SH_LIB@
+SOVERSION	:= 1
 
 # paths
 prefix		:= @prefix@
@@ -1273,7 +1274,7 @@ libliquid.a : $(objects)
 	${RANLIB} $@
 
 libliquid.so : libliquid.a
-	$(CC) $(CFLAGS) $(LDFLAGS) -shared -Xlinker -soname=$@ -o $@ -Wl,-whole-archive $^ -Wl,-no-whole-archive $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -shared -Xlinker -soname=libliquid.so.$(SOVERSION) -o $@ -Wl,-whole-archive $^ -Wl,-no-whole-archive $(LIBS)
 
 # static archive and library objects
 all: ${ARCHIVE_LIB} ${SHARED_LIB}
@@ -1300,7 +1301,7 @@ install: all
 	install -m 644 -p libliquid.${SH_LIB} $(DESTDIR)$(libdir)/libliquid.${SH_LIB}.${VERSION}
 	install -m 644 -p include/liquid.h $(DESTDIR)$(prefix)/include/liquid/liquid.h
 	ln -sf libliquid.${SH_LIB}.${VERSION} $(DESTDIR)$(libdir)/libliquid.${SH_LIB}
-	ln -sf libliquid.${SH_LIB}.${VERSION} $(DESTDIR)$(libdir)/libliquid.${SH_LIB}.1
+	ln -sf libliquid.${SH_LIB}.${VERSION} $(DESTDIR)$(libdir)/libliquid.${SH_LIB}.${SOVERSION}
 	@echo ""
 	@echo "---------------------------------------------------------"
 	@echo "  liquid-dsp was successfully installed.     "
@@ -1325,7 +1326,7 @@ uninstall:
 	$(RM) $(DESTDIR)$(prefix)/include/liquid/liquid.h
 	$(RM) $(DESTDIR)$(libdir)/libliquid.${AR_LIB}
 	$(RM) $(DESTDIR)$(libdir)/libliquid.${SH_LIB}.${VERSION}
-	$(RM) $(DESTDIR)$(libdir)/libliquid.${SH_LIB}.1
+	$(RM) $(DESTDIR)$(libdir)/libliquid.${SH_LIB}.${SOVERSION}
 	$(RM) $(DESTDIR)$(libdir)/libliquid.${SH_LIB}
 	@echo "done."
 


### PR DESCRIPTION
A SONAME was introduced to libliquid and used in installation file names however the shared library was always compiled with 'libliquid.so' as the SONAME rather than 'libliquid.so.1' as was probably intended.

Fix that and introduce a SOVERSION variable to the makefile so that it is defined in a single place only.