### PR TITLE
Return NULL IIR filter when filter design fails during prototype creation

### DIFF
--- a/src/filter/src/iirfilt.proto.c
+++ b/src/filter/src/iirfilt.proto.c
@@ -238,7 +238,9 @@ IIRFILT() IIRFILT(_create_prototype)(liquid_iirdes_filtertype _ftype,
     float A[h_len];
 
     // design filter (compute coefficients)
-    liquid_iirdes(_ftype, _btype, _format, _order, _fc, _f0, _ap, _as, B, A);
+    int err = liquid_iirdes(_ftype, _btype, _format, _order, _fc, _f0, _ap, _as, B, A);
+    if (err != LIQUID_OK)
+        return NULL;
 
     // move coefficients to type-specific arrays (e.g. float complex)
     TC Bc[h_len];


### PR DESCRIPTION
Failure in filter design via `liquid_iirdes` may cause the function to terminate without initialising the coefficient arrays, eg. failed input validation. Previously, usage of `liquid_iirdes` in `*_create_prototype` does not check for failure and a filter is created with the uninitialised coefficients, making it impossible to detect `liquid_iirdes`'s failure in the return value.
This change makes `*_create_prototype` return early with `NULL` if `liquid_iirdes` returns an error.