### PR TITLE
doc: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ methods for nearly all objects, improved speed, and resolves a number of
 issues and pull requests.
 
   * build
-    - added support for PlatformIO (https://platformio.org) for embeedded
+    - added support for PlatformIO (https://platformio.org) for embedded
       development (thanks, @jcw!)
     - incorporated recursive copy() methods to objects to facilitate c++ copy
       constructors for bindings; now all objects can be deep copied to a new
@@ -323,7 +323,7 @@ issues and pull requests.
       modulation, often with many samples per symbol (e.g. 256-FSK)
   * multicarrier
     - adding OFDM framing option for window tapering
-    - simplfying OFDM framing for generating preamble symbols (all
+    - simplifying OFDM framing for generating preamble symbols (all
       generated OFDM symbols are the same length)
     - adding run-time option for debugging ofdmframesync
     - adding method for initializing subcarriers with frequency range

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ processors and platforms. Packaged with liquid-dsp are a number of
 automatic test scripts to validate the correctness of the source code.
 The test scripts are located under each module's ``tests/`` directory and
 take the form of a C source file. When configured with ``BUILD_AUTOTESTS``
-enabled, these tests are parsed, compliled, and linked into an executable
+enabled, these tests are parsed, compiled, and linked into an executable
 which will run the tests.
 
 .. code-block:: bash
@@ -339,13 +339,13 @@ Finally, ``liquid-dsp`` makes extensive use of GNU
 `autoconf <https://www.gnu.org/software/autoconf/>`_,
 `automake <https://www.gnu.org/software/automake/>`_,
 and related tools.
-These are fantastic libraires with amazing functionality and their authors
+These are fantastic libraries with amazing functionality and their authors
 should be lauded for their efforts.
 In a similar vain, much the software I write for a living I give away for
 free;
 however I believe in more permissive licenses to allow individuals the
 flexibility to use software with fewer limitations.
-If these restrictions are not acceptible, ``liquid-dsp`` can be compiled and run
+If these restrictions are not acceptable, ``liquid-dsp`` can be compiled and run
 without use of these external libraries, albeit a bit slower and with limited
 functionality.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ This directory contains all the examples for interfacing the liquid modules.
 
  * `asgramf_example.c`:
     ASCII spectrogram example for real-valued input. This example demonstrates
-    the functionality of the ASCII spectrogram for real-valued input siganls.
+    the functionality of the ASCII spectrogram for real-valued input signals.
     A cosine signal with time-varying frequency is generated and the resulting
     spectral periodogram is printed to the screen. Because the time signal has
     no complex component, its spectrum is symmetric.
@@ -150,7 +150,7 @@ This directory contains all the examples for interfacing the liquid modules.
  * `eqlms_cccf_block_example.c`:
     This example tests the least mean-squares (LMS) equalizer (EQ) on a
     signal with an unknown modulation and carrier frequency offset.
-    Equalization is performed blind on a block of samples and the reulting
+    Equalization is performed blind on a block of samples and the resulting
     constellation is output to a file for plotting.
 
  * `eqlms_cccf_decisiondirected_example.c`:

--- a/examples/asgramf_example.c
+++ b/examples/asgramf_example.c
@@ -1,5 +1,5 @@
 // ASCII spectrogram example for real-valued input. This example demonstrates
-// the functionality of the ASCII spectrogram for real-valued input siganls.
+// the functionality of the ASCII spectrogram for real-valued input signals.
 // A cosine signal with time-varying frequency is generated and the resulting
 // spectral periodogram is printed to the screen. Because the time signal has
 // no complex component, its spectrum is symmetric.

--- a/examples/compand_cf_example.c
+++ b/examples/compand_cf_example.c
@@ -57,7 +57,7 @@ int main() {
 
     // close debug file
     fclose(fid);
-    printf("results wrtten to %s\n", OUTPUT_FILENAME);
+    printf("results written to %s\n", OUTPUT_FILENAME);
     printf("done.\n");
     return 0;
 }

--- a/examples/compand_example.c
+++ b/examples/compand_example.c
@@ -95,7 +95,7 @@ int main(int argc, char*argv[]) {
 
     // close debug file
     fclose(fid);
-    printf("results wrtten to %s\n", OUTPUT_FILENAME);
+    printf("results written to %s\n", OUTPUT_FILENAME);
     printf("done.\n");
     return 0;
 }

--- a/examples/cvsd_example.c
+++ b/examples/cvsd_example.c
@@ -122,7 +122,7 @@ int main(int argc, char*argv[])
 
     // close debug file
     fclose(fid);
-    printf("results wrtten to %s\n", OUTPUT_FILENAME);
+    printf("results written to %s\n", OUTPUT_FILENAME);
     printf("done.\n");
 
     return 0;

--- a/examples/eqlms_cccf_block_example.c
+++ b/examples/eqlms_cccf_block_example.c
@@ -3,7 +3,7 @@
 //
 // This example tests the least mean-squares (LMS) equalizer (EQ) on a
 // signal with an unknown modulation and carrier frequency offset.
-// Equalization is performed blind on a block of samples and the reulting
+// Equalization is performed blind on a block of samples and the resulting
 // constellation is output to a file for plotting.
 //
 

--- a/examples/modem_soft_example.c
+++ b/examples/modem_soft_example.c
@@ -1,4 +1,4 @@
-// Demonstate soft demodulation of linear modulation schemes.
+// Demonstrate soft demodulation of linear modulation schemes.
 #include <stdlib.h>
 #include <stdio.h>
 #include <getopt.h>

--- a/examples/quantize_example.c
+++ b/examples/quantize_example.c
@@ -114,7 +114,7 @@ int main(int argc, char*argv[]) {
  
     // close debug file
     fclose(fid);
-    printf("results wrtten to %s\n", OUTPUT_FILENAME);
+    printf("results written to %s\n", OUTPUT_FILENAME);
 
     printf("done.\n");
     return 0;

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -36,7 +36,7 @@ extern "C" {
 
 //
 // Make sure the version and version number macros weren't defined by
-// some prevoiusly included header file.
+// some previously included header file.
 //
 #ifdef LIQUID_VERSION
 #  undef LIQUID_VERSION
@@ -56,7 +56,7 @@ extern "C" {
 #define LIQUID_VERSION_PATCH    0
 #define LIQUID_VERSION_DEV      0
 
-// final version string is constructed by concatenating inidividual string versions
+// final version string is constructed by concatenating individual string versions
 #define LIQUID_VERSION \
     LIQUID_VERSION_STR(LIQUID_VERSION_MAJOR) "." \
     LIQUID_VERSION_STR(LIQUID_VERSION_MINOR) "." \

--- a/sandbox/fec_spc2216_test.c
+++ b/sandbox/fec_spc2216_test.c
@@ -82,7 +82,7 @@ void spc2216_unpack(unsigned char * _v,
 
 // transpose square message block (generic)
 //  _m  :   input message block [size: _n x _n bits, _n*_n/8 bytes]
-//  _n  :   matrix dimension (must be divisble by 8)
+//  _n  :   matrix dimension (must be divisible by 8)
 void spc2216_transpose_block(unsigned char * _m,
                              unsigned int    _n,
                              unsigned char * _mT);
@@ -662,7 +662,7 @@ void spc2216_transpose_col(unsigned char * _w,
 
 // transpose square message block (generic)
 //  _m  :   input message block [size: _n x _n bits, _n*_n/8 bytes]
-//  _n  :   matrix dimension (must be divisble by 8)
+//  _n  :   matrix dimension (must be divisible by 8)
 void spc2216_transpose_block(unsigned char * _m,
                              unsigned int    _n,
                              unsigned char * _mT)

--- a/src/dotprod/src/dotprod_crcf.av.c
+++ b/src/dotprod/src/dotprod_crcf.av.c
@@ -183,7 +183,7 @@ int dotprod_crcf_print(dotprod_crcf _q)
     return LIQUID_OK;
 }
 
-// exectue vectorized structured inner dot product
+// execute vectorized structured inner dot product
 int dotprod_crcf_execute(dotprod_crcf    _q,
                          float complex * _x,
                          float complex * _r)

--- a/src/equalization/src/eqlms.proto.c
+++ b/src/equalization/src/eqlms.proto.c
@@ -480,7 +480,7 @@ int EQLMS(_train)(EQLMS()      _q,
 {
     unsigned int p=_q->h_len;
     if (_n < _q->h_len) {
-        return liquid_error(LIQUID_EICONFIG,"eqlms_%s_train(), traning sequence less than filter order",
+        return liquid_error(LIQUID_EICONFIG,"eqlms_%s_train(), training sequence less than filter order",
                 EXTENSION_FULL);
     }
 

--- a/src/equalization/src/eqrls.proto.c
+++ b/src/equalization/src/eqrls.proto.c
@@ -387,7 +387,7 @@ int EQRLS(_train)(EQRLS()      _q,
 {
     unsigned int i;
     if (_n < _q->p)
-        return liquid_error(LIQUID_EIVAL,"eqrls_%s_train(), traning sequence less than filter order",EXTENSION_FULL);
+        return liquid_error(LIQUID_EIVAL,"eqrls_%s_train(), training sequence less than filter order",EXTENSION_FULL);
 
     // reset equalizer state
     EQRLS(_reset)(_q);

--- a/src/filter/src/firdespm.c
+++ b/src/filter/src/firdespm.c
@@ -828,7 +828,7 @@ int firdespm_iext_search(firdespm _q)
         }
 
         // Delete value in 'found_iext' at 'index imin'.  This
-        // is equivalent to shifing all values left one position
+        // is equivalent to shifting all values left one position
         // starting at index imin+1
         //printf("deleting found_iext[%3u] = %3u\n", imin, found_iext[imin]);
 #if 0

--- a/src/filter/src/rkaiser.c
+++ b/src/filter/src/rkaiser.c
@@ -302,7 +302,7 @@ int liquid_firdes_rkaiser_bisection(unsigned int _k,
     for (i=0; i<n; i++) e2 += _h[i]*_h[i];
     for (i=0; i<n; i++) _h[i] *= sqrtf(_k/e2);
 
-    // save trasition bandwidth adjustment
+    // save transition bandwidth adjustment
     *_rho = x_hat;
     return LIQUID_OK;
 }
@@ -438,7 +438,7 @@ int liquid_firdes_rkaiser_quadratic(unsigned int _k,
     for (i=0; i<n; i++) e2 += _h[i]*_h[i];
     for (i=0; i<n; i++) _h[i] *= sqrtf(_k/e2);
 
-    // save trasition bandwidth adjustment
+    // save transition bandwidth adjustment
     *_rho = rho_opt;
     return LIQUID_OK;
 }

--- a/src/framing/src/detector_cccf.c
+++ b/src/framing/src/detector_cccf.c
@@ -370,7 +370,7 @@ void detector_cccf_compute_dotprods(detector_cccf _q)
     printf("  rxy : ");
 #endif
     float rxy_max = 0;
-    // TODO: peridically re-compute scaling factor)
+    // TODO: periodically re-compute scaling factor)
     for (k=0; k<_q->m; k++) {
         // execute vector dot product
         dotprod_cccf_execute(_q->dp[k], r, &rxy);

--- a/src/framing/src/flexframegen.c
+++ b/src/framing/src/flexframegen.c
@@ -336,7 +336,7 @@ unsigned int flexframegen_getframelen(flexframegen _q)
     return num_frame_symbols*_q->k; // k samples/symbol
 }
 
-// exectue frame generator (create the frame)
+// execute frame generator (create the frame)
 //  _q              :   frame generator object
 //  _header         :   user-defined header
 //  _payload        :   variable payload buffer (configured by setprops method)

--- a/src/framing/tests/dsssframe64_autotest.c
+++ b/src/framing/tests/dsssframe64_autotest.c
@@ -133,7 +133,7 @@ void autotest_dsssframe64gen_copy()
 // object and it can maintain state
 void autotest_dsssframe64sync_copy()
 {
-    // create object and generte frame
+    // create object and generate frame
     dsssframe64gen fg = dsssframe64gen_create();
     unsigned int    frame_len = dsssframe64gen_get_frame_len(fg);
     float complex * frame= (float complex *)malloc(frame_len*sizeof(float complex));

--- a/src/framing/tests/qdsync_cccf_autotest.c
+++ b/src/framing/tests/qdsync_cccf_autotest.c
@@ -160,7 +160,7 @@ void autotest_qdsync_cccf_k2() { testbench_qdsync_linear(2, 7, 0.3f); }
 void autotest_qdsync_cccf_k3() { testbench_qdsync_linear(3, 7, 0.3f); }
 void autotest_qdsync_cccf_k4() { testbench_qdsync_linear(4, 7, 0.3f); }
 
-// test setting buffer length ot different sizes throughout run
+// test setting buffer length to different sizes throughout run
 void autotest_qdsync_set_buf_len()
 {
     // options

--- a/src/matrix/src/matrix.cgsolve.proto.c
+++ b/src/matrix/src/matrix.cgsolve.proto.c
@@ -137,7 +137,7 @@ int MATRIX(_cgsolve)(T *          _A,
 
         // update r
         if ( ((i+1)%50) == 0) {
-            // peridically re-compute: r = b - A*x1
+            // periodically re-compute: r = b - A*x1
             MATRIX(_mul)(_A,  _n, _n,
                          x1,  _n,  1,
                          Ax1, _n, 1);

--- a/src/multichannel/src/ofdmframegen.c
+++ b/src/multichannel/src/ofdmframegen.c
@@ -45,7 +45,7 @@ struct ofdmframegen_s {
     unsigned int cp_len;    // cyclic prefix length
     unsigned char * p;      // subcarrier allocation (null, pilot, data)
 
-    // tapering/trasition
+    // tapering/transition
     unsigned int taper_len; // number of samples in tapering window/overlap
     float * taper;          // tapering window
     float complex *postfix; // overlapping symbol buffer

--- a/src/random/tests/random_distributions_autotest.c
+++ b/src/random/tests/random_distributions_autotest.c
@@ -23,7 +23,7 @@
 #include "autotest/autotest.h"
 #include "liquid.internal.h"
 
-// compute emperical distributions and compare to theoretical
+// compute empirical distributions and compare to theoretical
 
 // add value to histogram
 unsigned int _support_histogram_add(float        _value,
@@ -42,7 +42,7 @@ unsigned int _support_histogram_add(float        _value,
     return index;
 }
 
-// noramlize histogram (area under curve)
+// normalize histogram (area under curve)
 float _support_histogram_normalize(float *      _bins,
                                    unsigned int _num_bins,
                                    float        _vmin,


### PR DESCRIPTION
Found via `codespell -q 3 -L ake,mis,nd`