### PR TITLE
cmake: fix version parsing on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,9 @@
 # cmake build file for liquid-dsp
 cmake_minimum_required(VERSION 3.10)
 
-# run custom command to parse version number from include/liquid.h
-execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/version.sh
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    OUTPUT_VARIABLE LIQUID_VERSION)
+# parse version number from include/liquid.h
+include(cmake/version.cmake)
+get_liquid_version("${CMAKE_CURRENT_SOURCE_DIR}/include/liquid.h" LIQUID_VERSION)
 
 # project definition
 project(liquid VERSION ${LIQUID_VERSION} LANGUAGES C CXX)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,0 +1,22 @@
+function(get_liquid_version HEADER_FILE OUTPUT_VAR)
+    if (NOT EXISTS "${HEADER_FILE}")
+        message(FATAL_ERROR "No ${HEADER_FILE} found!")
+    endif()
+
+    file(READ "${HEADER_FILE}" HEADER_CONTENTS)
+
+    string(REGEX MATCH "#define[ \t]+LIQUID_VERSION_MAJOR[ \t]+([0-9]+)" _ ${HEADER_CONTENTS})
+    set(VERSION_MAJOR ${CMAKE_MATCH_1})
+
+    string(REGEX MATCH "#define[ \t]+LIQUID_VERSION_MINOR[ \t]+([0-9]+)" _ ${HEADER_CONTENTS})
+    set(VERSION_MINOR ${CMAKE_MATCH_1})
+
+    string(REGEX MATCH "#define[ \t]+LIQUID_VERSION_PATCH[ \t]+([0-9]+)" _ ${HEADER_CONTENTS})
+    set(VERSION_PATCH ${CMAKE_MATCH_1})
+
+    if (VERSION_MAJOR STREQUAL "" OR VERSION_MINOR STREQUAL "" OR VERSION_PATCH STREQUAL "")
+        message(FATAL_ERROR "Could not extract version from ${HEADER_FILE}!")
+    endif()
+
+    set(${OUTPUT_VAR} "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
The method of getting the liquid version number through `version.sh` does not support Windows, which causes the `LIQUID_VERSION` to be empty, leading to an incorrect version number setting and resulting in a configuration failure.

![图片](https://github.com/user-attachments/assets/d717dbb4-e67d-463b-ad31-aa45557b3822)

<details>
<summary>Full log:</summary>

```
-- Building for: Visual Studio 17 2022
CMake Warning at CMakeLists.txt:10 (project):
  VERSION keyword not followed by a value or was followed by a value that
  expanded to nothing.


-- Selecting Windows SDK version 10.0.22621.0 to target Windows 10.0.26100.
-- The C compiler identification is MSVC 19.42.34438.0
-- The CXX compiler identification is MSVC 19.42.34438.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.42.34433/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.42.34433/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test C_HAS_SSE4_1
-- Performing Test C_HAS_SSE4_1 - Success
-- Performing Test C_HAS_AVX_1
-- Performing Test C_HAS_AVX_1 - Success
-- Performing Test C_HAS_AVX2_1
-- Performing Test C_HAS_AVX2_1 - Success
-- Performing Test C_HAS_AVX512_1
-- Performing Test C_HAS_AVX512_1 - Success
-- Performing Test C_HAS_NEON_1
-- Performing Test C_HAS_NEON_1 - Failed
-- Performing Test C_HAS_NEON_2
-- Performing Test C_HAS_NEON_2 - Failed
-- Performing Test C_HAS_NEON_3
-- Performing Test C_HAS_NEON_3 - Failed
-- Performing Test C_HAS_NEON_4
-- Performing Test C_HAS_NEON_4 - Failed
-- Performing Test C_HAS_ALTIVEC_1
-- Performing Test C_HAS_ALTIVEC_1 - Failed
-- Performing Test C_HAS_ALTIVEC_2
-- Performing Test C_HAS_ALTIVEC_2 - Failed
-- Performing Test C_HAS_ALTIVEC_3
-- Performing Test C_HAS_ALTIVEC_3 - Failed
-- Performing Test CXX_HAS_SSE4_1
-- Performing Test CXX_HAS_SSE4_1 - Success
-- Performing Test CXX_HAS_AVX_1
-- Performing Test CXX_HAS_AVX_1 - Success
-- Performing Test CXX_HAS_AVX2_1
-- Performing Test CXX_HAS_AVX2_1 - Success
-- Performing Test CXX_HAS_AVX512_1
-- Performing Test CXX_HAS_AVX512_1 - Success
-- Performing Test CXX_HAS_NEON_1
-- Performing Test CXX_HAS_NEON_1 - Failed
-- Performing Test CXX_HAS_NEON_2
-- Performing Test CXX_HAS_NEON_2 - Failed
-- Performing Test CXX_HAS_NEON_3
-- Performing Test CXX_HAS_NEON_3 - Failed
-- Performing Test CXX_HAS_NEON_4
-- Performing Test CXX_HAS_NEON_4 - Failed
-- Performing Test CXX_HAS_ALTIVEC_1
-- Performing Test CXX_HAS_ALTIVEC_1 - Failed
-- Performing Test CXX_HAS_ALTIVEC_2
-- Performing Test CXX_HAS_ALTIVEC_2 - Failed
-- Performing Test CXX_HAS_ALTIVEC_3
-- Performing Test CXX_HAS_ALTIVEC_3 - Failed
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of int
-- Check size of int - done
CMake Error at CMakeLists.txt:380 (set_target_properties):
  set_target_properties called with incorrect number of arguments.


--
-- ******************* liquid-dsp Configuration Summary *******************
-- General:
--   Version           :
--   System            :   Windows
--   C++ compiler      :   D:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/14.42.34433/bin/Hostx64/x64/cl.exe
--   Release CXX flags :   /MD /O2 /Ob2 /DNDEBUG /DWIN32 /D_WINDOWS /W3 /GR /EHsc
--   Debug CXX flags   :   /MDd /Zi /Ob0 /Od /RTC1 /DWIN32 /D_WINDOWS /W3 /GR /EHsc
--   Build type        :
--
--   BUILD_EXAMPLES    :   ON
--   BUILD_SANDBOX     :   OFF
--   BUILD_AUTOTESTS   :   ON
--   BUILD_BENCHMARKS  :   ON
--   BUILD_DOC         :   OFF
--   COVERAGE          :   OFF
--
-- Acceleration:
--   NEON              :   No
--   SSE4              :   Yes
--   AVX               :   Yes
--   AVX2              :   Yes
--   AVX512            :   Yes
--   AltiVec           :   No
--
-- Install:
--   Install path      :   C:/Program Files (x86)/liquid
--
-- Configuring incomplete, errors occurred!
```
</details>

This version uses CMake to parse the version number, supporting both Windows and Linux.
