### PR TITLE
Fix dsssframegen_getframelen

### DIFF
--- a/src/framing/src/dsssframegen.c
+++ b/src/framing/src/dsssframegen.c
@@ -253,8 +253,8 @@ int dsssframegen_set_header_props(dsssframegen _q, dsssframegenprops_s * _props)
 
 unsigned int dsssframegen_getframelen(dsssframegen _q)
 {
-    if (_q->frame_assembled) {
-        liquid_error(LIQUID_EICONFIG,"dsssframegen_get_header_props(), frame is already assembled; must reset() first");
+    if (!_q->frame_assembled) {
+        liquid_error(LIQUID_EICONFIG,"dsssframegen_getframelen(), frame not assembled!");
         return 0;
     }
 


### PR DESCRIPTION
dsssframegen_getframelen incorrectly checked for whether or not the frame is assembled, it seems to be due to a copy/paste given the error instead reports "dssframegen_get_header_props()", the changes made make it work in line with the other framegens that have the _getframelen method.