### PR TITLE
Implement Const-Correctness in Public API

### DIFF
--- a/autotest/autotest.c
+++ b/autotest/autotest.c
@@ -374,13 +374,13 @@ int liquid_autotest_validate_psd_spgramcf(spgramcf _q,
 
 // callback function to simplify testing for framing objects
 int framing_autotest_callback(
-    unsigned char *  _header,
-    int              _header_valid,
-    unsigned char *  _payload,
-    unsigned int     _payload_len,
-    int              _payload_valid,
-    framesyncstats_s _stats,
-    void *           _context)
+    const unsigned char *  _header,
+    int                    _header_valid,
+    const unsigned char *  _payload,
+    unsigned int           _payload_len,
+    int                    _payload_valid,
+    framesyncstats_s       _stats,
+    void *                 _context)
 {
     printf("*** callback invoked (%s) ***\n", _payload_valid ? "pass" : "FAIL");
     unsigned int * secret = (unsigned int*) _context;

--- a/autotest/autotest.h
+++ b/autotest/autotest.h
@@ -323,13 +323,13 @@ int liquid_autotest_validate_psd_spgramcf(spgramcf _q,
 // callback function to simplify testing for framing objects
 #define FRAMING_AUTOTEST_SECRET 0x01234567
 int framing_autotest_callback(
-    unsigned char *  _header,
-    int              _header_valid,
-    unsigned char *  _payload,
-    unsigned int     _payload_len,
-    int              _payload_valid,
-    framesyncstats_s _stats,
-    void *           _context);
+    const unsigned char *  _header,
+    int                    _header_valid,
+    const unsigned char *  _payload,
+    unsigned int           _payload_len,
+    int                    _payload_valid,
+    framesyncstats_s       _stats,
+    void *                 _context);
 
 #endif // __LIQUID_AUTOTEST_H__
 

--- a/examples/bpacketsync_example.c
+++ b/examples/bpacketsync_example.c
@@ -10,11 +10,11 @@
 
 #include "liquid.h"
 
-int callback(unsigned char *  _payload,
-             int              _payload_valid,
-             unsigned int     _payload_len,
-             framesyncstats_s _stats,
-             void *           _userdata)
+int callback(const unsigned char *  _payload,
+             int                    _payload_valid,
+             unsigned int           _payload_len,
+             framesyncstats_s       _stats,
+             void *                 _userdata)
 {
     printf("callback invoked, payload (%u bytes) : %s\n",
             _payload_len,

--- a/examples/dsssframe64sync_example.c
+++ b/examples/dsssframe64sync_example.c
@@ -11,13 +11,13 @@
 #include "liquid.h"
 
 // static callback function
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _context)
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _context)
 {
     printf("*** callback invoked (%s) ***\n", _payload_valid ? "pass" : "FAIL");
     framesyncstats_print(&_stats);

--- a/examples/dsssframesync_example.c
+++ b/examples/dsssframesync_example.c
@@ -28,13 +28,13 @@ void usage()
 }
 
 // dsssframesync callback function
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _userdata);
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _userdata);
 
 int main(int argc, char * argv[])
 {
@@ -128,13 +128,13 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _userdata)
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _userdata)
 {
     printf("******** callback invoked\n");
 

--- a/examples/flexframesync_debug_example.c
+++ b/examples/flexframesync_debug_example.c
@@ -11,13 +11,13 @@
 #include "liquid.h"
 
 // flexframesync callback function
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _userdata)
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _userdata)
 {
     const char * filename = (const char*)_userdata;
     FILE * fid = fopen(filename,"w");

--- a/examples/flexframesync_example.c
+++ b/examples/flexframesync_example.c
@@ -43,13 +43,13 @@ void usage()
 }
 
 // flexframesync callback function
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _userdata);
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _userdata);
 
 int main(int argc, char *argv[])
 {
@@ -146,13 +146,13 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _userdata)
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _userdata)
 {
     printf("******** callback invoked\n");
 

--- a/examples/framesync64_example.c
+++ b/examples/framesync64_example.c
@@ -16,13 +16,13 @@
 #define OUTPUT_FILENAME  "framesync64_example.m"
 
 // static callback function
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _userdata)
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _userdata)
 {
     printf("*** callback invoked ***\n");
     framesyncstats_print(&_stats);

--- a/examples/fskframesync_example.c
+++ b/examples/fskframesync_example.c
@@ -25,13 +25,13 @@ void usage()
 }
 
 // static callback function
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _userdata);
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _userdata);
 
 // global arrays
 unsigned char header[8];
@@ -162,13 +162,13 @@ int main(int argc, char*argv[])
 }
 
 // static callback function
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _userdata)
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _userdata)
 {
     printf("*** callback invoked ***\n");
     printf("    error vector mag.   : %12.8f dB\n", _stats.evm);

--- a/examples/gmskframesync_example.c
+++ b/examples/gmskframesync_example.c
@@ -7,13 +7,13 @@
 #define OUTPUT_FILENAME "gmskframesync_example.m"
 
 // callback function
-int callback(unsigned char *  _header,
-             int              _header_valid,
-             unsigned char *  _payload,
-             unsigned int     _payload_len,
-             int              _payload_valid,
-             framesyncstats_s _stats,
-             void *           _userdata)
+int callback(const unsigned char *  _header,
+             int                    _header_valid,
+             const unsigned char *  _payload,
+             unsigned int           _payload_len,
+             int                    _payload_valid,
+             framesyncstats_s       _stats,
+             void *                 _userdata)
 {
     printf("***** gmskframesync callback invoked *****\n");
     return 0;

--- a/examples/gradsearch_datafit_example.c
+++ b/examples/gradsearch_datafit_example.c
@@ -22,11 +22,11 @@ struct gsdataset {
 
 // gradient search curve-fit error
 float gserror(void * _dataset,
-              float * _v,
+              const float * _v,
               unsigned int _n);
 
 // parameterized function
-float gsfunc(float _x, float * _v)
+float gsfunc(float _x, const float * _v)
 {
     float c0 = _v[0];
     float c1 = _v[1];
@@ -124,7 +124,7 @@ int main() {
 
 // gradient search fit
 float gserror(void * _dataset,
-              float * _v,
+              const float * _v,
               unsigned int _n)
 {
     struct gsdataset * p = (struct gsdataset *) _dataset;

--- a/examples/ofdmflexframesync_example.c
+++ b/examples/ofdmflexframesync_example.c
@@ -33,13 +33,13 @@ void usage()
 }
 
 // callback function
-int callback(unsigned char *  _header,
-             int              _header_valid,
-             unsigned char *  _payload,
-             unsigned int     _payload_len,
-             int              _payload_valid,
-             framesyncstats_s _stats,
-             void *           _userdata);
+int callback(const unsigned char *  _header,
+             int                    _header_valid,
+             const unsigned char *  _payload,
+             unsigned int           _payload_len,
+             int                    _payload_valid,
+             framesyncstats_s       _stats,
+             void *                 _userdata);
 
 int main(int argc, char*argv[])
 {
@@ -148,13 +148,13 @@ int main(int argc, char*argv[])
 }
 
 // callback function
-int callback(unsigned char *  _header,
-             int              _header_valid,
-             unsigned char *  _payload,
-             unsigned int     _payload_len,
-             int              _payload_valid,
-             framesyncstats_s _stats,
-             void *           _userdata)
+int callback(const unsigned char *  _header,
+             int                    _header_valid,
+             const unsigned char *  _payload,
+             unsigned int           _payload_len,
+             int                    _payload_valid,
+             framesyncstats_s       _stats,
+             void *                 _userdata)
 {
     printf("**** callback invoked : rssi = %8.3f dB, evm = %8.3f dB, cfo = %8.5f\n", _stats.rssi, _stats.evm, _stats.cfo);
 

--- a/examples/ofdmframesync_example.c
+++ b/examples/ofdmframesync_example.c
@@ -33,10 +33,10 @@ void usage()
 //  _p          : subcarrier allocation array [size: _M x 1]
 //  _M          : number of subcarriers
 //  _userdata   : user-defined data pointer
-static int callback(float complex * _X,
-                    unsigned char * _p,
-                    unsigned int    _M,
-                    void *          _userdata);
+static int callback(float complex *       _X,
+                    const unsigned char * _p,
+                    unsigned int          _M,
+                    void *                _userdata);
 
 // custom data type to pass to callback function
 struct rx_symbols {
@@ -242,10 +242,10 @@ int main(int argc, char*argv[])
 //  _p          : subcarrier allocation array [size: _M x 1]
 //  _M          : number of subcarriers
 //  _userdata   : user-defined data pointer
-static int callback(float complex * _X,
-                    unsigned char * _p,
-                    unsigned int    _M,
-                    void *          _userdata)
+static int callback(float complex *       _X,
+                    const unsigned char * _p,
+                    unsigned int          _M,
+                    void *                _userdata)
 {
     // print status to the screen
     printf("**** callback invoked\n");

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -427,7 +427,7 @@ CBUFFER() CBUFFER(_create_max)(unsigned int _max_size,                      \
                                unsigned int _max_read);                     \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
-CBUFFER() CBUFFER(_copy)(CBUFFER() _q);                                     \
+CBUFFER() CBUFFER(_copy)(const CBUFFER() _q);                               \
                                                                             \
 /* Destroy cbuffer object, freeing all internal memory                  */  \
 int CBUFFER(_destroy)(CBUFFER() _q);                                        \
@@ -467,7 +467,7 @@ int CBUFFER(_push)(CBUFFER() _q,                                            \
 /*  _v  : array of samples to write to buffer                           */  \
 /*  _n  : number of samples to write                                    */  \
 int CBUFFER(_write)(CBUFFER()    _q,                                        \
-                    T *          _v,                                        \
+                    const T *    _v,                                        \
                     unsigned int _n);                                       \
                                                                             \
 /* Remove and return a single element from the buffer by setting the    */  \
@@ -530,7 +530,7 @@ WINDOW() WINDOW(_create)(unsigned int _n);                                  \
 WINDOW() WINDOW(_recreate)(WINDOW() _q, unsigned int _n);                   \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
-WINDOW() WINDOW(_copy)(WINDOW() _q);                                        \
+WINDOW() WINDOW(_copy)(const WINDOW() _q);                                  \
                                                                             \
 /* Destroy window object, freeing all internally memory                 */  \
 int WINDOW(_destroy)(WINDOW() _q);                                          \
@@ -585,7 +585,7 @@ int WINDOW(_push)(WINDOW() _q,                                              \
 /*  _v      : input array of values to write                            */  \
 /*  _n      : number of input values to write                           */  \
 int WINDOW(_write)(WINDOW()     _q,                                         \
-                   T *          _v,                                         \
+                   const T *    _v,                                         \
                    unsigned int _n);                                        \
 
 // Define window APIs
@@ -614,7 +614,7 @@ typedef struct WDELAY(_s) * WDELAY();                                       \
 WDELAY() WDELAY(_create)(unsigned int _delay);                              \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
-WDELAY() WDELAY(_copy)(WDELAY() _q);                                        \
+WDELAY() WDELAY(_copy)(const WDELAY() _q);                                  \
                                                                             \
 /* Re-create delay buffer object, adjusting the delay size, preserving  */  \
 /* the internal state of the object                                     */  \

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -9372,9 +9372,9 @@ LIQUID_SYNTH_DEFINE_API(SYNTH_MANGLE_FLOAT, float, liquid_float_complex)
 //
 
 // utility function pointer definition
-typedef float (*utility_function)(void *       _userdata,
-                                  float *      _v,
-                                  unsigned int _n);
+typedef float (*utility_function)(void *        _userdata,
+                                  const float * _v,
+                                  unsigned int  _n);
 
 // One-dimensional utility function pointer definition
 typedef float (*liquid_utility_1d)(float  _v,
@@ -9384,33 +9384,33 @@ typedef float (*liquid_utility_1d)(float  _v,
 //  _userdata   :   user-defined data structure (convenience)
 //  _v          :   input vector, [size: _n x 1]
 //  _n          :   input vector size
-float liquid_rosenbrock(void *       _userdata,
-                        float *      _v,
-                        unsigned int _n);
+float liquid_rosenbrock(void *        _userdata,
+                        const float * _v,
+                        unsigned int  _n);
 
 // n-dimensional inverse Gauss utility function (minimum at _v = {0,0,0...}
 //  _userdata   :   user-defined data structure (convenience)
 //  _v          :   input vector, [size: _n x 1]
 //  _n          :   input vector size
-float liquid_invgauss(void *       _userdata,
-                      float *      _v,
-                      unsigned int _n);
+float liquid_invgauss(void *        _userdata,
+                      const float * _v,
+                      unsigned int  _n);
 
 // n-dimensional multimodal utility function (minimum at _v = {0,0,0...}
 //  _userdata   :   user-defined data structure (convenience)
 //  _v          :   input vector, [size: _n x 1]
 //  _n          :   input vector size
-float liquid_multimodal(void *       _userdata,
-                        float *      _v,
-                        unsigned int _n);
+float liquid_multimodal(void *        _userdata,
+                        const float * _v,
+                        unsigned int  _n);
 
 // n-dimensional spiral utility function (minimum at _v = {0,0,0...}
 //  _userdata   :   user-defined data structure (convenience)
 //  _v          :   input vector, [size: _n x 1]
 //  _n          :   input vector size
-float liquid_spiral(void *       _userdata,
-                    float *      _v,
-                    unsigned int _n);
+float liquid_spiral(void *        _userdata,
+                    const float * _v,
+                    unsigned int  _n);
 
 
 //
@@ -9515,7 +9515,7 @@ float qnsearch_execute(qnsearch _g,
 typedef struct chromosome_s * chromosome;
 
 // create a chromosome object, variable bits/trait
-chromosome chromosome_create(unsigned int * _bits_per_trait,
+chromosome chromosome_create(const unsigned int * _bits_per_trait,
                              unsigned int _num_traits);
 
 // create a chromosome object, all traits same resolution
@@ -9546,10 +9546,10 @@ int chromosome_reset(chromosome _c);
 
 // initialize chromosome on integer values
 int chromosome_init(chromosome _c,
-                     unsigned int * _v);
+                    const unsigned int * _v);
 
 // initialize chromosome on floating-point values
-int chromosome_initf(chromosome _c, float * _v);
+int chromosome_initf(chromosome _c, const float * _v);
 
 // Mutates chromosome _c at _index
 int chromosome_mutate(chromosome _c, unsigned int _index);

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -1797,7 +1797,7 @@ int SPGRAM(_push)(SPGRAM() _q,                                              \
 /*  _x  : input buffer, [size: _n x 1]                                  */  \
 /*  _n  : input buffer length                                           */  \
 int SPGRAM(_write)(SPGRAM()     _q,                                         \
-                   TI *         _x,                                         \
+                   const TI *   _x,                                         \
                    unsigned int _n);                                        \
                                                                             \
 /* Compute spectral periodogram output (fft-shifted values, linear)     */  \
@@ -1828,7 +1828,7 @@ int SPGRAM(_export_gnuplot)(SPGRAM()     _q,                                \
 /*  _n      : input signal length                                       */  \
 /*  _psd    : output spectrum, [size: _nfft x 1]                        */  \
 int SPGRAM(_estimate_psd)(unsigned int _nfft,                               \
-                          TI *         _x,                                  \
+                          const TI *   _x,                                  \
                           unsigned int _n,                                  \
                           T *          _psd);                               \
 
@@ -1908,7 +1908,7 @@ int ASGRAM(_push)(ASGRAM() _q,                                              \
 /*  _x  : input buffer, [size: _n x 1]                                  */  \
 /*  _n  : input buffer length                                           */  \
 int ASGRAM(_write)(ASGRAM()     _q,                                         \
-                   TI *         _x,                                         \
+                   const TI *   _x,                                         \
                    unsigned int _n);                                        \
                                                                             \
 /* Compute spectral periodogram output from current buffer contents     */  \
@@ -2052,7 +2052,7 @@ int SPWATERFALL(_push)(SPWATERFALL() _q,                                    \
 /*  _x  : input buffer, [size: _n x 1]                                  */  \
 /*  _n  : input buffer length                                           */  \
 int SPWATERFALL(_write)(SPWATERFALL() _q,                                   \
-                        TI *          _x,                                   \
+                        const TI *    _x,                                   \
                         unsigned int  _n);                                  \
                                                                             \
 /* Export set of files for plotting                                     */  \

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -1226,9 +1226,9 @@ unsigned int crc_get_length(crc_scheme _scheme);
 //  _scheme     :   error-detection scheme
 //  _msg        :   input data message, [size: _n x 1]
 //  _n          :   input data message size
-unsigned int crc_generate_key(crc_scheme      _scheme,
-                              unsigned char * _msg,
-                              unsigned int    _n);
+unsigned int crc_generate_key(crc_scheme            _scheme,
+                              const unsigned char * _msg,
+                              unsigned int          _n);
 
 // generate error-detection key and append to end of message
 //  _scheme     :   error-detection scheme (resulting in 'p' bytes)
@@ -1243,18 +1243,18 @@ int crc_append_key(crc_scheme      _scheme,
 //  _msg        :   input data message, [size: _n x 1]
 //  _n          :   input data message size
 //  _key        :   error-detection key
-int crc_validate_message(crc_scheme      _scheme,
-                         unsigned char * _msg,
-                         unsigned int    _n,
-                         unsigned int    _key);
+int crc_validate_message(crc_scheme            _scheme,
+                         const unsigned char * _msg,
+                         unsigned int          _n,
+                         unsigned int          _key);
 
 // check message with key appended to end of array
 //  _scheme     :   error-detection scheme (resulting in 'p' bytes)
 //  _msg        :   input data message, [size: _n+p x 1]
 //  _n          :   input data message size (excluding key at end)
-int crc_check_key(crc_scheme      _scheme,
-                  unsigned char * _msg,
-                  unsigned int    _n);
+int crc_check_key(crc_scheme            _scheme,
+                  const unsigned char * _msg,
+                  unsigned int          _n);
 
 // get size of key (bytes)
 unsigned int crc_sizeof_key(crc_scheme _scheme);
@@ -1352,30 +1352,30 @@ int fec_print(fec _q);
 //  _dec_msg_len    :   decoded message length
 //  _msg_dec        :   decoded message
 //  _msg_enc        :   encoded message
-int fec_encode(fec _q,
-               unsigned int _dec_msg_len,
-               unsigned char * _msg_dec,
-               unsigned char * _msg_enc);
+int fec_encode(fec                     _q,
+               unsigned int           _dec_msg_len,
+               const unsigned char * _msg_dec,
+               unsigned char *       _msg_enc);
 
 // decode a block of data using a fec scheme
 //  _q              :   fec object
 //  _dec_msg_len    :   decoded message length
 //  _msg_enc        :   encoded message
 //  _msg_dec        :   decoded message
-int fec_decode(fec _q,
-               unsigned int _dec_msg_len,
-               unsigned char * _msg_enc,
-               unsigned char * _msg_dec);
+int fec_decode(fec                     _q,
+               unsigned int           _dec_msg_len,
+               const unsigned char * _msg_enc,
+               unsigned char *       _msg_dec);
 
 // decode a block of data using a fec scheme (soft decision)
 //  _q              :   fec object
 //  _dec_msg_len    :   decoded message length
 //  _msg_enc        :   encoded message (soft bits)
 //  _msg_dec        :   decoded message
-int fec_decode_soft(fec _q,
-                    unsigned int _dec_msg_len,
-                    unsigned char * _msg_enc,
-                    unsigned char * _msg_dec);
+int fec_decode_soft(fec                     _q,
+                    unsigned int           _dec_msg_len,
+                    const unsigned char * _msg_enc,
+                    unsigned char *       _msg_dec);
 
 //
 // Packetizer
@@ -1504,33 +1504,33 @@ int interleaver_set_depth(interleaver  _q,
 //  _q          :   interleaver object
 //  _msg_dec    :   decoded (un-interleaved) message
 //  _msg_enc    :   encoded (interleaved) message
-int interleaver_encode(interleaver     _q,
-                       unsigned char * _msg_dec,
-                       unsigned char * _msg_enc);
+int interleaver_encode(interleaver           _q,
+                       const unsigned char * _msg_dec,
+                       unsigned char *       _msg_enc);
 
 // execute forward interleaver (encoder) on soft bits
 //  _q          :   interleaver object
 //  _msg_dec    :   decoded (un-interleaved) message
 //  _msg_enc    :   encoded (interleaved) message
-int interleaver_encode_soft(interleaver     _q,
-                            unsigned char * _msg_dec,
-                            unsigned char * _msg_enc);
+int interleaver_encode_soft(interleaver           _q,
+                            const unsigned char * _msg_dec,
+                            unsigned char *       _msg_enc);
 
 // execute reverse interleaver (decoder)
 //  _q          :   interleaver object
 //  _msg_enc    :   encoded (interleaved) message
 //  _msg_dec    :   decoded (un-interleaved) message
-int interleaver_decode(interleaver     _q,
-                       unsigned char * _msg_enc,
-                       unsigned char * _msg_dec);
+int interleaver_decode(interleaver           _q,
+                       const unsigned char * _msg_enc,
+                       unsigned char *       _msg_dec);
 
 // execute reverse interleaver (decoder) on soft bits
 //  _q          :   interleaver object
 //  _msg_enc    :   encoded (interleaved) message
 //  _msg_dec    :   decoded (un-interleaved) message
-int interleaver_decode_soft(interleaver     _q,
-                            unsigned char * _msg_enc,
-                            unsigned char * _msg_dec);
+int interleaver_decode_soft(interleaver           _q,
+                            const unsigned char * _msg_enc,
+                            unsigned char *       _msg_dec);
 
 
 

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -9826,8 +9826,8 @@ int bsequence_destroy(bsequence _bs);
 int bsequence_reset(bsequence _bs);
 
 // initialize sequence on external array
-int bsequence_init(bsequence       _bs,
-                   unsigned char * _v);
+int bsequence_init(bsequence             _bs,
+                   const unsigned char * _v);
 
 // Print sequence to the screen
 int bsequence_print(bsequence _bs);

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -530,7 +530,7 @@ WINDOW() WINDOW(_create)(unsigned int _n);                                  \
 WINDOW() WINDOW(_recreate)(WINDOW() _q, unsigned int _n);                   \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
-WINDOW() WINDOW(_copy)(const WINDOW() _q);                                  \
+WINDOW() WINDOW(_copy)(WINDOW() _q);                                        \
                                                                             \
 /* Destroy window object, freeing all internally memory                 */  \
 int WINDOW(_destroy)(WINDOW() _q);                                          \
@@ -614,7 +614,7 @@ typedef struct WDELAY(_s) * WDELAY();                                       \
 WDELAY() WDELAY(_create)(unsigned int _delay);                              \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
-WDELAY() WDELAY(_copy)(const WDELAY() _q);                                  \
+WDELAY() WDELAY(_copy)(WDELAY() _q);                                        \
                                                                             \
 /* Re-create delay buffer object, adjusting the delay size, preserving  */  \
 /* the internal state of the object                                     */  \

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -7335,7 +7335,7 @@ int   kbd_window(unsigned int _wlen,float _beta,float * _w);
 /*  _p      : polynomial coefficients, [size: _k x 1]                   */  \
 /*  _k      : polynomial coefficients length, order is _k - 1           */  \
 /*  _x      : input to evaluate polynomial                              */  \
-T POLY(_val)(T *          _p,                                               \
+T POLY(_val)(const T *    _p,                                               \
              unsigned int _k,                                               \
              T            _x);                                              \
                                                                             \
@@ -7345,8 +7345,8 @@ T POLY(_val)(T *          _p,                                               \
 /*  _n      : number of samples in _x and _y                            */  \
 /*  _p      : polynomial coefficients output, [size: _k x 1]            */  \
 /*  _k      : polynomial coefficients length, order is _k - 1           */  \
-int POLY(_fit)(T *          _x,                                             \
-               T *          _y,                                             \
+int POLY(_fit)(const T *    _x,                                             \
+               const T *    _y,                                             \
                unsigned int _n,                                             \
                T *          _p,                                             \
                unsigned int _k);                                            \
@@ -7356,8 +7356,8 @@ int POLY(_fit)(T *          _x,                                             \
 /*  _y      : y-value sample set, size [_n x 1]                         */  \
 /*  _n      : number of samples in _x and _y                            */  \
 /*  _p      : polynomial coefficients output, [size: _n x 1]            */  \
-int POLY(_fit_lagrange)(T *          _x,                                    \
-                        T *          _y,                                    \
+int POLY(_fit_lagrange)(const T *    _x,                                    \
+                        const T *    _y,                                    \
                         unsigned int _n,                                    \
                         T *          _p);                                   \
                                                                             \
@@ -7367,8 +7367,8 @@ int POLY(_fit_lagrange)(T *          _x,                                    \
 /*  _y      : y-value sample set, [size: _n x 1]                        */  \
 /*  _n      : number of samples in _x and _y                            */  \
 /*  _x0     : x-value to evaluate and compute interpolant               */  \
-T POLY(_interp_lagrange)(T *          _x,                                   \
-                         T *          _y,                                   \
+T POLY(_interp_lagrange)(const T *    _x,                                   \
+                         const T *    _y,                                   \
                          unsigned int _n,                                   \
                          T           _x0);                                  \
                                                                             \
@@ -7376,7 +7376,7 @@ T POLY(_interp_lagrange)(T *          _x,                                   \
 /*  _x      : x-value sample set, size [_n x 1]                         */  \
 /*  _n      : number of samples in _x                                   */  \
 /*  _w      : barycentric weights normalized so _w[0]=1, size [_n x 1]  */  \
-int POLY(_fit_lagrange_barycentric)(T *          _x,                        \
+int POLY(_fit_lagrange_barycentric)(const T *    _x,                        \
                                     unsigned int _n,                        \
                                     T *          _w);                       \
                                                                             \
@@ -7387,9 +7387,9 @@ int POLY(_fit_lagrange_barycentric)(T *          _x,                        \
 /*  _w      : barycentric weights, [size: _n x 1]                       */  \
 /*  _x0     : x-value to evaluate and compute interpolant               */  \
 /*  _n      : number of samples in _x, _y, and _w                       */  \
-T POLY(_val_lagrange_barycentric)(T *          _x,                          \
-                                  T *          _y,                          \
-                                  T *          _w,                          \
+T POLY(_val_lagrange_barycentric)(const T *    _x,                          \
+                                  const T *    _y,                          \
+                                  const T *    _w,                          \
                                   T            _x0,                         \
                                   unsigned int _n);                         \
                                                                             \
@@ -7424,7 +7424,7 @@ int POLY(_expandbinomial_pm)(unsigned int _m,                               \
 /*  _r      : roots of polynomial, [size: _n x 1]                       */  \
 /*  _n      : number of roots in polynomial                             */  \
 /*  _p      : polynomial coefficients, [size: _n+1 x 1]                 */  \
-int POLY(_expandroots)(T *          _r,                                     \
+int POLY(_expandroots)(const T *    _r,                                     \
                        unsigned int _n,                                     \
                        T *          _p);                                    \
                                                                             \
@@ -7437,8 +7437,8 @@ int POLY(_expandroots)(T *          _r,                                     \
 /*  _b      : multiplicant of polynomial roots, [size: _n x 1]          */  \
 /*  _n      : number of roots in polynomial                             */  \
 /*  _p      : polynomial coefficients, [size: _n+1 x 1]                 */  \
-int POLY(_expandroots2)(T *          _a,                                    \
-                        T *          _b,                                    \
+int POLY(_expandroots2)(const T *    _a,                                    \
+                        const T *    _b,                                    \
                         unsigned int _n,                                    \
                         T *          _p);                                   \
                                                                             \
@@ -7446,7 +7446,7 @@ int POLY(_expandroots2)(T *          _a,                                    \
 /*  _p      : polynomial coefficients, [size: _n x 1]                   */  \
 /*  _k      : polynomial length                                         */  \
 /*  _roots  : resulting complex roots, [size: _k-1 x 1]                 */  \
-int POLY(_findroots)(T *          _poly,                                    \
+int POLY(_findroots)(const T *    _poly,                                    \
                      unsigned int _n,                                       \
                      TC *         _roots);                                  \
                                                                             \
@@ -7455,7 +7455,7 @@ int POLY(_findroots)(T *          _poly,                                    \
 /*  _p      : polynomial coefficients, [size: _n x 1]                   */  \
 /*  _k      : polynomial length                                         */  \
 /*  _roots  : resulting complex roots, [size: _k-1 x 1]                 */  \
-int POLY(_findroots_durandkerner)(T *          _p,                          \
+int POLY(_findroots_durandkerner)(const T *    _p,                          \
                                   unsigned int _k,                          \
                                   TC *         _roots);                     \
                                                                             \
@@ -7463,7 +7463,7 @@ int POLY(_findroots_durandkerner)(T *          _p,                          \
 /*  _p      : polynomial coefficients, [size: _n x 1]                   */  \
 /*  _k      : polynomial length                                         */  \
 /*  _roots  : resulting complex roots, [size: _k-1 x 1]                 */  \
-int POLY(_findroots_bairstow)(T *          _p,                              \
+int POLY(_findroots_bairstow)(const T *    _p,                              \
                               unsigned int _k,                              \
                               TC *         _roots);                         \
                                                                             \
@@ -7478,9 +7478,9 @@ int POLY(_findroots_bairstow)(T *          _p,                              \
 /*  _b          : 2nd polynomial coefficients (length is _order_b+1)    */  \
 /*  _order_b    : 2nd polynomial order                                  */  \
 /*  _c          : output polynomial, [size: _order_a+_order_b+1 x 1]    */  \
-int POLY(_mul)(T *          _a,                                             \
+int POLY(_mul)(const T *    _a,                                             \
                unsigned int _order_a,                                       \
-               T *          _b,                                             \
+               const T *    _b,                                             \
                unsigned int _order_b,                                       \
                T *          _c);                                            \
 

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -2176,14 +2176,14 @@ typedef enum {
 //  _wtype      :   weight types (e.g. LIQUID_FIRDESPM_FLATWEIGHT) [size: _num_bands x 1]
 //  _btype      :   band type (e.g. LIQUID_FIRDESPM_BANDPASS)
 //  _h          :   output coefficients array, [size: _h_len x 1]
-int firdespm_run(unsigned int            _h_len,
-                 unsigned int            _num_bands,
-                 float *                 _bands,
-                 float *                 _des,
-                 float *                 _weights,
-                 liquid_firdespm_wtype * _wtype,
-                 liquid_firdespm_btype   _btype,
-                 float *                 _h);
+int firdespm_run(unsigned int                  _h_len,
+                 unsigned int                  _num_bands,
+                 const float *                 _bands,
+                 const float *                 _des,
+                 const float *                 _weights,
+                 const liquid_firdespm_wtype * _wtype,
+                 liquid_firdespm_btype         _btype,
+                 float *                       _h);
 
 // run filter design for basic low-pass filter
 //  _n      : filter length, _n > 0
@@ -2218,13 +2218,13 @@ typedef struct firdespm_s * firdespm;
 //  _weights    :   response weighting, [size: _num_bands x 1]
 //  _wtype      :   weight types (e.g. LIQUID_FIRDESPM_FLATWEIGHT) [size: _num_bands x 1]
 //  _btype      :   band type (e.g. LIQUID_FIRDESPM_BANDPASS)
-firdespm firdespm_create(unsigned int            _h_len,
-                         unsigned int            _num_bands,
-                         float *                 _bands,
-                         float *                 _des,
-                         float *                 _weights,
-                         liquid_firdespm_wtype * _wtype,
-                         liquid_firdespm_btype   _btype);
+firdespm firdespm_create(unsigned int                  _h_len,
+                         unsigned int                  _num_bands,
+                         const float *                 _bands,
+                         const float *                 _des,
+                         const float *                 _weights,
+                         const liquid_firdespm_wtype * _wtype,
+                         liquid_firdespm_btype         _btype);
 
 // create firdespm object with user-defined callback
 //  _h_len      :   length of filter (number of taps)
@@ -2235,7 +2235,7 @@ firdespm firdespm_create(unsigned int            _h_len,
 //  _userdata   :   user-defined data structure for callback function
 firdespm firdespm_create_callback(unsigned int          _h_len,
                                   unsigned int          _num_bands,
-                                  float *               _bands,
+                                  const float *         _bands,
                                   liquid_firdespm_btype _btype,
                                   firdespm_callback     _callback,
                                   void *                _userdata);
@@ -2361,7 +2361,7 @@ int liquid_firdes_rfarcsech(unsigned int _k, unsigned int _m, float _beta, float
 //  _h      : filter coefficients array
 //  _n      : filter length
 //  _fc     : frequency at which delay is evaluated (-0.5 < _fc < 0.5)
-float fir_group_delay(float * _h,
+float fir_group_delay(const float * _h,
                       unsigned int _n,
                       float _fc);
 
@@ -2371,9 +2371,9 @@ float fir_group_delay(float * _h,
 //  _a      : filter denominator coefficients
 //  _na     : filter denominator length
 //  _fc     : frequency at which delay is evaluated (-0.5 < _fc < 0.5)
-float iir_group_delay(float * _b,
+float iir_group_delay(const float * _b,
                       unsigned int _nb,
-                      float * _a,
+                      const float * _a,
                       unsigned int _na,
                       float _fc);
 
@@ -2385,9 +2385,9 @@ float iir_group_delay(float * _b,
 //  _h      :   filter coefficients, [size: _h_len x 1]
 //  _h_len  :   filter length
 //  _lag    :   auto-correlation lag (samples)
-float liquid_filter_autocorr(float *      _h,
-                             unsigned int _h_len,
-                             int          _lag);
+float liquid_filter_autocorr(const float * _h,
+                             unsigned int  _h_len,
+                             int           _lag);
 
 // liquid_filter_crosscorr()
 //
@@ -2398,11 +2398,11 @@ float liquid_filter_autocorr(float *      _h,
 //  _g      :   filter coefficients, [size: _g_len]
 //  _g_len  :   filter length
 //  _lag    :   cross-correlation lag (samples)
-float liquid_filter_crosscorr(float *      _h,
-                              unsigned int _h_len,
-                              float *      _g,
-                              unsigned int _g_len,
-                              int          _lag);
+float liquid_filter_crosscorr(const float * _h,
+                              unsigned int  _h_len,
+                              const float * _g,
+                              unsigned int  _g_len,
+                              int           _lag);
 
 // liquid_filter_isi()
 //
@@ -2414,11 +2414,11 @@ float liquid_filter_crosscorr(float *      _h,
 //  _m      :   filter delay (symbols)
 //  _rms    :   output root mean-squared ISI
 //  _max    :   maximum ISI
-void liquid_filter_isi(float *      _h,
-                       unsigned int _k,
-                       unsigned int _m,
-                       float *      _rms,
-                       float *      _max);
+void liquid_filter_isi(const float * _h,
+                       unsigned int  _k,
+                       unsigned int  _m,
+                       float *       _rms,
+                       float *       _max);
 
 // Compute relative out-of-band energy
 //
@@ -2426,10 +2426,10 @@ void liquid_filter_isi(float *      _h,
 //  _h_len  :   filter length
 //  _fc     :   analysis cut-off frequency
 //  _nfft   :   fft size
-float liquid_filter_energy(float *      _h,
-                           unsigned int _h_len,
-                           float        _fc,
-                           unsigned int _nfft);
+float liquid_filter_energy(const float * _h,
+                           unsigned int  _h_len,
+                           float         _fc,
+                           unsigned int  _nfft);
 
 // Get static frequency response from filter coefficients at particular
 // frequency with real-valued coefficients
@@ -2437,7 +2437,7 @@ float liquid_filter_energy(float *      _h,
 //  _h_len  : length of coefficients array
 //  _fc     : center frequency for analysis, -0.5 <= _fc <= 0.5
 //  _H      : pointer to output value
-int liquid_freqrespf(float *                _h,
+int liquid_freqrespf(const float *          _h,
                      unsigned int           _h_len,
                      float                  _fc,
                      liquid_float_complex * _H);
@@ -2448,10 +2448,10 @@ int liquid_freqrespf(float *                _h,
 //  _h_len  : length of coefficients array
 //  _fc     : center frequency for analysis, -0.5 <= _fc <= 0.5
 //  _H      : pointer to output value
-int liquid_freqrespcf(liquid_float_complex * _h,
-                      unsigned int           _h_len,
-                      float                  _fc,
-                      liquid_float_complex * _H);
+int liquid_freqrespcf(const liquid_float_complex * _h,
+                      unsigned int                 _h_len,
+                      float                        _fc,
+                      liquid_float_complex *       _H);
 
 
 //
@@ -2543,15 +2543,15 @@ float iirdes_freqprewarp(liquid_iirdes_bandtype _btype,
 //  _zd     :   output digital zeros [length: _npa]
 //  _pd     :   output digital poles [length: _npa]
 //  _kd     :   output digital gain (should actually be real-valued)
-int bilinear_zpkf(liquid_float_complex * _za,
-                  unsigned int           _nza,
-                  liquid_float_complex * _pa,
-                  unsigned int           _npa,
-                  liquid_float_complex   _ka,
-                  float                  _m,
-                  liquid_float_complex * _zd,
-                  liquid_float_complex * _pd,
-                  liquid_float_complex * _kd);
+int bilinear_zpkf(const liquid_float_complex * _za,
+                  unsigned int                 _nza,
+                  const liquid_float_complex * _pa,
+                  unsigned int                 _npa,
+                  liquid_float_complex         _ka,
+                  float                        _m,
+                  liquid_float_complex *       _zd,
+                  liquid_float_complex *       _pd,
+                  liquid_float_complex *       _kd);
 
 // compute bilinear z-transform using polynomial expansion in numerator and
 // denominator
@@ -2573,13 +2573,13 @@ int bilinear_zpkf(liquid_float_complex * _za,
 //  _m          : bilateral warping factor
 //  _bd         : output digital filter numerator, [size: _b_order+1]
 //  _ad         : output digital filter numerator, [size: _a_order+1]
-int bilinear_nd(liquid_float_complex * _b,
-                unsigned int           _b_order,
-                liquid_float_complex * _a,
-                unsigned int           _a_order,
-                float                  _m,
-                liquid_float_complex * _bd,
-                liquid_float_complex * _ad);
+int bilinear_nd(const liquid_float_complex * _b,
+                unsigned int                 _b_order,
+                const liquid_float_complex * _a,
+                unsigned int                 _a_order,
+                float                        _m,
+                liquid_float_complex *       _bd,
+                liquid_float_complex *       _ad);
 
 // digital z/p/k low-pass to high-pass
 //  _zd     :   digital zeros (low-pass prototype), [length: _n]
@@ -2587,11 +2587,11 @@ int bilinear_nd(liquid_float_complex * _b,
 //  _n      :   low-pass filter order
 //  _zdt    :   output digital zeros transformed [length: _n]
 //  _pdt    :   output digital poles transformed [length: _n]
-int iirdes_dzpk_lp2hp(liquid_float_complex * _zd,
-                      liquid_float_complex * _pd,
-                      unsigned int _n,
-                      liquid_float_complex * _zdt,
-                      liquid_float_complex * _pdt);
+int iirdes_dzpk_lp2hp(const liquid_float_complex * _zd,
+                      const liquid_float_complex * _pd,
+                      unsigned int                 _n,
+                      liquid_float_complex *       _zdt,
+                      liquid_float_complex *       _pdt);
 
 // digital z/p/k low-pass to band-pass
 //  _zd     :   digital zeros (low-pass prototype), [length: _n]
@@ -2600,12 +2600,12 @@ int iirdes_dzpk_lp2hp(liquid_float_complex * _zd,
 //  _f0     :   center frequency
 //  _zdt    :   output digital zeros transformed [length: 2*_n]
 //  _pdt    :   output digital poles transformed [length: 2*_n]
-int iirdes_dzpk_lp2bp(liquid_float_complex * _zd,
-                      liquid_float_complex * _pd,
-                      unsigned int           _n,
-                      float                  _f0,
-                      liquid_float_complex * _zdt,
-                      liquid_float_complex * _pdt);
+int iirdes_dzpk_lp2bp(const liquid_float_complex * _zd,
+                      const liquid_float_complex * _pd,
+                      unsigned int                 _n,
+                      float                        _f0,
+                      liquid_float_complex *       _zdt,
+                      liquid_float_complex *       _pdt);
 
 // convert discrete z/p/k form to transfer function
 //  _zd     :   digital zeros [length: _n]
@@ -2614,12 +2614,12 @@ int iirdes_dzpk_lp2bp(liquid_float_complex * _zd,
 //  _kd     :   digital gain
 //  _b      :   output numerator [length: _n+1]
 //  _a      :   output denominator [length: _n+1]
-int iirdes_dzpk2tff(liquid_float_complex * _zd,
-                    liquid_float_complex * _pd,
-                    unsigned int           _n,
-                    liquid_float_complex   _kd,
-                    float *                _b,
-                    float *                _a);
+int iirdes_dzpk2tff(const liquid_float_complex * _zd,
+                    const liquid_float_complex * _pd,
+                    unsigned int                 _n,
+                    liquid_float_complex         _kd,
+                    float *                      _b,
+                    float *                      _a);
 
 // convert discrete z/p/k form to second-order sections
 //  _zd     :   digital zeros [length: _n]
@@ -2629,12 +2629,12 @@ int iirdes_dzpk2tff(liquid_float_complex * _zd,
 //  _b      :   output numerator, [size: 3 x L+r]
 //  _a      :   output denominator, [size: 3 x L+r]
 //  where r = _n%2, L = (_n-r)/2
-int iirdes_dzpk2sosf(liquid_float_complex * _zd,
-                     liquid_float_complex * _pd,
-                     unsigned int           _n,
-                     liquid_float_complex   _kd,
-                     float *                _b,
-                     float *                _a);
+int iirdes_dzpk2sosf(const liquid_float_complex * _zd,
+                     const liquid_float_complex * _pd,
+                     unsigned int                 _n,
+                     liquid_float_complex         _kd,
+                     float *                      _b,
+                     float *                      _a);
 
 // additional IIR filter design templates
 
@@ -2674,8 +2674,8 @@ void iirdes_pll_active_PI(float _w,
 //  _b      :   feed-forward coefficients, [size: _n x 1]
 //  _a      :   feed-back coefficients, [size: _n x 1]
 //  _n      :   number of coefficients
-int iirdes_isstable(float * _b,
-                    float * _a,
+int iirdes_isstable(const float * _b,
+                    const float * _a,
                     unsigned int _n);
 
 //
@@ -2688,7 +2688,7 @@ int iirdes_isstable(float * _b,
 //  _p      :   prediction filter order
 //  _a      :   prediction filter, [size: _p+1 x 1]
 //  _e      :   prediction error variance, [size: _p+1 x 1]
-void liquid_lpc(float * _x,
+void liquid_lpc(const float * _x,
                 unsigned int _n,
                 unsigned int _p,
                 float * _a,
@@ -2703,7 +2703,7 @@ void liquid_lpc(float * _x,
 //
 // NOTES:
 //  By definition _a[0] = 1.0
-void liquid_levinson(float * _r,
+void liquid_levinson(const float * _r,
                      unsigned int _p,
                      float * _a,
                      float * _e);
@@ -2752,7 +2752,7 @@ int AUTOCORR(_push)(AUTOCORR() _q,                                          \
 /*  _x      :   input array, [size: _n x 1]                             */  \
 /*  _n      :   number of input samples                                 */  \
 int AUTOCORR(_write)(AUTOCORR()   _q,                                       \
-                     TI *         _x,                                       \
+                     const TI *   _x,                                       \
                      unsigned int _n);                                      \
                                                                             \
 /* Compute single auto-correlation output                               */  \
@@ -2768,7 +2768,7 @@ int AUTOCORR(_execute)(AUTOCORR() _q,                                       \
 /*  _n      :   number of input, output samples                         */  \
 /*  _rxx    :   input array, [size: _n x 1]                             */  \
 int AUTOCORR(_execute_block)(AUTOCORR()   _q,                               \
-                             TI *         _x,                               \
+                             const TI *   _x,                               \
                              unsigned int _n,                               \
                              TO *         _rxx);                            \
                                                                             \
@@ -2808,7 +2808,7 @@ typedef struct FIRFILT(_s) * FIRFILT();                                     \
 /* specifying the filter coefficients in an array                       */  \
 /*  _h      : filter coefficients, [size: _n x 1]                       */  \
 /*  _n      : number of filter coefficients, _n > 0                     */  \
-FIRFILT() FIRFILT(_create)(TC *         _h,                                 \
+FIRFILT() FIRFILT(_create)(const TC *   _h,                                 \
                            unsigned int _n);                                \
                                                                             \
 /* Create object using Kaiser-Bessel windowed sinc method               */  \
@@ -2869,7 +2869,7 @@ FIRFILT() FIRFILT(_create_notch)(unsigned int _m,                           \
 /*  _h      : pointer to filter coefficients, [size: _n x 1]            */  \
 /*  _n      : filter length, _n > 0                                     */  \
 FIRFILT() FIRFILT(_recreate)(FIRFILT()    _q,                               \
-                             TC *         _h,                               \
+                             const TC *   _h,                               \
                              unsigned int _n);                              \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
@@ -2907,7 +2907,7 @@ int FIRFILT(_push)(FIRFILT() _q,                                            \
 /*  _x      : buffer of input samples, [size: _n x 1]                   */  \
 /*  _n      : number of input samples                                   */  \
 int FIRFILT(_write)(FIRFILT()    _q,                                        \
-                    TI *         _x,                                        \
+                    const TI *   _x,                                        \
                     unsigned int _n);                                       \
                                                                             \
 /* Execute vector dot product on the filter's internal buffer and       */  \
@@ -2932,7 +2932,7 @@ int FIRFILT(_execute_one)(FIRFILT() _q,                                     \
 /*  _n      : number of input, output samples                           */  \
 /*  _y      : pointer to output array, [size: _n x 1]                   */  \
 int FIRFILT(_execute_block)(FIRFILT()    _q,                                \
-                            TI *         _x,                                \
+                            const TI *   _x,                                \
                             unsigned int _n,                                \
                             TO *         _y);                               \
                                                                             \
@@ -3033,7 +3033,7 @@ int FDELAY(_push)(FDELAY() _q,                                              \
 /*  _x      : buffer of input samples, [size: _n x 1]                   */  \
 /*  _n      : number of input samples                                   */  \
 int FDELAY(_write)(FDELAY()     _q,                                         \
-                   TI *         _x,                                         \
+                   const TI *   _x,                                         \
                    unsigned int _n);                                        \
                                                                             \
 /* Execute vector dot product on the filter's internal buffer and       */  \
@@ -3050,7 +3050,7 @@ int FDELAY(_execute)(FDELAY() _q,                                           \
 /*  _n      : number of input, output samples                           */  \
 /*  _y      : pointer to output array, [size: _n x 1]                   */  \
 int FDELAY(_execute_block)(FDELAY()     _q,                                 \
-                           TI *         _x,                                 \
+                           const TI *   _x,                                 \
                            unsigned int _n,                                 \
                            TO *         _y);                                \
 
@@ -3127,7 +3127,7 @@ int FIRHILB(_c2r_execute)(FIRHILB() _q,                                     \
 /*  _x      :   real-valued input array, [size: 2 x 1]                  */  \
 /*  _y      :   complex-valued output sample                            */  \
 int FIRHILB(_decim_execute)(FIRHILB() _q,                                   \
-                            T *       _x,                                   \
+                            const T * _x,                                   \
                             TC *      _y);                                  \
                                                                             \
 /* Execute Hilbert transform decimator (real to complex) on a block of  */  \
@@ -3137,7 +3137,7 @@ int FIRHILB(_decim_execute)(FIRHILB() _q,                                   \
 /*  _n      :   number of output samples                                */  \
 /*  _y      :   complex-valued output array, [size: _n x 1]             */  \
 int FIRHILB(_decim_execute_block)(FIRHILB()    _q,                          \
-                                  T *          _x,                          \
+                                  const T *    _x,                          \
                                   unsigned int _n,                          \
                                   TC *         _y);                         \
                                                                             \
@@ -3156,7 +3156,7 @@ int FIRHILB(_interp_execute)(FIRHILB() _q,                                  \
 /*  _n      :   number of *input* samples                               */  \
 /*  _y      :   real-valued output array, [size: 2*_n x 1]              */  \
 int FIRHILB(_interp_execute_block)(FIRHILB()    _q,                         \
-                                   TC *         _x,                         \
+                                   const TC *   _x,                         \
                                    unsigned int _n,                         \
                                    T *          _y);                        \
 
@@ -3223,7 +3223,7 @@ int IIRHILB(_r2c_execute)(IIRHILB() _q,                                     \
 /*  _n      : number of input,output samples                            */  \
 /*  _y      : complex-valued output sample array, [size: _n x 1]        */  \
 int IIRHILB(_r2c_execute_block)(IIRHILB()    _q,                            \
-                                T *          _x,                            \
+                                const T *    _x,                            \
                                 unsigned int _n,                            \
                                 TC *         _y);                           \
                                                                             \
@@ -3241,7 +3241,7 @@ int IIRHILB(_c2r_execute)(IIRHILB() _q,                                     \
 /*  _n      : number of input,output samples                            */  \
 /*  _y      : real-valued output sample array, [size: _n x 1]           */  \
 int IIRHILB(_c2r_execute_block)(IIRHILB()    _q,                            \
-                                TC *         _x,                            \
+                                const TC *   _x,                            \
                                 unsigned int _n,                            \
                                 T *          _y);                           \
                                                                             \
@@ -3250,7 +3250,7 @@ int IIRHILB(_c2r_execute_block)(IIRHILB()    _q,                            \
 /*  _x      : real-valued input array, [size: 2 x 1]                    */  \
 /*  _y      : complex-valued output sample                              */  \
 int IIRHILB(_decim_execute)(IIRHILB() _q,                                   \
-                            T *       _x,                                   \
+                            const T * _x,                                   \
                             TC *      _y);                                  \
                                                                             \
 /* Execute Hilbert transform decimator (real to complex) on a block of  */  \
@@ -3260,7 +3260,7 @@ int IIRHILB(_decim_execute)(IIRHILB() _q,                                   \
 /*  _n      : number of output samples                                  */  \
 /*  _y      : complex-valued output array, [size: _n x 1]               */  \
 int IIRHILB(_decim_execute_block)(IIRHILB()    _q,                          \
-                                  T *          _x,                          \
+                                  const T *    _x,                          \
                                   unsigned int _n,                          \
                                   TC *         _y);                         \
                                                                             \
@@ -3279,7 +3279,7 @@ int IIRHILB(_interp_execute)(IIRHILB() _q,                                  \
 /*  _n      : number of *input* samples                                 */  \
 /*  _y      : real-valued output array, [size: 2*_n x 1]                */  \
 int IIRHILB(_interp_execute_block)(IIRHILB()    _q,                         \
-                                   TC *         _x,                         \
+                                   const TC *   _x,                         \
                                    unsigned int _n,                         \
                                    T *          _y);                        \
 
@@ -3309,7 +3309,7 @@ typedef struct FFTFILT(_s) * FFTFILT();                                     \
 /*  _h      : filter coefficients, [size: _h_len x 1]                   */  \
 /*  _h_len  : filter length, _h_len > 0                                 */  \
 /*  _n      : block size = nfft/2, _n >= _h_len-1                       */  \
-FFTFILT() FFTFILT(_create)(TC *         _h,                                 \
+FFTFILT() FFTFILT(_create)(const TC *   _h,                                 \
                            unsigned int _h_len,                             \
                            unsigned int _n);                                \
                                                                             \
@@ -3340,7 +3340,7 @@ int FFTFILT(_get_scale)(FFTFILT() _q,                                       \
 /*  _x      : pointer to input data array,  [size: _n x 1]              */  \
 /*  _y      : pointer to output data array, [size: _n x 1]              */  \
 int FFTFILT(_execute)(FFTFILT() _q,                                         \
-                      TI *      _x,                                         \
+                      const TI * _x,                                        \
                       TO *      _y);                                        \
                                                                             \
 /* Get length of filter object's internal coefficients                  */  \
@@ -3392,9 +3392,9 @@ typedef struct IIRFILT(_s) * IIRFILT();                                     \
 /*  _nb     : number of feed-forward coefficients, _nb > 0              */  \
 /*  _a      : feed-back coefficients (denominator), [size: _na x 1]     */  \
 /*  _na     : number of feed-back coefficients, _na > 0                 */  \
-IIRFILT() IIRFILT(_create)(TC *         _b,                                 \
+IIRFILT() IIRFILT(_create)(const TC *   _b,                                 \
                            unsigned int _nb,                                \
-                           TC *         _a,                                 \
+                           const TC *   _a,                                 \
                            unsigned int _na);                               \
                                                                             \
 /* Create IIR filter using 2nd-order sections from external             */  \
@@ -3402,8 +3402,8 @@ IIRFILT() IIRFILT(_create)(TC *         _b,                                 \
 /*  _b      : feed-forward coefficients, [size: _nsos x 3]              */  \
 /*  _a      : feed-back coefficients,    [size: _nsos x 3]              */  \
 /*  _nsos   : number of second-order sections (sos), _nsos > 0          */  \
-IIRFILT() IIRFILT(_create_sos)(TC *         _b,                             \
-                               TC *         _a,                             \
+IIRFILT() IIRFILT(_create_sos)(const TC *   _b,                             \
+                               const TC *   _a,                             \
                                unsigned int _nsos);                         \
                                                                             \
 /* Create IIR filter from design template                               */  \
@@ -3489,7 +3489,7 @@ int IIRFILT(_execute)(IIRFILT() _q,                                         \
 /*  _n      : number of input, output samples, _n > 0                   */  \
 /*  _y      : pointer to output array, [size: _n x 1]                   */  \
 int IIRFILT(_execute_block)(IIRFILT()    _q,                                \
-                            TI *         _x,                                \
+                            const TI *   _x,                                \
                             unsigned int _n,                                \
                             TO *         _y);                               \
                                                                             \
@@ -3548,8 +3548,8 @@ typedef struct IIRFILTSOS(_s) * IIRFILTSOS();                               \
 /* create 2nd-order infinite impulse response filter                    */  \
 /*  _b      : feed-forward coefficients, [size: _3 x 1]                 */  \
 /*  _a      : feed-back coefficients,    [size: _3 x 1]                 */  \
-IIRFILTSOS() IIRFILTSOS(_create)(TC * _b,                                   \
-                                 TC * _a);                                  \
+IIRFILTSOS() IIRFILTSOS(_create)(const TC * _b,                             \
+                                 const TC * _a);                            \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
 IIRFILTSOS() IIRFILTSOS(_copy)(IIRFILTSOS() _q);                            \
@@ -3559,8 +3559,8 @@ IIRFILTSOS() IIRFILTSOS(_copy)(IIRFILTSOS() _q);                            \
 /*  _b      : feed-forward coefficients, [size: 3 x 1]                  */  \
 /*  _a      : feed-back coefficients, [size: 3 x 1]                     */  \
 int IIRFILTSOS(_set_coefficients)(IIRFILTSOS() _q,                          \
-                                  TC *         _b,                          \
-                                  TC *         _a);                         \
+                                  const TC *   _b,                          \
+                                  const TC *   _a);                         \
                                                                             \
 /* destroy iirfiltsos object, freeing all internal memory               */  \
 int IIRFILTSOS(_destroy)(IIRFILTSOS() _q);                                  \
@@ -3641,7 +3641,7 @@ typedef struct FIRPFB(_s) * FIRPFB();                                       \
 /*  _h_len          : complete filter length (where _h_len is a         */  \
 /*                    multiple of _num_filters), _h_len >= _num_filters */  \
 FIRPFB() FIRPFB(_create)(unsigned int _num_filters,                         \
-                         TC *         _h,                                   \
+                         const TC *   _h,                                   \
                          unsigned int _h_len);                              \
                                                                             \
 /* Create firpfb object using Kaiser-Bessel windowed sinc filter design */  \
@@ -3699,7 +3699,7 @@ FIRPFB() FIRPFB(_create_drnyquist)(int          _type,                      \
 /*                    multiple of _num_filters), _h_len >= _num_filters */  \
 FIRPFB() FIRPFB(_recreate)(FIRPFB()     _q,                                 \
                            unsigned int _num_filters,                       \
-                           TC *         _h,                                 \
+                           const TC *   _h,                                 \
                            unsigned int _h_len);                            \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
@@ -3737,7 +3737,7 @@ int FIRPFB(_push)(FIRPFB() _q,                                              \
 /*  _q      : filter object                                             */  \
 /*  _x      : single input sample                                       */  \
 int FIRPFB(_write)(FIRPFB()     _q,                                         \
-                   TI *         _x,                                         \
+                   const TI *   _x,                                         \
                    unsigned int _n);                                        \
                                                                             \
 /* Execute vector dot product on the filter's internal buffer and       */  \
@@ -3759,7 +3759,7 @@ int FIRPFB(_execute)(FIRPFB()     _q,                                       \
 /*  _y      : pointer to output array, [size: _n x 1]                   */  \
 int FIRPFB(_execute_block)(FIRPFB()     _q,                                 \
                            unsigned int _i,                                 \
-                           TI *         _x,                                 \
+                           const TI *   _x,                                 \
                            unsigned int _n,                                 \
                            TO *         _y);                                \
 
@@ -3802,7 +3802,7 @@ typedef struct FIRINTERP(_s) * FIRINTERP();                                 \
 /*  _h      : filter coefficients, [size: _h_len x 1]                   */  \
 /*  _h_len  : filter length, _h_len >= _interp                          */  \
 FIRINTERP() FIRINTERP(_create)(unsigned int _interp,                        \
-                               TC *         _h,                             \
+                               const TC *   _h,                             \
                                unsigned int _h_len);                        \
                                                                             \
 /* Create interpolator from filter prototype prototype (Kaiser-Bessel   */  \
@@ -3882,7 +3882,7 @@ int FIRINTERP(_execute)(FIRINTERP() _q,                                     \
 /*  _n      : size of input array                                       */  \
 /*  _y      : output sample array, [size: M*_n x 1]                     */  \
 int FIRINTERP(_execute_block)(FIRINTERP()  _q,                              \
-                              TI *         _x,                              \
+                              const TI *   _x,                              \
                               unsigned int _n,                              \
                               TO *         _y);                             \
                                                                             \
@@ -3933,9 +3933,9 @@ typedef struct IIRINTERP(_s) * IIRINTERP();                                 \
 /*  _a      : feed-back coefficients (denominator), [size: _na x 1]     */  \
 /*  _na     : number of feed-back coefficients, _na > 0                 */  \
 IIRINTERP() IIRINTERP(_create)(unsigned int _M,                             \
-                               TC *         _b,                             \
+                               const TC *   _b,                             \
                                unsigned int _nb,                            \
-                               TC *         _a,                             \
+                               const TC *   _a,                             \
                                unsigned int _na);                           \
                                                                             \
 /* Create interpolator object with default Butterworth prototype        */  \
@@ -3992,7 +3992,7 @@ int IIRINTERP(_execute)(IIRINTERP() _q,                                     \
 /*  _n      : size of input array                                       */  \
 /*  _y      : output sample array, [size: _M*_n x 1]                    */  \
 int IIRINTERP(_execute_block)(IIRINTERP()  _q,                              \
-                              TI *         _x,                              \
+                              const TI *   _x,                              \
                               unsigned int _n,                              \
                               TO *         _y);                             \
                                                                             \
@@ -4036,7 +4036,7 @@ typedef struct FIRDECIM(_s) * FIRDECIM();                                   \
 /*  _h      : filter coefficients, [size: _h_len x 1]                   */  \
 /*  _h_len  : filter length, _h_len >= _M                               */  \
 FIRDECIM() FIRDECIM(_create)(unsigned int _M,                               \
-                             TC *         _h,                               \
+                             const TC *   _h,                               \
                              unsigned int _h_len);                          \
                                                                             \
 /* Create decimator from filter prototype prototype (Kaiser-Bessel      */  \
@@ -4101,7 +4101,7 @@ int FIRDECIM(_freqresp)(FIRDECIM()             _q,                          \
 /*  _x      : input samples, [size: _M x 1]                             */  \
 /*  _y      : output sample pointer                                     */  \
 int FIRDECIM(_execute)(FIRDECIM() _q,                                       \
-                       TI *       _x,                                       \
+                       const TI * _x,                                       \
                        TO *       _y);                                      \
                                                                             \
 /* Execute decimator on block of _n*_M input samples                    */  \
@@ -4110,7 +4110,7 @@ int FIRDECIM(_execute)(FIRDECIM() _q,                                       \
 /*  _n      : number of _output_ samples                                */  \
 /*  _y      : output array, [_size: _n x 1]                             */  \
 int FIRDECIM(_execute_block)(FIRDECIM()   _q,                               \
-                             TI *         _x,                               \
+                             const TI *   _x,                               \
                              unsigned int _n,                               \
                              TO *         _y);                              \
 
@@ -4155,9 +4155,9 @@ typedef struct IIRDECIM(_s) * IIRDECIM();                                   \
 /*  _a      : feed-back coefficients (denominator), [size: _na x 1]     */  \
 /*  _na     : number of feed-back coefficients, _na > 0                 */  \
 IIRDECIM() IIRDECIM(_create)(unsigned int _M,                               \
-                             TC *         _b,                               \
+                             const TC *   _b,                               \
                              unsigned int _nb,                              \
-                             TC *         _a,                               \
+                             const TC *   _a,                               \
                              unsigned int _na);                             \
                                                                             \
 /* Create decimator object with default Butterworth prototype           */  \
@@ -4204,7 +4204,7 @@ int IIRDECIM(_reset)(IIRDECIM() _q);                                        \
 /*  _x      : input samples, [size: _M x 1]                             */  \
 /*  _y      : output sample pointer                                     */  \
 int IIRDECIM(_execute)(IIRDECIM() _q,                                       \
-                       TI *       _x,                                       \
+                       const TI * _x,                                       \
                        TO *       _y);                                      \
                                                                             \
 /* Execute decimator on block of _n*_M input samples                    */  \
@@ -4213,7 +4213,7 @@ int IIRDECIM(_execute)(IIRDECIM() _q,                                       \
 /*  _n      : number of _output_ samples                                */  \
 /*  _y      : output array, [_sze: _n x 1]                              */  \
 int IIRDECIM(_execute_block)(IIRDECIM()   _q,                               \
-                             TI *         _x,                               \
+                             const TI *   _x,                               \
                              unsigned int _n,                               \
                              TO *         _y);                              \
                                                                             \
@@ -4389,7 +4389,7 @@ typedef struct RRESAMP(_s) * RRESAMP();                                     \
 RRESAMP() RRESAMP(_create)(unsigned int _interp,                            \
                            unsigned int _decim,                             \
                            unsigned int _m,                                 \
-                           TC *         _h);                                \
+                           const TC *   _h);                                \
                                                                             \
 /* Create rational-rate resampler object from filter prototype to       */  \
 /* resample at an exact rate \(P/Q\) = interp/decim.                    */  \
@@ -4499,8 +4499,8 @@ float RRESAMP(_get_rate)(RRESAMP() _q);                                     \
 /* internal state of the resampler.                                     */  \
 /*  _q      : resamp object                                             */  \
 /*  _buf    : input sample array, [size: decim x 1]                     */  \
-int RRESAMP(_write)(RRESAMP() _q,                                           \
-                    TI *      _buf);                                        \
+int RRESAMP(_write)(RRESAMP()   _q,                                         \
+                    const TI * _buf);                                       \
                                                                             \
 /* Execute rational-rate resampler on a block of input samples and      */  \
 /* store the resulting samples in the output array.                     */  \
@@ -4520,8 +4520,8 @@ int RRESAMP(_write)(RRESAMP() _q,                                           \
 /*  _q  : resamp object                                                 */  \
 /*  _x  : input sample array, [size: decim x 1]                         */  \
 /*  _y  : output sample array, [size: interp x 1]                       */  \
-int RRESAMP(_execute)(RRESAMP()       _q,                                   \
-                      TI *           _x,                                    \
+int RRESAMP(_execute)(RRESAMP()      _q,                                    \
+                      const TI *     _x,                                    \
                       TO *           _y);                                   \
                                                                             \
 /* Execute on a block of samples                                        */  \
@@ -4530,7 +4530,7 @@ int RRESAMP(_execute)(RRESAMP()       _q,                                   \
 /*  _n  : block size                                                    */  \
 /*  _y  : output sample array, [size: interp*n x 1]                     */  \
 int RRESAMP(_execute_block)(RRESAMP()      _q,                              \
-                            TI *           _x,                              \
+                            const TI *     _x,                              \
                             unsigned int   _n,                              \
                             TO *           _y);                             \
 
@@ -4670,7 +4670,7 @@ int RESAMP(_execute)(RESAMP()       _q,                                     \
 /*  _y              : output sample array (pointer)                     */  \
 /*  _ny             : number of samples written to _y                   */  \
 int RESAMP(_execute_block)(RESAMP()       _q,                               \
-                           TI *           _x,                               \
+                           const TI *     _x,                               \
                            unsigned int   _nx,                              \
                            TO *           _y,                               \
                            unsigned int * _ny);                             \
@@ -4830,7 +4830,7 @@ unsigned int MSRESAMP(_get_num_output)(MSRESAMP()   _q,                     \
 /*  _y  : pointer to output array for storing result                    */  \
 /*  _ny : number of samples written to _y                               */  \
 int MSRESAMP(_execute)(MSRESAMP()     _q,                                   \
-                       TI *           _x,                                   \
+                       const TI *     _x,                                   \
                        unsigned int   _nx,                                  \
                        TO *           _y,                                   \
                        unsigned int * _ny);                                 \
@@ -4908,9 +4908,9 @@ float        DDS(_get_delay_decim)(DDS() _q);                               \
 /*  _q      : synthesizer object                                        */  \
 /*  _x      : input data array, [size: (1<<_num_stages) x 1]            */  \
 /*  _y      : output sample                                             */  \
-int DDS(_decim_execute)(DDS() _q,                                           \
-                        TI *  _x,                                           \
-                        TO *  _y);                                          \
+int DDS(_decim_execute)(DDS()      _q,                                      \
+                        const TI * _x,                                      \
+                        TO *       _y);                                     \
                                                                             \
 /* Run DDS object as interpolator                                       */  \
 /*  _q      : synthesizer object                                        */  \
@@ -4944,7 +4944,7 @@ typedef struct SYMSYNC(_s) * SYMSYNC();                                     \
 /*  _h_len  : length of matched filter; \( h_{len} = 2 k m + 1 \)       */  \
 SYMSYNC() SYMSYNC(_create)(unsigned int _k,                                 \
                            unsigned int _M,                                 \
-                           TC *         _h,                                 \
+                           const TC *   _h,                                 \
                            unsigned int _h_len);                            \
                                                                             \
 /* Create square-root Nyquist symbol synchronizer from prototype        */  \
@@ -5014,7 +5014,7 @@ float SYMSYNC(_get_tau)(SYMSYNC() _q);                                      \
 /*  _y      : output data array                                         */  \
 /*  _ny     : number of samples written to output buffer                */  \
 int SYMSYNC(_execute)(SYMSYNC()      _q,                                    \
-                      TI *           _x,                                    \
+                      const TI *     _x,                                    \
                       unsigned int   _nx,                                   \
                       TO *           _y,                                    \
                       unsigned int * _ny);                                  \
@@ -5092,10 +5092,10 @@ int FIRFARROW(_execute)(FIRFARROW() _q,                                     \
 /*  _x      : input array, [size: _n x 1]                               */  \
 /*  _n      : input, output array size                                  */  \
 /*  _y      : output array, [size: _n x 1]                              */  \
-int FIRFARROW(_execute_block)(FIRFARROW()  _q,                              \
-                              TI *         _x,                              \
-                              unsigned int _n,                              \
-                              TO *         _y);                             \
+int FIRFARROW(_execute_block)(FIRFARROW()    _q,                            \
+                              const TI *     _x,                            \
+                              unsigned int   _n,                            \
+                              TO *           _y);                           \
                                                                             \
 /* Get length of firfarrow object (number of filter taps)               */  \
 unsigned int FIRFARROW(_get_length)(FIRFARROW() _q);                        \
@@ -5181,7 +5181,7 @@ int ORDFILT(_push)(ORDFILT() _q,                                            \
 /*  _x      : array of input samples, [size: _n x 1]                    */  \
 /*  _n      : number of input elements                                  */  \
 int ORDFILT(_write)(ORDFILT()    _q,                                        \
-                    TI *         _x,                                        \
+                    const TI *   _x,                                        \
                     unsigned int _n);                                       \
                                                                             \
 /* Execute on the filter's internal buffer                              */  \
@@ -5205,7 +5205,7 @@ int ORDFILT(_execute_one)(ORDFILT() _q,                                     \
 /*  _n      : number of input, output samples                           */  \
 /*  _y      : pointer to output array, [size: _n x 1]                   */  \
 int ORDFILT(_execute_block)(ORDFILT()    _q,                                \
-                            TI *         _x,                                \
+                            const TI *   _x,                                \
                             unsigned int _n,                                \
                             TO *         _y);                               \
 

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -701,7 +701,7 @@ int CHANNEL(_add_carrier_offset)(CHANNEL() _q,                              \
 /*  _h          : channel coefficients (NULL for random)                */  \
 /*  _h_len      : number of channel coefficients                        */  \
 int CHANNEL(_add_multipath)(CHANNEL()    _q,                                \
-                            TC *         _h,                                \
+                            const TC *   _h,                                \
                             unsigned int _h_len);                           \
                                                                             \
 /* Include slowly-varying shadowing impairment                          */  \
@@ -726,7 +726,7 @@ int CHANNEL(_execute)(CHANNEL()      _q,                                    \
 /*  _n      : input array, length                                       */  \
 /*  _y      : output array, [size: _n x 1]                              */  \
 int CHANNEL(_execute_block)(CHANNEL()      _q,                              \
-                            TI *           _x,                              \
+                            const TI *     _x,                              \
                             unsigned int   _n,                              \
                             TO *           _y);                             \
 
@@ -801,7 +801,7 @@ int TVMPCH(_execute_one)(TVMPCH() _q,                                       \
 /*  _n      : input array length                                        */  \
 /*  _y      : output array, [size: _n x 1]                              */  \
 int TVMPCH(_execute_block)(TVMPCH()     _q,                                 \
-                           TI *         _x,                                 \
+                           const TI *   _x,                                 \
                            unsigned int _n,                                 \
                            TO *         _y);                                \
 

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -8768,7 +8768,7 @@ typedef struct FIRPFBCH(_s) * FIRPFBCH();                                   \
 FIRPFBCH() FIRPFBCH(_create)(int          _type,                            \
                              unsigned int _M,                               \
                              unsigned int _p,                               \
-                             TC *         _h);                              \
+                             const TC *   _h);                              \
                                                                             \
 /* Create FIR polyphase filterbank channelizer object with              */  \
 /* prototype filter based on windowed Kaiser design                     */  \
@@ -8808,7 +8808,7 @@ int FIRPFBCH(_print)(FIRPFBCH() _q);                                        \
 /*  _x      : channelized input, [size: num_channels x 1]               */  \
 /*  _y      : output time series, [size: num_channels x 1]              */  \
 int FIRPFBCH(_synthesizer_execute)(FIRPFBCH() _q,                           \
-                                   TI *       _x,                           \
+                                   const TI * _x,                           \
                                    TO *       _y);                          \
                                                                             \
 /* Execute filterbank as analyzer on block of samples                   */  \
@@ -8816,7 +8816,7 @@ int FIRPFBCH(_synthesizer_execute)(FIRPFBCH() _q,                           \
 /*  _x      : input time series, [size: num_channels x 1]               */  \
 /*  _y      : channelized output, [size: num_channels x 1]              */  \
 int FIRPFBCH(_analyzer_execute)(FIRPFBCH() _q,                              \
-                                TI *       _x,                              \
+                                const TI * _x,                              \
                                 TO *       _y);                             \
 
 
@@ -8858,7 +8858,7 @@ typedef struct FIRPFBCH2(_s) * FIRPFBCH2();                                 \
 FIRPFBCH2() FIRPFBCH2(_create)(int          _type,                          \
                                unsigned int _M,                             \
                                unsigned int _m,                             \
-                               TC *         _h);                            \
+                               const TC *   _h);                            \
                                                                             \
 /* Create firpfbch2 object using Kaiser window prototype                */  \
 /*  _type   : channelizer type (e.g. LIQUID_ANALYZER)                   */  \
@@ -8897,7 +8897,7 @@ unsigned int FIRPFBCH2(_get_m)(FIRPFBCH2() _q);                             \
 /*  _x      :   channelizer input                                       */  \
 /*  _y      :   channelizer output                                      */  \
 int FIRPFBCH2(_execute)(FIRPFBCH2() _q,                                     \
-                        TI *        _x,                                     \
+                        const TI *  _x,                                     \
                         TO *        _y);                                    \
 
 
@@ -8928,7 +8928,7 @@ typedef struct FIRPFBCHR(_s) * FIRPFBCHR();                                 \
 FIRPFBCHR() FIRPFBCHR(_create)(unsigned int _chans,                         \
                                unsigned int _decim,                         \
                                unsigned int _m,                             \
-                               TC *         _h);                            \
+                               const TC *   _h);                            \
                                                                             \
 /* create rational rate resampling channelizer (firpfbchr) object by    */  \
 /* specifying filter design parameters for Kaiser prototype             */  \
@@ -8967,7 +8967,7 @@ unsigned int FIRPFBCHR(_get_m)(FIRPFBCHR() _q);                             \
 /*  _q      : channelizer object                                        */  \
 /*  _x      : channelizer input, [size: decim x 1]                      */  \
 int FIRPFBCHR(_push)(FIRPFBCHR() _q,                                        \
-                     TI *        _x);                                       \
+                     const TI *  _x);                                       \
                                                                             \
 /* execute filterbank channelizer, writing complex baseband samples for */  \
 /* each channel into output array                                       */  \
@@ -9011,7 +9011,7 @@ int ofdmframe_init_sctype_range(unsigned int    _M,
 //  _M_null     :   output number of null subcarriers
 //  _M_pilot    :   output number of pilot subcarriers
 //  _M_data     :   output number of data subcarriers
-int ofdmframe_validate_sctype(unsigned char * _p,
+int ofdmframe_validate_sctype(const unsigned char * _p,
                               unsigned int _M,
                               unsigned int * _M_null,
                               unsigned int * _M_pilot,
@@ -9020,8 +9020,8 @@ int ofdmframe_validate_sctype(unsigned char * _p,
 // print subcarrier allocation to screen
 //  _p      :   output subcarrier allocation array, [size: _M x 1]
 //  _M      :   number of subcarriers
-int ofdmframe_print_sctype(unsigned char * _p,
-                           unsigned int    _M);
+int ofdmframe_print_sctype(const unsigned char * _p,
+                           unsigned int          _M);
 
 
 //
@@ -9034,10 +9034,10 @@ typedef struct ofdmframegen_s * ofdmframegen;
 //  _cp_len     :   cyclic prefix length
 //  _taper_len  :   taper length (OFDM symbol overlap)
 //  _p          :   subcarrier allocation (null, pilot, data), [size: _M x 1]
-ofdmframegen ofdmframegen_create(unsigned int    _M,
-                                 unsigned int    _cp_len,
-                                 unsigned int    _taper_len,
-                                 unsigned char * _p);
+ofdmframegen ofdmframegen_create(unsigned int          _M,
+                                 unsigned int          _cp_len,
+                                 unsigned int          _taper_len,
+                                 const unsigned char * _p);
 
 int ofdmframegen_destroy(ofdmframegen _q);
 
@@ -9059,7 +9059,7 @@ int ofdmframegen_write_S1(ofdmframegen _q,
 
 // write data symbol
 int ofdmframegen_writesymbol(ofdmframegen _q,
-                             liquid_float_complex * _x,
+                             const liquid_float_complex * _x,
                              liquid_float_complex *_y);
 
 // write tail
@@ -9085,7 +9085,7 @@ typedef struct ofdmframesync_s * ofdmframesync;
 ofdmframesync ofdmframesync_create(unsigned int           _M,
                                    unsigned int           _cp_len,
                                    unsigned int           _taper_len,
-                                   unsigned char *        _p,
+                                   const unsigned char *  _p,
                                    ofdmframesync_callback _callback,
                                    void *                 _userdata);
 int ofdmframesync_destroy(ofdmframesync _q);
@@ -9093,7 +9093,7 @@ int ofdmframesync_print(ofdmframesync _q);
 int ofdmframesync_reset(ofdmframesync _q);
 int ofdmframesync_is_frame_open(ofdmframesync _q);
 int ofdmframesync_execute(ofdmframesync _q,
-                          liquid_float_complex * _x,
+                          const liquid_float_complex * _x,
                           unsigned int _n);
 
 // query methods

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -9266,7 +9266,7 @@ int NCO(_mix_down)(NCO() _q,                                                \
 /*  _y      : array of output samples, [size: _n x 1]                   */  \
 /*  _n      : number of input (and output) samples                      */  \
 int NCO(_mix_block_up)(NCO()        _q,                                     \
-                       TC *         _x,                                     \
+                       const TC *   _x,                                     \
                        TC *         _y,                                     \
                        unsigned int _n);                                    \
                                                                             \
@@ -9278,7 +9278,7 @@ int NCO(_mix_block_up)(NCO()        _q,                                     \
 /*  _y      : array of output samples, [size: _n x 1]                   */  \
 /*  _n      : number of input (and output) samples                      */  \
 int NCO(_mix_block_down)(NCO()        _q,                                   \
-                         TC *         _x,                                   \
+                         const TC *   _x,                                   \
                          TC *         _y,                                   \
                          unsigned int _n);                                  \
 
@@ -9338,13 +9338,13 @@ void SYNTH(_mix_down)(SYNTH() _q, TC _x, TC *_y);                           \
                                                                             \
 /* Rotate input vector up by SYNTH angle (stepping)       */                \
 void SYNTH(_mix_block_up)(SYNTH() _q,                                       \
-                          TC *_x,                                           \
+                          const TC *_x,                                     \
                           TC *_y,                                           \
                           unsigned int _n);                                 \
                                                                             \
 /* Rotate input vector down by SYNTH angle (stepping)     */                \
 void SYNTH(_mix_block_down)(SYNTH() _q,                                     \
-                            TC *_x,                                         \
+                            const TC *_x,                                   \
                             TC *_y,                                         \
                             unsigned int _n);                               \
                                                                             \
@@ -9353,11 +9353,11 @@ void SYNTH(_spread)(SYNTH() _q,                                             \
                     TC *_y);                                                \
                                                                             \
 void SYNTH(_despread)(SYNTH() _q,                                           \
-                      TC *_x,                                               \
+                      const TC *_x,                                         \
                       TC *_y);                                              \
                                                                             \
 void SYNTH(_despread_triple)(SYNTH() _q,                                    \
-                             TC *_x,                                        \
+                             const TC *_x,                                  \
                              TC *_early,                                    \
                              TC *_punctual,                                 \
                              TC *_late);                                    \

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -10159,59 +10159,59 @@ void VECTOR(_init)(T            _c,                                         \
                    unsigned int _n);                                        \
                                                                             \
 /* Add each element pointwise: z[i] = x[i] + y[i]                       */  \
-void VECTOR(_add)(T *          _x,                                          \
-                  T *          _y,                                          \
+void VECTOR(_add)(const T *    _x,                                          \
+                  const T *    _y,                                          \
                   unsigned int _n,                                          \
                   T *          _z);                                         \
                                                                             \
 /* Add scalar to each element: y[i] = x[i] + c                          */  \
-void VECTOR(_addscalar)(T *          _x,                                    \
+void VECTOR(_addscalar)(const T *    _x,                                    \
                         unsigned int _n,                                    \
                         T            _c,                                    \
                         T *          _y);                                   \
                                                                             \
 /* Multiply each element pointwise: z[i] = x[i] * y[i]                  */  \
-void VECTOR(_mul)(T *          _x,                                          \
-                  T *          _y,                                          \
+void VECTOR(_mul)(const T *    _x,                                          \
+                  const T *    _y,                                          \
                   unsigned int _n,                                          \
                   T *          _z);                                         \
                                                                             \
 /* Multiply each element with scalar: y[i] = x[i] * c                   */  \
-void VECTOR(_mulscalar)(T *          _x,                                    \
+void VECTOR(_mulscalar)(const T *    _x,                                    \
                         unsigned int _n,                                    \
                         T            _c,                                    \
                         T *          _y);                                   \
                                                                             \
 /* Compute complex phase rotation: x[i] = exp{j theta[i]}               */  \
-void VECTOR(_cexpj)(TP *         _theta,                                    \
+void VECTOR(_cexpj)(const TP *   _theta,                                    \
                     unsigned int _n,                                        \
                     T *          _x);                                       \
                                                                             \
 /* Compute angle of each element: theta[i] = arg{ x[i] }                */  \
-void VECTOR(_carg)(T *          _x,                                         \
+void VECTOR(_carg)(const T *    _x,                                         \
                    unsigned int _n,                                         \
                    TP *         _theta);                                    \
                                                                             \
 /* Compute absolute value of each element: y[i] = |x[i]|                */  \
-void VECTOR(_abs)(T *          _x,                                          \
+void VECTOR(_abs)(const T *    _x,                                          \
                   unsigned int _n,                                          \
                   TP *         _y);                                         \
                                                                             \
 /* Compute sum of squares: sum{ |x|^2 }                                 */  \
-TP VECTOR(_sumsq)(T *          _x,                                          \
+TP VECTOR(_sumsq)(const T *    _x,                                          \
                   unsigned int _n);                                         \
                                                                             \
 /* Compute l-2 norm: sqrt{ sum{ |x|^2 } }                               */  \
-TP VECTOR(_norm)(T *          _x,                                           \
+TP VECTOR(_norm)(const T *    _x,                                           \
                  unsigned int _n);                                          \
                                                                             \
 /* Compute l-p norm: { sum{ |x|^p } }^(1/p)                             */  \
-TP VECTOR(_pnorm)(T *          _x,                                          \
+TP VECTOR(_pnorm)(const T *    _x,                                          \
                   unsigned int _n,                                          \
                   TP           _p);                                         \
                                                                             \
 /* Scale vector elements by l-2 norm: y[i] = x[i]/norm(x)               */  \
-void VECTOR(_normalize)(T *          _x,                                    \
+void VECTOR(_normalize)(const T *    _x,                                    \
                         unsigned int _n,                                    \
                         T *          _y);                                   \
 

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -393,7 +393,7 @@ unsigned char   cvsd_encode(cvsd _q, float _audio_sample);
 float           cvsd_decode(cvsd _q, unsigned char _bit);
 
 // encode/decode 8 samples at a time
-int cvsd_encode8(cvsd _q, float * _audio, unsigned char * _data);
+int cvsd_encode8(cvsd _q, const float * _audio, unsigned char * _data);
 int cvsd_decode8(cvsd _q, unsigned char _data, float * _audio);
 
 

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -249,7 +249,7 @@ int AGC(_execute)(AGC() _q,                                                 \
 /*  _n      : number of input, output samples                           */  \
 /*  _y      : output data array, [size: _n x 1]                         */  \
 int AGC(_execute_block)(AGC()        _q,                                    \
-                        TC *         _x,                                    \
+                        const TC *   _x,                                    \
                         unsigned int _n,                                    \
                         TC *         _y);                                   \
                                                                             \
@@ -327,7 +327,7 @@ int AGC(_set_scale)(AGC() _q,                                               \
 /*  _x      : input data array, [size: _n x 1]                          */  \
 /*  _n      : number of input, output samples                           */  \
 int AGC(_init)(AGC()        _q,                                             \
-               TC *         _x,                                             \
+               const TC *   _x,                                             \
                unsigned int _n);                                            \
                                                                             \
 /* Enable squelch mode.                                                 */  \

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -9974,7 +9974,7 @@ unsigned int msequence_genpoly_period(unsigned int _g);
 //  _orig   : pointer to original memory array
 //  _num    : number of original elements
 //  _size   : size of each element
-void * liquid_malloc_copy(void * _orig, unsigned int _num, unsigned int _size);
+void * liquid_malloc_copy(const void * _orig, unsigned int _num, unsigned int _size);
 
 // pack binary array with symbol(s)
 //  _src        :   source array, [size: _n x 1]
@@ -9994,7 +9994,7 @@ int liquid_pack_array(unsigned char * _src,
 //  _k          :   bit index to write in _src
 //  _b          :   number of bits in output symbol
 //  _sym_out    :   output symbol
-int liquid_unpack_array(unsigned char * _src,
+int liquid_unpack_array(const unsigned char * _src,
                         unsigned int _n,
                         unsigned int _k,
                         unsigned int _b,
@@ -10006,7 +10006,7 @@ int liquid_unpack_array(unsigned char * _src,
 //  _sym_out            :   output symbols
 //  _sym_out_len        :   number of bytes allocated to output symbols array
 //  _num_written        :   number of output symbols actually written
-int liquid_pack_bytes(unsigned char * _sym_in,
+int liquid_pack_bytes(const unsigned char * _sym_in,
                       unsigned int _sym_in_len,
                       unsigned char * _sym_out,
                       unsigned int _sym_out_len,
@@ -10018,7 +10018,7 @@ int liquid_pack_bytes(unsigned char * _sym_in,
 //  _sym_out            :   output symbols array
 //  _sym_out_len        :   number of bytes allocated to output symbols array
 //  _num_written        :   number of output symbols actually written
-int liquid_unpack_bytes(unsigned char * _sym_in,
+int liquid_unpack_bytes(const unsigned char * _sym_in,
                         unsigned int _sym_in_len,
                         unsigned char * _sym_out,
                         unsigned int _sym_out_len,
@@ -10032,7 +10032,7 @@ int liquid_unpack_bytes(unsigned char * _sym_in,
 //  _sym_out_bps        :   number of bits per output symbol
 //  _sym_out_len        :   number of bytes allocated to output symbols array
 //  _num_written        :   number of output symbols actually written
-int liquid_repack_bytes(unsigned char * _sym_in,
+int liquid_repack_bytes(const unsigned char * _sym_in,
                         unsigned int _sym_in_bps,
                         unsigned int _sym_in_len,
                         unsigned char * _sym_out,

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -7574,7 +7574,7 @@ unsigned int liquid_totient(unsigned int _n);
 /*  _x      : input matrix, [size: _r x _c]                             */  \
 /*  _r      : rows in matrix                                            */  \
 /*  _c      : columns in matrix                                         */  \
-int MATRIX(_print)(T *          _x,                                         \
+int MATRIX(_print)(const T *    _x,                                         \
                    unsigned int _r,                                         \
                    unsigned int _c);                                        \
                                                                             \
@@ -7587,8 +7587,8 @@ int MATRIX(_print)(T *          _x,                                         \
 /*  _z      : output matrix, [size: _r x _c]                            */  \
 /*  _r      : number of rows in each matrix                             */  \
 /*  _c      : number of columns in each matrix                          */  \
-int MATRIX(_add)(T *          _x,                                           \
-                 T *          _y,                                           \
+int MATRIX(_add)(const T *    _x,                                           \
+                 const T *    _y,                                           \
                  T *          _z,                                           \
                  unsigned int _r,                                           \
                  unsigned int _c);                                          \
@@ -7602,8 +7602,8 @@ int MATRIX(_add)(T *          _x,                                           \
 /*  _z      : output matrix, [size: _r x _c]                            */  \
 /*  _r      : number of rows in each matrix                             */  \
 /*  _c      : number of columns in each matrix                          */  \
-int MATRIX(_sub)(T *          _x,                                           \
-                 T *          _y,                                           \
+int MATRIX(_sub)(const T *    _x,                                           \
+                 const T *    _y,                                           \
                  T *          _z,                                           \
                  unsigned int _r,                                           \
                  unsigned int _c);                                          \
@@ -7617,8 +7617,8 @@ int MATRIX(_sub)(T *          _x,                                           \
 /*  _z      : output matrix, [size: _r x _c]                            */  \
 /*  _r      : number of rows in each matrix                             */  \
 /*  _c      : number of columns in each matrix                          */  \
-int MATRIX(_pmul)(T *          _x,                                          \
-                  T *          _y,                                          \
+int MATRIX(_pmul)(const T *    _x,                                          \
+                  const T *    _y,                                          \
                   T *          _z,                                          \
                   unsigned int _r,                                          \
                   unsigned int _c);                                         \
@@ -7632,8 +7632,8 @@ int MATRIX(_pmul)(T *          _x,                                          \
 /*  _z      : output matrix, [size: _r x _c]                            */  \
 /*  _r      : number of rows in each matrix                             */  \
 /*  _c      : number of columns in each matrix                          */  \
-int MATRIX(_pdiv)(T *          _x,                                          \
-                  T *          _y,                                          \
+int MATRIX(_pdiv)(const T *    _x,                                          \
+                  const T *    _y,                                          \
                   T *          _z,                                          \
                   unsigned int _r,                                          \
                   unsigned int _c);                                         \
@@ -7650,8 +7650,8 @@ int MATRIX(_pdiv)(T *          _x,                                          \
 /*  _z      : output matrix, [size: _rz x _cz]                          */  \
 /*  _rz     : number of rows in _z                                      */  \
 /*  _cz     : number of columns in _z                                   */  \
-int MATRIX(_mul)(T * _x, unsigned int _rx, unsigned int _cx,                \
-                 T * _y, unsigned int _ry, unsigned int _cy,                \
+int MATRIX(_mul)(const T * _x, unsigned int _rx, unsigned int _cx,          \
+                 const T * _y, unsigned int _ry, unsigned int _cy,          \
                  T * _z, unsigned int _rz, unsigned int _cz);               \
                                                                             \
 /* Solve \(\vec{X} = \vec{Y} \vec{Z}\) for \(\vec{Z}\) for square       */  \
@@ -7660,8 +7660,8 @@ int MATRIX(_mul)(T * _x, unsigned int _rx, unsigned int _cx,                \
 /*  _y      : input matrix,  [size: _n x _n]                            */  \
 /*  _z      : output matrix, [size: _n x _n]                            */  \
 /*  _n      : number of rows and columns in each matrix                 */  \
-int MATRIX(_div)(T *          _x,                                           \
-                 T *          _y,                                           \
+int MATRIX(_div)(const T *    _x,                                           \
+                 const T *    _y,                                           \
                  T *          _z,                                           \
                  unsigned int _n);                                          \
                                                                             \
@@ -7669,7 +7669,7 @@ int MATRIX(_div)(T *          _x,                                           \
 /*  _x      : input matrix, [size: _r x _c]                             */  \
 /*  _r      : rows                                                      */  \
 /*  _c      : columns                                                   */  \
-T MATRIX(_det)(T *          _x,                                             \
+T MATRIX(_det)(const T *    _x,                                             \
                unsigned int _r,                                             \
                unsigned int _c);                                            \
                                                                             \
@@ -7695,7 +7695,7 @@ int MATRIX(_hermitian)(T *          _x,                                     \
 /*  _m      : input rows                                                */  \
 /*  _n      : input columns                                             */  \
 /*  _xxT    : output matrix, [size: _m x _m]                            */  \
-int MATRIX(_mul_transpose)(T *          _x,                                 \
+int MATRIX(_mul_transpose)(const T *    _x,                                 \
                            unsigned int _m,                                 \
                            unsigned int _n,                                 \
                            T *          _xxT);                              \
@@ -7706,7 +7706,7 @@ int MATRIX(_mul_transpose)(T *          _x,                                 \
 /*  _m      : input rows                                                */  \
 /*  _n      : input columns                                             */  \
 /*  _xTx    : output matrix, [size: _n x _n]                            */  \
-int MATRIX(_transpose_mul)(T *          _x,                                 \
+int MATRIX(_transpose_mul)(const T *    _x,                                 \
                            unsigned int _m,                                 \
                            unsigned int _n,                                 \
                            T *          _xTx);                              \
@@ -7717,7 +7717,7 @@ int MATRIX(_transpose_mul)(T *          _x,                                 \
 /*  _m      : input rows                                                */  \
 /*  _n      : input columns                                             */  \
 /*  _xxH    : output matrix, [size: _m x _m]                            */  \
-int MATRIX(_mul_hermitian)(T *          _x,                                 \
+int MATRIX(_mul_hermitian)(const T *    _x,                                 \
                            unsigned int _m,                                 \
                            unsigned int _n,                                 \
                            T *          _xxH);                              \
@@ -7728,7 +7728,7 @@ int MATRIX(_mul_hermitian)(T *          _x,                                 \
 /*  _m      : input rows                                                */  \
 /*  _n      : input columns                                             */  \
 /*  _xHx    : output matrix, [size: _n x _n]                            */  \
-int MATRIX(_hermitian_mul)(T *          _x,                                 \
+int MATRIX(_hermitian_mul)(const T *    _x,                                 \
                            unsigned int _m,                                 \
                            unsigned int _n,                                 \
                            T *          _xHx);                              \
@@ -7746,8 +7746,8 @@ int MATRIX(_hermitian_mul)(T *          _x,                                 \
 /*  _z      : output matrix, [size: _rz x _cz]                          */  \
 /*  _rz     : number of rows in _z                                      */  \
 /*  _cz     : number of columns in _z                                   */  \
-int MATRIX(_aug)(T * _x, unsigned int _rx, unsigned int _cx,                \
-                 T * _y, unsigned int _ry, unsigned int _cy,                \
+int MATRIX(_aug)(const T * _x, unsigned int _rx, unsigned int _cx,          \
+                 const T * _y, unsigned int _ry, unsigned int _cy,          \
                  T * _z, unsigned int _rz, unsigned int _cz);               \
                                                                             \
 /* Compute the inverse of a square matrix \(\vec{X}\)                   */  \
@@ -7818,9 +7818,9 @@ int MATRIX(_swaprows)(T *          _x,                                      \
 /*  _b      : equality vector, [size: _n x 1]                           */  \
 /*  _x      : solution vector, [size: _n x 1]                           */  \
 /*  _opts   : options (ignored for now)                                 */  \
-int MATRIX(_linsolve)(T *          _A,                                      \
+int MATRIX(_linsolve)(const T *    _A,                                      \
                       unsigned int _n,                                      \
-                      T *          _b,                                      \
+                      const T *    _b,                                      \
                       T *          _x,                                      \
                       void *       _opts);                                  \
                                                                             \
@@ -7830,9 +7830,9 @@ int MATRIX(_linsolve)(T *          _A,                                      \
 /*  _b      : equality, [size: _n x 1]                                  */  \
 /*  _x      : solution estimate, [size: _n x 1]                         */  \
 /*  _opts   : options (ignored for now)                                 */  \
-int MATRIX(_cgsolve)(T *          _A,                                       \
+int MATRIX(_cgsolve)(const T *    _A,                                       \
                      unsigned int _n,                                       \
-                     T *          _b,                                       \
+                     const T *    _b,                                       \
                      T *          _x,                                       \
                      void *       _opts);                                   \
                                                                             \
@@ -7843,7 +7843,7 @@ int MATRIX(_cgsolve)(T *          _A,                                       \
 /*  _l      : first row to swap                                         */  \
 /*  _u      : first row to swap                                         */  \
 /*  _p      : first row to swap                                         */  \
-int MATRIX(_ludecomp_crout)(T *          _x,                                \
+int MATRIX(_ludecomp_crout)(const T *    _x,                                \
                             unsigned int _rx,                               \
                             unsigned int _cx,                               \
                             T *          _l,                                \
@@ -7857,7 +7857,7 @@ int MATRIX(_ludecomp_crout)(T *          _x,                                \
 /*  _l      : first row to swap                                         */  \
 /*  _u      : first row to swap                                         */  \
 /*  _p      : first row to swap                                         */  \
-int MATRIX(_ludecomp_doolittle)(T *          _x,                            \
+int MATRIX(_ludecomp_doolittle)(const T *    _x,                            \
                                 unsigned int _rx,                           \
                                 unsigned int _cx,                           \
                                 T *          _l,                            \
@@ -7869,7 +7869,7 @@ int MATRIX(_ludecomp_doolittle)(T *          _x,                            \
 /*  _r      : rows                                                      */  \
 /*  _c      : columns                                                   */  \
 /*  _v      : output matrix                                             */  \
-int MATRIX(_gramschmidt)(T *          _A,                                   \
+int MATRIX(_gramschmidt)(const T *    _A,                                   \
                          unsigned int _r,                                   \
                          unsigned int _c,                                   \
                          T *          _v);                                  \
@@ -7884,7 +7884,7 @@ int MATRIX(_gramschmidt)(T *          _A,                                   \
 /*  _n      : columns (same as cols)                                    */  \
 /*  _q      : output matrix, [size: _m x _m]                            */  \
 /*  _r      : output matrix, [size: _m x _m]                            */  \
-int MATRIX(_qrdecomp_gramschmidt)(T *          _a,                          \
+int MATRIX(_qrdecomp_gramschmidt)(const T *    _a,                          \
                                   unsigned int _m,                          \
                                   unsigned int _n,                          \
                                   T *          _q,                          \
@@ -7895,7 +7895,7 @@ int MATRIX(_qrdecomp_gramschmidt)(T *          _a,                          \
 /*  _a      : input square matrix, [size: _n x _n]                      */  \
 /*  _n      : input matrix dimension                                    */  \
 /*  _l      : output lower-triangular matrix                            */  \
-int MATRIX(_chol)(T *          _a,                                          \
+int MATRIX(_chol)(const T *    _a,                                          \
                   unsigned int _n,                                          \
                   T *          _l);                                         \
 
@@ -7935,7 +7935,7 @@ SMATRIX() SMATRIX(_create)(unsigned int _m,                                 \
 /*  _x  : input matrix, [size: _m x _n]                                 */  \
 /*  _m  : number of rows in input matrix                                */  \
 /*  _n  : number of columns in input matrix                             */  \
-SMATRIX() SMATRIX(_create_array)(T *          _x,                           \
+SMATRIX() SMATRIX(_create_array)(const T *    _x,                           \
                                  unsigned int _m,                           \
                                  unsigned int _n);                          \
                                                                             \
@@ -8023,8 +8023,8 @@ int SMATRIX(_mul)(SMATRIX() _x,                                             \
 /*  _q  : sparse matrix                                                 */  \
 /*  _x  : input vector, [size: _n x 1]                                  */  \
 /*  _y  : output vector, [size: _m x 1]                                 */  \
-int SMATRIX(_vmul)(SMATRIX() _q,                                            \
-                   T *       _x,                                            \
+int SMATRIX(_vmul)(SMATRIX()  _q,                                           \
+                   const T * _x,                                            \
                    T *       _y);                                           \
 
 LIQUID_SMATRIX_DEFINE_API(LIQUID_SMATRIX_MANGLE_BOOL,  unsigned char)
@@ -8040,7 +8040,7 @@ LIQUID_SMATRIX_DEFINE_API(LIQUID_SMATRIX_MANGLE_INT,   short int)
 //  _x  :   input vector,  [size:  mx  x  nx ]
 //  _y  :   output vector, [size:  my  x  ny ]
 int smatrixb_mulf(smatrixb     _A,
-                  float *      _x,
+                  const float * _x,
                   unsigned int _mx,
                   unsigned int _nx,
                   float *      _y,
@@ -8051,9 +8051,9 @@ int smatrixb_mulf(smatrixb     _A,
 //  _q  :   sparse matrix
 //  _x  :   input vector, [size: _N x 1]
 //  _y  :   output vector, [size: _M x 1]
-int smatrixb_vmulf(smatrixb _q,
-                   float *  _x,
-                   float *  _y);
+int smatrixb_vmulf(smatrixb     _q,
+                   const float * _x,
+                   float *      _y);
 
 
 //

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -427,7 +427,7 @@ CBUFFER() CBUFFER(_create_max)(unsigned int _max_size,                      \
                                unsigned int _max_read);                     \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
-CBUFFER() CBUFFER(_copy)(const CBUFFER() _q);                               \
+CBUFFER() CBUFFER(_copy)(CBUFFER() _q);                                     \
                                                                             \
 /* Destroy cbuffer object, freeing all internal memory                  */  \
 int CBUFFER(_destroy)(CBUFFER() _q);                                        \

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -839,8 +839,8 @@ typedef struct DOTPROD(_s) * DOTPROD();                                     \
 /*  _x      : input array, [size: _n x 1]                               */  \
 /*  _n      : dotprod length, _n > 0                                    */  \
 /*  _y      : output sample pointer                                     */  \
-int DOTPROD(_run)( TC *         _v,                                         \
-                   TI *         _x,                                         \
+int DOTPROD(_run)( const TC *   _v,                                         \
+                   const TI *   _x,                                         \
                    unsigned int _n,                                         \
                    TO *         _y);                                        \
                                                                             \
@@ -851,21 +851,21 @@ int DOTPROD(_run)( TC *         _v,                                         \
 /*  _x      : input array, [size: _n x 1]                               */  \
 /*  _n      : dotprod length, _n > 0                                    */  \
 /*  _y      : output sample pointer                                     */  \
-int DOTPROD(_run4)(TC *         _v,                                         \
-                   TI *         _x,                                         \
+int DOTPROD(_run4)(const TC *   _v,                                         \
+                   const TI *   _x,                                         \
                    unsigned int _n,                                         \
                    TO *         _y);                                        \
                                                                             \
 /* Create vector dot product object                                     */  \
 /*  _v      : coefficients array, [size: _n x 1]                        */  \
 /*  _n      : dotprod length, _n > 0                                    */  \
-DOTPROD() DOTPROD(_create)(TC *         _v,                                 \
+DOTPROD() DOTPROD(_create)(const TC *   _v,                                 \
                            unsigned int _n);                                \
                                                                             \
 /* Create vector dot product object with time-reversed coefficients     */  \
 /*  _v      : time-reversed coefficients array, [size: _n x 1]          */  \
 /*  _n      : dotprod length, _n > 0                                    */  \
-DOTPROD() DOTPROD(_create_rev)(TC *         _v,                             \
+DOTPROD() DOTPROD(_create_rev)(const TC *   _v,                             \
                                unsigned int _n);                            \
                                                                             \
 /* Re-create dot product object of potentially a different length with  */  \
@@ -875,7 +875,7 @@ DOTPROD() DOTPROD(_create_rev)(TC *         _v,                             \
 /*  _v      : coefficients array, [size: _n x 1]                        */  \
 /*  _n      : dotprod length, _n > 0                                    */  \
 DOTPROD() DOTPROD(_recreate)(DOTPROD()    _q,                               \
-                             TC *         _v,                               \
+                             const TC *   _v,                               \
                              unsigned int _n);                              \
                                                                             \
 /* Re-create dot product object of potentially a different length with  */  \
@@ -886,7 +886,7 @@ DOTPROD() DOTPROD(_recreate)(DOTPROD()    _q,                               \
 /*  _v      : time-reversed coefficients array, [size: _n x 1]          */  \
 /*  _n      : dotprod length, _n > 0                                    */  \
 DOTPROD() DOTPROD(_recreate_rev)(DOTPROD()    _q,                           \
-                                 TC *         _v,                           \
+                                 const TC *   _v,                           \
                                  unsigned int _n);                          \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
@@ -903,7 +903,7 @@ int DOTPROD(_print)(DOTPROD() _q);                                          \
 /*  _x      : input array, [size: _n x 1]                               */  \
 /*  _y      : output sample pointer                                     */  \
 int DOTPROD(_execute)(DOTPROD() _q,                                         \
-                      TI *      _x,                                         \
+                      const TI * _x,                                        \
                       TO *      _y);                                        \
 
 LIQUID_DOTPROD_DEFINE_API(LIQUID_DOTPROD_MANGLE_RRRF,
@@ -925,11 +925,11 @@ LIQUID_DOTPROD_DEFINE_API(LIQUID_DOTPROD_MANGLE_CRCF,
 // sum squared methods
 //
 
-float liquid_sumsqf(float *      _v,
+float liquid_sumsqf(const float * _v,
                     unsigned int _n);
 
-float liquid_sumsqcf(liquid_float_complex * _v,
-                     unsigned int           _n);
+float liquid_sumsqcf(const liquid_float_complex * _v,
+                     unsigned int                 _n);
 
 
 //

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -5272,13 +5272,13 @@ int framedatastats_print(framedatastats_s * _stats);
 //  _payload_valid  :   is payload valid? (0:no, 1:yes)
 //  _stats          :   frame statistics object
 //  _userdata       :   pointer to userdata
-typedef int (*framesync_callback)(unsigned char *  _header,
-                                  int              _header_valid,
-                                  unsigned char *  _payload,
-                                  unsigned int     _payload_len,
-                                  int              _payload_valid,
-                                  framesyncstats_s _stats,
-                                  void *           _userdata);
+typedef int (*framesync_callback)(const unsigned char * _header,
+                                  int                   _header_valid,
+                                  const unsigned char * _payload,
+                                  unsigned int          _payload_len,
+                                  int                   _payload_valid,
+                                  framesyncstats_s      _stats,
+                                  void *                _userdata);
 
 // framesync csma callback functions invoked when signal levels is high or low
 //  _userdata       :   user-defined data pointer
@@ -5457,9 +5457,9 @@ int qpilotgen_print(  qpilotgen _q);
 unsigned int qpilotgen_get_frame_len(qpilotgen _q);
 
 // insert pilot symbols
-int qpilotgen_execute(qpilotgen              _q,
-                      liquid_float_complex * _payload,
-                      liquid_float_complex * _frame);
+int qpilotgen_execute(qpilotgen                    _q,
+                      const liquid_float_complex * _payload,
+                      liquid_float_complex *       _frame);
 
 //
 // pilot synchronizer for packet burst recovery
@@ -5522,8 +5522,8 @@ int framegen64_print(framegen64 _q);
 //  _payload    :   64-byte payload data, NULL for random
 //  _frame      :   output frame samples, [size: LIQUID_FRAME64_LEN x 1]
 int framegen64_execute(framegen64             _q,
-                       unsigned char *        _header,
-                       unsigned char *        _payload,
+                       const unsigned char *  _header,
+                       const unsigned char *  _payload,
                        liquid_float_complex * _frame);
 
 typedef struct framesync64_s * framesync64;
@@ -5771,19 +5771,19 @@ void bpacketgen_print(bpacketgen _q);
 unsigned int bpacketgen_get_packet_len(bpacketgen _q);
 
 // encode packet
-void bpacketgen_encode(bpacketgen _q,
-                       unsigned char * _msg_dec,
-                       unsigned char * _packet);
+void bpacketgen_encode(bpacketgen            _q,
+                       const unsigned char * _msg_dec,
+                       unsigned char *       _packet);
 
 //
 // bpacket synchronizer/decoder
 //
 typedef struct bpacketsync_s * bpacketsync;
-typedef int (*bpacketsync_callback)(unsigned char *  _payload,
-                                    int              _payload_valid,
-                                    unsigned int     _payload_len,
-                                    framesyncstats_s _stats,
-                                    void *           _userdata);
+typedef int (*bpacketsync_callback)(const unsigned char * _payload,
+                                    int                   _payload_valid,
+                                    unsigned int          _payload_len,
+                                    framesyncstats_s      _stats,
+                                    void *                _userdata);
 bpacketsync bpacketsync_create(unsigned int _m,
                                bpacketsync_callback _callback,
                                void * _userdata);
@@ -5828,13 +5828,13 @@ fskframegen fskframegen_create();
 int fskframegen_destroy (fskframegen     _fg);
 int fskframegen_print   (fskframegen     _fg);
 int fskframegen_reset   (fskframegen     _fg);
-int fskframegen_assemble(fskframegen     _fg,
-                         unsigned char * _header,
-                         unsigned char * _payload,
-                         unsigned int    _payload_len,
-                         crc_scheme      _check,
-                         fec_scheme      _fec0,
-                         fec_scheme      _fec1);
+int fskframegen_assemble(fskframegen           _fg,
+                         const unsigned char * _header,
+                         const unsigned char * _payload,
+                         unsigned int          _payload_len,
+                         crc_scheme            _check,
+                         fec_scheme            _fec0,
+                         fec_scheme            _fec1);
 unsigned int fskframegen_getframelen(fskframegen _q);
 int fskframegen_write_samples(fskframegen            _fg,
                               liquid_float_complex * _buf,
@@ -6012,7 +6012,7 @@ int dsssframesync_set_header_len      (dsssframesync _q, unsigned int  _len);
 int dsssframesync_decode_header_soft  (dsssframesync _q, int _soft);
 int dsssframesync_decode_payload_soft (dsssframesync _q, int _soft);
 int dsssframesync_set_header_props    (dsssframesync _q, dsssframegenprops_s * _props);
-int dsssframesync_execute             (dsssframesync _q, liquid_float_complex * _x, unsigned int _n);
+int dsssframesync_execute             (dsssframesync _q, const liquid_float_complex * _x, unsigned int _n);
 int dsssframesync_reset_framedatastats(dsssframesync _q);
 int dsssframesync_debug_enable        (dsssframesync _q);
 int dsssframesync_debug_disable       (dsssframesync _q);
@@ -6074,7 +6074,7 @@ int dsssframe64sync_set_context(dsssframe64sync _q,
 //  _q       : frame synchronizer object
 //  _buf     : input sample array, shape: (_buf_len,)
 //  _buf_len : number of input samples
-int dsssframe64sync_execute(dsssframe64sync _q, liquid_float_complex * _buf, unsigned int _buf_len);
+int dsssframe64sync_execute(dsssframe64sync _q, const liquid_float_complex * _buf, unsigned int _buf_len);
 
 // get detection threshold
 float dsssframe64sync_get_threshold(dsssframe64sync _q);
@@ -6261,7 +6261,7 @@ typedef struct BSYNC(_s) * BSYNC();                                         \
 /*  _n  : sequence length                                               */  \
 /*  _v  : correlation sequence, [size: _n x 1]                          */  \
 BSYNC() BSYNC(_create)(unsigned int _n,                                     \
-                       TC *         _v);                                    \
+                       const TC *   _v);                                    \
                                                                             \
 /* Create binary synchronizer from m-sequence                           */  \
 /*  _g  :   m-sequence generator polynomial                             */  \
@@ -6322,7 +6322,7 @@ typedef struct PRESYNC(_s) * PRESYNC();                                     \
 /*  _n          : baseband sequence length, _n > 0                      */  \
 /*  _dphi_max   : maximum absolute frequency deviation for detection    */  \
 /*  _m          : number of correlators, _m > 0                         */  \
-PRESYNC() PRESYNC(_create)(TC *         _v,                                 \
+PRESYNC() PRESYNC(_create)(const TC *   _v,                                 \
                            unsigned int _n,                                 \
                            float        _dphi_max,                          \
                            unsigned int _m);                                \
@@ -6379,7 +6379,7 @@ typedef struct QDETECTOR(_s) * QDETECTOR();                                 \
 /* Create detector with generic sequence                                */  \
 /*  _s      :   sample sequence                                         */  \
 /*  _s_len  :   length of sample sequence                               */  \
-QDETECTOR() QDETECTOR(_create)(TI *         _s,                             \
+QDETECTOR() QDETECTOR(_create)(const TI *   _s,                             \
                                unsigned int _s_len);                        \
                                                                             \
 /* Create detector from sequence of symbols using internal linear       */  \
@@ -6390,7 +6390,7 @@ QDETECTOR() QDETECTOR(_create)(TI *         _s,                             \
 /*  _k              :   samples/symbol                                  */  \
 /*  _m              :   filter delay                                    */  \
 /*  _beta           :   excess bandwidth factor                         */  \
-QDETECTOR() QDETECTOR(_create_linear)(TI *         _sequence,               \
+QDETECTOR() QDETECTOR(_create_linear)(const TI *   _sequence,               \
                                       unsigned int _sequence_len,           \
                                       int          _ftype,                  \
                                       unsigned int _k,                      \
@@ -6403,11 +6403,11 @@ QDETECTOR() QDETECTOR(_create_linear)(TI *         _sequence,               \
 /*  _k              :   samples/symbol                                  */  \
 /*  _m              :   filter delay                                    */  \
 /*  _beta           :   excess bandwidth factor                         */  \
-QDETECTOR() QDETECTOR(_create_gmsk)(unsigned char * _sequence,              \
-                                    unsigned int    _sequence_len,          \
-                                    unsigned int    _k,                     \
-                                    unsigned int    _m,                     \
-                                    float           _beta);                 \
+QDETECTOR() QDETECTOR(_create_gmsk)(const unsigned char * _sequence,        \
+                                    unsigned int          _sequence_len,    \
+                                    unsigned int          _k,               \
+                                    unsigned int          _m,               \
+                                    float                 _beta);           \
                                                                             \
 /* create detector from sequence of CP-FSK symbols (assuming one        */  \
 /* bit/symbol)                                                          */  \
@@ -6419,14 +6419,14 @@ QDETECTOR() QDETECTOR(_create_gmsk)(unsigned char * _sequence,              \
 /*  _m              :   filter delay                                    */  \
 /*  _beta           :   filter bandwidth parameter, _beta > 0           */  \
 /*  _type           :   filter type (e.g. LIQUID_CPFSK_SQUARE)          */  \
-QDETECTOR() QDETECTOR(_create_cpfsk)(unsigned char * _sequence,             \
-                                     unsigned int    _sequence_len,         \
-                                     unsigned int    _bps,                  \
-                                     float           _h,                    \
-                                     unsigned int    _k,                    \
-                                     unsigned int    _m,                    \
-                                     float           _beta,                 \
-                                     int             _type);                \
+QDETECTOR() QDETECTOR(_create_cpfsk)(const unsigned char * _sequence,       \
+                                     unsigned int          _sequence_len,   \
+                                     unsigned int          _bps,            \
+                                     float                 _h,              \
+                                     unsigned int          _k,              \
+                                     unsigned int          _m,              \
+                                     float                 _beta,           \
+                                     int                   _type);          \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
 QDETECTOR() QDETECTOR(_copy)(QDETECTOR() _q);                               \
@@ -6531,7 +6531,7 @@ typedef int (*QDSYNC(_callback))(TO *         _buf,                         \
 /*  _beta       : filter excess bandwidth factor                        */  \
 /*  _callback   : user-defined callback                                 */  \
 /*  _context    : user-defined context                                  */  \
-QDSYNC() QDSYNC(_create_linear)(TI *              _s,                       \
+QDSYNC() QDSYNC(_create_linear)(const TI *        _s,                       \
                                 unsigned int      _s_len,                   \
                                 int               _ftype,                   \
                                 unsigned int      _k,                       \
@@ -6582,7 +6582,7 @@ int QDSYNC(_set_buf_len)(QDSYNC() _q, unsigned int _buf_len);               \
                                                                             \
 /* execute block of samples                                             */  \
 int QDSYNC(_execute)(QDSYNC()     _q,                                       \
-                     TI *         _buf,                                     \
+                     const TI *   _buf,                                     \
                      unsigned int _buf_len);                                \
                                                                             \
 /* Return flag indicating if synchronizer actively running.             */  \
@@ -6619,10 +6619,10 @@ typedef struct detector_cccf_s * detector_cccf;
 //  _n          :   sequence length
 //  _threshold  :   detection threshold (default: 0.7)
 //  _dphi_max   :   maximum carrier offset
-detector_cccf detector_cccf_create(liquid_float_complex * _s,
-                                   unsigned int           _n,
-                                   float                  _threshold,
-                                   float                  _dphi_max);
+detector_cccf detector_cccf_create(const liquid_float_complex * _s,
+                                   unsigned int                 _n,
+                                   float                        _threshold,
+                                   float                        _dphi_max);
 
 // destroy pre-demo detector object
 void detector_cccf_destroy(detector_cccf _q);
@@ -9070,9 +9070,9 @@ int ofdmframegen_writetail(ofdmframegen _q,
 // OFDM frame (symbol) synchronizer
 //
 typedef int (*ofdmframesync_callback)(liquid_float_complex * _y,
-                                      unsigned char * _p,
-                                      unsigned int _M,
-                                      void * _userdata);
+                                      const unsigned char *  _p,
+                                      unsigned int           _M,
+                                      void *                 _userdata);
 typedef struct ofdmframesync_s * ofdmframesync;
 
 // create OFDM framing synchronizer object

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -951,7 +951,7 @@ typedef struct EQLMS(_s) * EQLMS();                                         \
 /* Create LMS EQ initialized with external coefficients                 */  \
 /*  _h : filter coefficients; set to NULL for {1,0,0...},[size: _n x 1] */  \
 /*  _n : filter length                                                  */  \
-EQLMS() EQLMS(_create)(T *          _h,                                     \
+EQLMS() EQLMS(_create)(const T *    _h,                                     \
                        unsigned int _n);                                    \
                                                                             \
 /* Create LMS EQ initialized with square-root Nyquist prototype filter  */  \
@@ -982,7 +982,7 @@ EQLMS() EQLMS(_create_lowpass)(unsigned int _n,                             \
 /*  _h : filter coefficients; set to NULL for {1,0,0...},[size: _n x 1] */  \
 /*  _n : filter length                                                  */  \
 EQLMS() EQLMS(_recreate)(EQLMS()      _q,                                   \
-                         T *          _h,                                   \
+                         const T *    _h,                                   \
                          unsigned int _n);                                  \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
@@ -1037,7 +1037,7 @@ int EQLMS(_push)(EQLMS() _q,                                                \
 /*  _x      :   input sample array, [size: _n x 1]                      */  \
 /*  _n      :   input sample array length                               */  \
 int EQLMS(_push_block)(EQLMS()      _q,                                     \
-                       T *          _x,                                     \
+                       const T *    _x,                                     \
                        unsigned int _n);                                    \
                                                                             \
 /* Execute internal dot product and return result                       */  \
@@ -1052,7 +1052,7 @@ int EQLMS(_execute)(EQLMS() _q,                                             \
 /*  _y      :   output sample                                           */  \
 /*  _k      :   down-sampling rate                                      */  \
 int EQLMS(_decim_execute)(EQLMS()      _q,                                  \
-                          T *          _x,                                  \
+                          const T *    _x,                                  \
                           T *          _y,                                  \
                           unsigned int _k);                                 \
                                                                             \
@@ -1066,7 +1066,7 @@ int EQLMS(_decim_execute)(EQLMS()      _q,                                  \
 /*  _y      :   output sample array, [size: _n x 1]                     */  \
 int EQLMS(_execute_block)(EQLMS()      _q,                                  \
                           unsigned int _k,                                  \
-                          T *          _x,                                  \
+                          const T *    _x,                                  \
                           unsigned int _n,                                  \
                           T *          _y);                                 \
                                                                             \
@@ -1093,8 +1093,8 @@ int EQLMS(_step_blind)(EQLMS() _q,                                          \
 DEPRECATED("method provides complexity with little benefit",                \
 int EQLMS(_train)(EQLMS()      _q,                                          \
                   T *          _w,                                          \
-                  T *          _x,                                          \
-                  T *          _d,                                          \
+                  const T *    _x,                                          \
+                  const T *    _d,                                          \
                   unsigned int _n);                                         \
 )                                                                           \
 
@@ -1117,7 +1117,7 @@ typedef struct EQRLS(_s) * EQRLS();                                         \
 /* Create RLS EQ initialized with external coefficients                 */  \
 /*  _h : filter coefficients; set to NULL for {1,0,0...},[size: _n x 1] */  \
 /*  _n : filter length                                                  */  \
-EQRLS() EQRLS(_create)(T *          _h,                                     \
+EQRLS() EQRLS(_create)(const T *    _h,                                     \
                        unsigned int _n);                                    \
                                                                             \
 /* Re-create EQ initialized with external coefficients                  */  \
@@ -1125,7 +1125,7 @@ EQRLS() EQRLS(_create)(T *          _h,                                     \
 /*  _h :   filter coefficients (NULL for {1,0,0...}), [size: _n x 1]    */  \
 /*  _n :   filter length                                                */  \
 EQRLS() EQRLS(_recreate)(EQRLS()      _q,                                   \
-                         T *          _h,                                   \
+                         const T *    _h,                                   \
                          unsigned int _n);                                  \
                                                                             \
 /* Copy object including all internal objects and state                 */  \
@@ -1179,8 +1179,8 @@ int EQRLS(_get_weights)(EQRLS() _q,                                         \
 /*  _n      :   input, output vector length                             */  \
 int EQRLS(_train)(EQRLS()      _q,                                          \
                   T *          _w,                                          \
-                  T *          _x,                                          \
-                  T *          _d,                                          \
+                  const T *    _x,                                          \
+                  const T *    _d,                                          \
                   unsigned int _n);                                         \
 
 LIQUID_EQRLS_DEFINE_API(LIQUID_EQRLS_MANGLE_RRRF, float)

--- a/include/liquid.h
+++ b/include/liquid.h
@@ -8151,8 +8151,8 @@ unsigned int count_bit_errors(unsigned int _s1, unsigned int _s2);
 //  _msg0   :   original message, [size: _n x 1]
 //  _msg1   :   copy of original message, [size: _n x 1]
 //  _n      :   message size
-unsigned int count_bit_errors_array(unsigned char * _msg0,
-                                    unsigned char * _msg1,
+unsigned int count_bit_errors_array(const unsigned char * _msg0,
+                                    const unsigned char * _msg1,
                                     unsigned int _n);
 
 // converts binary-coded decimal (BCD) to gray, ensuring successive values
@@ -8166,7 +8166,7 @@ unsigned int gray_decode(unsigned int symbol_in);
 //  _soft_bits  :   soft input bits, [size: _bps x 1]
 //  _bps        :   bits per symbol
 //  _sym_out    :   output symbol, value in [0,2^_bps)
-int liquid_pack_soft_bits(unsigned char * _soft_bits,
+int liquid_pack_soft_bits(const unsigned char * _soft_bits,
                           unsigned int _bps,
                           unsigned int * _sym_out);
 
@@ -8210,8 +8210,8 @@ MODEM() MODEM(_create)(modulation_scheme _scheme);                          \
 /* provided as complex float pairs and converted internally if needed.  */  \
 /*  _table  : array of complex constellation points, [size: _M x 1]     */  \
 /*  _M      : modulation order and table size, _M must be power of 2    */  \
-MODEM() MODEM(_create_arbitrary)(liquid_float_complex * _table,             \
-                                 unsigned int           _M);                \
+MODEM() MODEM(_create_arbitrary)(const liquid_float_complex * _table,       \
+                                 unsigned int                   _M);        \
                                                                             \
 /* Recreate modulation scheme, re-allocating memory as necessary        */  \
 /*  _q      : modem object                                              */  \
@@ -8498,7 +8498,7 @@ int CPFSKDEM(_get_type)(CPFSKDEM() _q);                                     \
 /*  _q      :   continuous-phase frequency demodulator object           */  \
 /*  _y      :   input sample array, [size: _k x 1]                      */  \
 unsigned int CPFSKDEM(_demodulate)(CPFSKDEM() _q,                           \
-                                   TC *       _y);                          \
+                                   const TC * _y);                          \
                                                                             \
 /* demodulate_block */                                                      \
 
@@ -8568,8 +8568,8 @@ int fskdem_reset(fskdem _q);
 // demodulate symbol, assuming perfect symbol timing
 //  _q      :   fskdem object
 //  _y      :   input sample array, [size: _k x 1]
-unsigned int fskdem_demodulate(fskdem                 _q,
-                               liquid_float_complex * _y);
+unsigned int fskdem_demodulate(fskdem                       _q,
+                               const liquid_float_complex * _y);
 
 // get demodulator frequency error
 float fskdem_get_frequency_error(fskdem _q);
@@ -8622,7 +8622,7 @@ int FREQMOD(_modulate)(FREQMOD() _q,                                        \
 /*  _n  : number of input, output samples                               */  \
 /*  _s  : complex baseband signal \( s(t) \),  [size: _n x 1]           */  \
 int FREQMOD(_modulate_block)(FREQMOD()    _q,                               \
-                             T *          _m,                               \
+                             const T *    _m,                               \
                              unsigned int _n,                               \
                              TC *         _s);                              \
 
@@ -8671,7 +8671,7 @@ int FREQDEM(_demodulate)(FREQDEM() _q,                                      \
 /*  _n      :   number of input, output samples                         */  \
 /*  _m      :   message signal m(t), [size: _n x 1]                     */  \
 int FREQDEM(_demodulate_block)(FREQDEM()    _q,                             \
-                               TC *         _r,                             \
+                               const TC *   _r,                             \
                                unsigned int _n,                             \
                                T *          _m);                            \
 
@@ -8716,7 +8716,7 @@ int ampmodem_modulate(ampmodem               _q,
                       liquid_float_complex * _y);
 
 int ampmodem_modulate_block(ampmodem               _q,
-                            float *                _m,
+                            const float *          _m,
                             unsigned int           _n,
                             liquid_float_complex * _s);
 
@@ -8725,10 +8725,10 @@ int ampmodem_demodulate(ampmodem             _q,
                         liquid_float_complex _y,
                         float *              _x);
 
-int ampmodem_demodulate_block(ampmodem               _q,
-                              liquid_float_complex * _r,
-                              unsigned int           _n,
-                              float *                _m);
+int ampmodem_demodulate_block(ampmodem                     _q,
+                              const liquid_float_complex * _r,
+                              unsigned int                 _n,
+                              float *                      _m);
 
 //
 // MODULE : multichannel

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -858,10 +858,10 @@ int liquid_firdes_farcsech_freqresponse(unsigned int _k,
 //  _n      :   number of elements in _z
 //  _tol    :   tolerance for finding complex pairs
 //  _p      :   resulting pairs, pure real values of _z at end
-int liquid_cplxpair(float complex * _z,
-                    unsigned int    _n,
-                    float           _tol,
-                    float complex * _p);
+int liquid_cplxpair(const float complex * _z,
+                    unsigned int          _n,
+                    float                 _tol,
+                    float complex *       _p);
 
 // post-process cleanup used with liquid_cplxpair
 //

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -1261,9 +1261,9 @@ MODEM() MODEM(_create_apsk)(unsigned int _bits_per_symbol);     \
 MODEM() MODEM(_create_arb)( unsigned int _bits_per_symbol);     \
                                                                 \
 /* Initialize arbitrary modem constellation */                  \
-int MODEM(_arb_init)(MODEM()         _q,                        \
-                      float complex * _symbol_map,              \
-                      unsigned int    _len);                    \
+int MODEM(_arb_init)(MODEM()                _q,                 \
+                      const float complex * _symbol_map,        \
+                      unsigned int          _len);              \
                                                                 \
 /* Initialize arb modem constellation from external file */     \
 int MODEM(_arb_init_file)(MODEM() _q, char * _filename);        \

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -1137,7 +1137,7 @@ float complex liquid_catanf(float complex _z);
 //  _p      :   polynomial array, ascending powers, [size: _k x 1]
 //  _k      :   polynomials length (poly order = _k - 1)
 //  _roots  :   resulting complex roots, [size: _k-1 x 1]
-int liquid_poly_findroots_durandkerner(double *         _p,
+int liquid_poly_findroots_durandkerner(const double *   _p,
                                        unsigned int     _k,
                                        double complex * _roots);
 
@@ -1145,7 +1145,7 @@ int liquid_poly_findroots_durandkerner(double *         _p,
 //  _p      :   polynomial array, ascending powers, [size: _k x 1]
 //  _k      :   polynomials length (poly order = _k - 1)
 //  _roots  :   resulting complex roots, [size: _k-1 x 1]
-int liquid_poly_findroots_bairstow(double *         _p,
+int liquid_poly_findroots_bairstow(const double *   _p,
                                    unsigned int     _k,
                                    double complex * _roots);
 

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -1183,7 +1183,7 @@ int liquid_poly_sort_roots_compare(const void * _a,
 //   MATRIX : name-mangling macro
 //   T      : data type
 #define LIQUID_MATRIX_DEFINE_INTERNAL_API(MATRIX,T)             \
-T    MATRIX(_det2x2)(T * _x,                                    \
+T    MATRIX(_det2x2)(const T *     _x,                          \
                      unsigned int _rx,                          \
                      unsigned int _cx);
 

--- a/include/liquid.internal.h
+++ b/include/liquid.internal.h
@@ -147,19 +147,19 @@ struct fec_s {
     // encode function pointer
     int (*encode_func)(fec _q,
                        unsigned int _dec_msg_len,
-                       unsigned char * _msg_dec,
+                       const unsigned char * _msg_dec,
                        unsigned char * _msg_enc);
 
     // decode function pointer
     int (*decode_func)(fec _q,
                        unsigned int _dec_msg_len,
-                       unsigned char * _msg_enc,
+                       const unsigned char * _msg_enc,
                        unsigned char * _msg_dec);
 
     // decode function pointer (soft decision)
     int (*decode_soft_func)(fec _q,
                             unsigned int _dec_msg_len,
-                            unsigned char * _msg_enc,
+                            const unsigned char * _msg_enc,
                             unsigned char * _msg_dec);
 };
 
@@ -176,11 +176,11 @@ int fec_pass_destroy(fec _q);
 int fec_pass_print(fec _q);
 int fec_pass_encode(fec _q,
                     unsigned int _dec_msg_len,
-                    unsigned char * _msg_dec,
+                    const unsigned char * _msg_dec,
                     unsigned char * _msg_enc);
 int fec_pass_decode(fec _q,
                     unsigned int _dec_msg_len,
-                    unsigned char * _msg_enc,
+                    const unsigned char * _msg_enc,
                     unsigned char * _msg_dec);
 
 // Repeat (3)
@@ -189,15 +189,15 @@ int fec_rep3_destroy(fec _q);
 int fec_rep3_print(fec _q);
 int fec_rep3_encode(fec _q,
                     unsigned int _dec_msg_len,
-                    unsigned char * _msg_dec,
+                    const unsigned char * _msg_dec,
                     unsigned char * _msg_enc);
 int fec_rep3_decode(fec _q,
                     unsigned int _dec_msg_len,
-                    unsigned char * _msg_enc,
+                    const unsigned char * _msg_enc,
                     unsigned char * _msg_dec);
 int fec_rep3_decode_soft(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_enc,
+                         const unsigned char * _msg_enc,
                          unsigned char * _msg_dec);
 
 // Repeat (5)
@@ -206,15 +206,15 @@ int fec_rep5_destroy(fec _q);
 int fec_rep5_print(fec _q);
 int fec_rep5_encode(fec _q,
                     unsigned int _dec_msg_len,
-                    unsigned char * _msg_dec,
+                    const unsigned char * _msg_dec,
                     unsigned char * _msg_enc);
 int fec_rep5_decode(fec _q,
                     unsigned int _dec_msg_len,
-                    unsigned char * _msg_enc,
+                    const unsigned char * _msg_enc,
                     unsigned char * _msg_dec);
 int fec_rep5_decode_soft(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_enc,
+                         const unsigned char * _msg_enc,
                          unsigned char * _msg_dec);
 
 // Hamming(7,4)
@@ -225,18 +225,18 @@ int fec_hamming74_destroy(fec _q);
 int fec_hamming74_print(fec _q);
 int fec_hamming74_encode(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_dec,
+                         const unsigned char * _msg_dec,
                          unsigned char * _msg_enc);
 int fec_hamming74_decode(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_enc,
+                         const unsigned char * _msg_enc,
                          unsigned char * _msg_dec);
 int fec_hamming74_decode_soft(fec _q,
                               unsigned int _dec_msg_len,
-                              unsigned char * _msg_enc,
+                              const unsigned char * _msg_enc,
                               unsigned char * _msg_dec);
 // soft decoding of one symbol
-unsigned char fecsoft_hamming74_decode(unsigned char * _soft_bits);
+unsigned char fecsoft_hamming74_decode(const unsigned char * _soft_bits);
 
 // Hamming(8,4)
 extern unsigned char hamming84_enc_gentab[16];
@@ -246,18 +246,18 @@ int fec_hamming84_destroy(fec _q);
 int fec_hamming84_print(fec _q);
 int fec_hamming84_encode(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_dec,
+                         const unsigned char * _msg_dec,
                          unsigned char * _msg_enc);
 int fec_hamming84_decode(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_enc,
+                         const unsigned char * _msg_enc,
                          unsigned char * _msg_dec);
 int fec_hamming84_decode_soft(fec _q,
                               unsigned int _dec_msg_len,
-                              unsigned char * _msg_enc,
+                              const unsigned char * _msg_enc,
                               unsigned char * _msg_dec);
 // soft decoding of one symbol
-unsigned char fecsoft_hamming84_decode(unsigned char * _soft_bits);
+unsigned char fecsoft_hamming84_decode(const unsigned char * _soft_bits);
 
 // Hamming(12,8)
 
@@ -270,20 +270,20 @@ int fec_hamming128_destroy(fec _q);
 int fec_hamming128_print(fec _q);
 int fec_hamming128_encode(fec _q,
                           unsigned int _dec_msg_len,
-                          unsigned char * _msg_dec,
+                          const unsigned char * _msg_dec,
                           unsigned char * _msg_enc);
 int fec_hamming128_decode(fec _q,
                           unsigned int _dec_msg_len,
-                          unsigned char * _msg_enc,
+                          const unsigned char * _msg_enc,
                           unsigned char * _msg_dec);
 int fec_hamming128_decode_soft(fec _q,
                                unsigned int _dec_msg_len,
-                               unsigned char * _msg_enc,
+                               const unsigned char * _msg_enc,
                                unsigned char * _msg_dec);
 // soft decoding of one symbol
-unsigned int fecsoft_hamming128_decode(unsigned char * _soft_bits);
+unsigned int fecsoft_hamming128_decode(const unsigned char * _soft_bits);
 extern unsigned char fecsoft_hamming128_n3[256][17];
-unsigned int fecsoft_hamming128_decode_n3(unsigned char * _soft_bits);
+unsigned int fecsoft_hamming128_decode_n3(const unsigned char * _soft_bits);
 
 
 // Hamming(15,11)
@@ -316,37 +316,37 @@ int fec_golay2412_destroy(fec _q);
 int fec_golay2412_print(fec _q);
 int fec_golay2412_encode(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_dec,
+                         const unsigned char * _msg_dec,
                          unsigned char * _msg_enc);
 int fec_golay2412_decode(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_enc,
+                         const unsigned char * _msg_enc,
                          unsigned char * _msg_dec);
 
 // SEC-DED (22,16)
 
 // compute parity on 16-bit input
-unsigned char fec_secded2216_compute_parity(unsigned char * _m);
+unsigned char fec_secded2216_compute_parity(const unsigned char * _m);
 
 // compute syndrome on 22-bit input
-unsigned char fec_secded2216_compute_syndrome(unsigned char * _v);
+unsigned char fec_secded2216_compute_syndrome(const unsigned char * _v);
 
 // encode symbol
 //  _sym_dec    :   decoded symbol, [size: 2 x 1]
 //  _sym_enc    :   encoded symbol, [size: 3 x 1], _sym_enc[0] has only 6 bits
-int fec_secded2216_encode_symbol(unsigned char * _sym_dec,
+int fec_secded2216_encode_symbol(const unsigned char * _sym_dec,
                                  unsigned char * _sym_enc);
 
 // decode symbol, returning 0/1/2 for zero/one/multiple errors detected
 //  _sym_enc    :   encoded symbol, [size: 3 x 1], _sym_enc[0] has only 6 bits
 //  _sym_dec    :   decoded symbol, [size: 2 x 1]
-int  fec_secded2216_decode_symbol(unsigned char * _sym_enc,
+int  fec_secded2216_decode_symbol(const unsigned char * _sym_enc,
                                   unsigned char * _sym_dec);
 
 // estimate error vector, returning 0/1/2 for zero/one/multiple errors detected
 //  _sym_enc    :   encoded symbol, [size: 3 x 1], _sym_enc[0] has only 6 bits
 //  _e_hat      :   estimated error vector, [size: 3 x 1]
-int  fec_secded2216_estimate_ehat(unsigned char * _sym_enc,
+int  fec_secded2216_estimate_ehat(const unsigned char * _sym_enc,
                                   unsigned char * _e_hat);
 
 // parity matrix [6 x 16 bits], [6 x 2 bytes]
@@ -360,37 +360,37 @@ int fec_secded2216_destroy(fec _q);
 int fec_secded2216_print(fec _q);
 int fec_secded2216_encode(fec _q,
                           unsigned int _dec_msg_len,
-                          unsigned char * _msg_dec,
+                          const unsigned char * _msg_dec,
                           unsigned char * _msg_enc);
 int fec_secded2216_decode(fec _q,
                           unsigned int _dec_msg_len,
-                          unsigned char * _msg_enc,
+                          const unsigned char * _msg_enc,
                           unsigned char * _msg_dec);
 
 // SEC-DED (39,32)
 
 // compute parity on 32-bit input
-unsigned char fec_secded3932_compute_parity(unsigned char * _m);
+unsigned char fec_secded3932_compute_parity(const unsigned char * _m);
 
 // compute syndrome on 39-bit input
-unsigned char fec_secded3932_compute_syndrome(unsigned char * _v);
+unsigned char fec_secded3932_compute_syndrome(const unsigned char * _v);
 
 // encode symbol
 //  _sym_dec    :   decoded symbol, [size: 4 x 1]
 //  _sym_enc    :   encoded symbol, [size: 5 x 1], _sym_enc[0] has only 7 bits
-int fec_secded3932_encode_symbol(unsigned char * _sym_dec,
+int fec_secded3932_encode_symbol(const unsigned char * _sym_dec,
                                  unsigned char * _sym_enc);
 
 // estimate error vector, returning 0/1/2 for zero/one/multiple errors detected
 //  _sym_enc    :   encoded symbol, [size: 5 x 1], _sym_enc[0] has only 7 bits
 //  _e_hat      :   estimated error vector, [size: 5 x 1]
-int  fec_secded3932_estimate_ehat(unsigned char * _sym_enc,
+int  fec_secded3932_estimate_ehat(const unsigned char * _sym_enc,
                                   unsigned char * _e_hat);
 
 // decode symbol, returning 0/1/2 for zero/one/multiple errors detected
 //  _sym_enc    :   encoded symbol (_sym_enc[0] has only 7 bits), [size: 5 x 1]
 //  _sym_dec    :   decoded symbol, [size: 4 x 1]
-int fec_secded3932_decode_symbol(unsigned char * _sym_enc,
+int fec_secded3932_decode_symbol(const unsigned char * _sym_enc,
                                 unsigned char * _sym_dec);
 
 // parity matrix [7 x 32 bits], [7 x 4 bytes]
@@ -404,37 +404,37 @@ int fec_secded3932_destroy(fec _q);
 int fec_secded3932_print(fec _q);
 int fec_secded3932_encode(fec _q,
                           unsigned int _dec_msg_len,
-                          unsigned char * _msg_dec,
+                          const unsigned char * _msg_dec,
                           unsigned char * _msg_enc);
 int fec_secded3932_decode(fec _q,
                           unsigned int _dec_msg_len,
-                          unsigned char * _msg_enc,
+                          const unsigned char * _msg_enc,
                           unsigned char * _msg_dec);
 
 // SEC-DED (72,64)
 
 // compute parity byte on 64-byte input
-unsigned char fec_secded7264_compute_parity(unsigned char * _v);
+unsigned char fec_secded7264_compute_parity(const unsigned char * _v);
 
 // compute syndrome on 72-bit input
-unsigned char fec_secded7264_compute_syndrome(unsigned char * _v);
+unsigned char fec_secded7264_compute_syndrome(const unsigned char * _v);
 
 // encode symbol
 //  _sym_dec    :   input symbol, [size: 8 x 1]
 //  _sym_enc    :   input symbol, [size: 9 x 1]
-int fec_secded7264_encode_symbol(unsigned char * _sym_dec,
+int fec_secded7264_encode_symbol(const unsigned char * _sym_dec,
                                  unsigned char * _sym_enc);
 
 // estimate error vector, returning 0/1/2 for zero/one/multiple errors detected
 //  _sym_enc    :   encoded symbol, [size: 9 x 1]
 //  _e_hat      :   estimated error vector, [size: 9 x 1]
-int fec_secded7264_estimate_ehat(unsigned char * _sym_enc,
+int fec_secded7264_estimate_ehat(const unsigned char * _sym_enc,
                                  unsigned char * _e_hat);
 
 // decode symbol, returning 0/1/2 for zero/one/multiple errors detected
 //  _sym_enc    :   input symbol, [size: 8 x 1]
 //  _sym_dec    :   input symbol, [size: 9 x 1]
-int fec_secded7264_decode_symbol(unsigned char * _sym_enc,
+int fec_secded7264_decode_symbol(const unsigned char * _sym_enc,
                                  unsigned char * _sym_dec);
 
 extern unsigned char secded7264_P[64];
@@ -445,11 +445,11 @@ int fec_secded7264_destroy(fec _q);
 int fec_secded7264_print(fec _q);
 int fec_secded7264_encode(fec _q,
                           unsigned int _dec_msg_len,
-                          unsigned char * _msg_dec,
+                          const unsigned char * _msg_dec,
                           unsigned char * _msg_enc);
 int fec_secded7264_decode(fec _q,
                           unsigned int _dec_msg_len,
-                          unsigned char * _msg_enc,
+                          const unsigned char * _msg_enc,
                           unsigned char * _msg_dec);
 
 
@@ -500,15 +500,15 @@ int fec_conv_destroy(fec _q);
 int fec_conv_print(fec _q);
 int fec_conv_encode(fec _q,
                     unsigned int _dec_msg_len,
-                    unsigned char * _msg_dec,
+                    const unsigned char * _msg_dec,
                     unsigned char * _msg_enc);
 int fec_conv_decode_hard(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_enc,
+                         const unsigned char * _msg_enc,
                          unsigned char * _msg_dec);
 int fec_conv_decode_soft(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char * _msg_enc,
+                         const unsigned char * _msg_enc,
                          unsigned char * _msg_dec);
 int fec_conv_decode(fec _q, unsigned char * _msg_dec);
 int fec_conv_setlength(fec _q, unsigned int _dec_msg_len);
@@ -525,15 +525,15 @@ int fec_conv_punctured_destroy(fec _q);
 int fec_conv_punctured_print(fec _q);
 int fec_conv_punctured_encode(fec _q,
                                unsigned int _dec_msg_len,
-                               unsigned char * _msg_dec,
+                               const unsigned char * _msg_dec,
                                unsigned char * _msg_enc);
 int fec_conv_punctured_decode_hard(fec _q,
                                    unsigned int _dec_msg_len,
-                                   unsigned char * _msg_enc,
+                                   const unsigned char * _msg_enc,
                                    unsigned char * _msg_dec);
 int fec_conv_punctured_decode_soft(fec _q,
                                    unsigned int _dec_msg_len,
-                                   unsigned char * _msg_enc,
+                                   const unsigned char * _msg_enc,
                                    unsigned char * _msg_dec);
 int fec_conv_punctured_setlength(fec _q, unsigned int _dec_msg_len);
 
@@ -573,11 +573,11 @@ int fec_rs_setlength(fec _q,
                      unsigned int _dec_msg_len);
 int fec_rs_encode(fec _q,
                   unsigned int _dec_msg_len,
-                  unsigned char * _msg_dec,
+                  const unsigned char * _msg_dec,
                   unsigned char * _msg_enc);
 int fec_rs_decode(fec _q,
                   unsigned int _dec_msg_len,
-                  unsigned char * _msg_enc,
+                  const unsigned char * _msg_enc,
                   unsigned char * _msg_dec);
 
 // phi(x) = -logf( tanhf( x/2 ) )

--- a/src/agc/src/agc.proto.c
+++ b/src/agc/src/agc.proto.c
@@ -184,7 +184,7 @@ int AGC(_execute)(AGC() _q,
 //  _n      : number of input, output samples
 //  _y      : output data array, [size: _n x 1]
 int AGC(_execute_block)(AGC()        _q,
-                        TC *         _x,
+                        const TC *   _x,
                         unsigned int _n,
                         TC *         _y)
 {
@@ -334,7 +334,7 @@ int AGC(_set_scale)(AGC() _q,
 //  _x      : input data array, [size: _n x 1]
 //  _n      : number of input, output samples
 int AGC(_init)(AGC()        _q,
-               TC *         _x,
+               const TC *   _x,
                unsigned int _n)
 {
     // ensure number of samples is greater than zero

--- a/src/audio/src/cvsd.c
+++ b/src/audio/src/cvsd.c
@@ -199,7 +199,7 @@ float cvsd_decode(cvsd _q,
 
 // encode 8 samples
 int cvsd_encode8(cvsd _q,
-                 float * _audio,
+                 const float * _audio,
                  unsigned char * _data)
 {
     unsigned char data=0x00;

--- a/src/buffer/src/cbuffer.proto.c
+++ b/src/buffer/src/cbuffer.proto.c
@@ -94,7 +94,7 @@ CBUFFER() CBUFFER(_create_max)(unsigned int _max_size,
 }
 
 // copy object
-CBUFFER() CBUFFER(_copy)(CBUFFER() q_orig)
+CBUFFER() CBUFFER(_copy)(const CBUFFER() q_orig)
 {
     // validate input
     if (q_orig == NULL)
@@ -201,7 +201,7 @@ int CBUFFER(_push)(CBUFFER() _q,
 //  _v  : output array
 //  _n  : number of samples to write
 int CBUFFER(_write)(CBUFFER()    _q,
-                    T *          _v,
+                    const T *    _v,
                     unsigned int _n)
 {
     // ensure number of samples to write doesn't exceed space available

--- a/src/buffer/src/wdelay.proto.c
+++ b/src/buffer/src/wdelay.proto.c
@@ -84,7 +84,7 @@ WDELAY() WDELAY(_recreate)(WDELAY()     _q,
 }
 
 // copy object
-WDELAY() WDELAY(_copy)(WDELAY() q_orig)
+WDELAY() WDELAY(_copy)(const WDELAY() q_orig)
 {
     // validate input
     if (q_orig == NULL)

--- a/src/buffer/src/window.proto.c
+++ b/src/buffer/src/window.proto.c
@@ -108,7 +108,7 @@ WINDOW() WINDOW(_recreate)(WINDOW() _q, unsigned int _n)
 }
 
 // copy object
-WINDOW() WINDOW(_copy)(WINDOW() q_orig)
+WINDOW() WINDOW(_copy)(const WINDOW() q_orig)
 {
     // validate input
     if (q_orig == NULL)
@@ -238,7 +238,7 @@ int WINDOW(_push)(WINDOW() _q, T _v)
 //  _v      : input array of values to write
 //  _n      : number of input values to write
 int WINDOW(_write)(WINDOW()     _q,
-                   T *          _v,
+                   const T *    _v,
                    unsigned int _n)
 {
     // TODO make this more efficient

--- a/src/channel/src/channel.proto.c
+++ b/src/channel/src/channel.proto.c
@@ -179,7 +179,7 @@ int CHANNEL(_add_carrier_offset)(CHANNEL() _q,
 //  _h          : channel coefficients (NULL for random)
 //  _h_len      : number of channel coefficients
 int CHANNEL(_add_multipath)(CHANNEL()    _q,
-                            TC *         _h,
+                            const TC *   _h,
                             unsigned int _h_len)
 {
     if (_h_len == 0)
@@ -303,7 +303,7 @@ int CHANNEL(_execute)(CHANNEL() _q,
 //  _n      : input array length
 //  _y      : output array [size: _n x 1]
 int CHANNEL(_execute_block)(CHANNEL()    _q,
-                            TI *         _x,
+                            const TI *   _x,
                             unsigned int _n,
                             TO *         _y)
 {

--- a/src/channel/src/tvmpch.proto.c
+++ b/src/channel/src/tvmpch.proto.c
@@ -181,7 +181,7 @@ int TVMPCH(_execute_one)(TVMPCH() _q,
 //  _n      : number of input, output samples
 //  _y      : pointer to output array [size: _n x 1]
 int TVMPCH(_execute_block)(TVMPCH()     _q,
-                           TI *         _x,
+                           const TI *   _x,
                            unsigned int _n,
                            TO *         _y)
 {

--- a/src/dotprod/src/dotprod.proto.c
+++ b/src/dotprod/src/dotprod.proto.c
@@ -39,8 +39,8 @@ struct DOTPROD(_s) {
 //  _x      :   input array [size: 1 x _n]
 //  _n      :   input lengths
 //  _y      :   output dot product
-int DOTPROD(_run)(TC *         _h,
-                  TI *         _x,
+int DOTPROD(_run)(const TC *   _h,
+                  const TI *   _x,
                   unsigned int _n,
                   TO *         _y)
 {
@@ -61,8 +61,8 @@ int DOTPROD(_run)(TC *         _h,
 //  _x      :   input array [size: 1 x _n]
 //  _n      :   input lengths
 //  _y      :   output dot product
-int DOTPROD(_run4)(TC *         _h,
-                   TI *         _x,
+int DOTPROD(_run4)(const TC *   _h,
+                   const TI *   _x,
                    unsigned int _n,
                    TO *         _y)
 {
@@ -97,7 +97,7 @@ int DOTPROD(_run4)(TC *         _h,
 // create vector dot product object
 //  _h      :   coefficients array [size: 1 x _n]
 //  _n      :   dot product length
-DOTPROD() DOTPROD(_create)(TC *         _h,
+DOTPROD() DOTPROD(_create)(const TC *   _h,
                            unsigned int _n)
 {
     DOTPROD() q = (DOTPROD()) malloc(sizeof(struct DOTPROD(_s)));
@@ -116,7 +116,7 @@ DOTPROD() DOTPROD(_create)(TC *         _h,
 // create vector dot product object with time-reversed coefficients
 //  _h      :   coefficients array [size: 1 x _n]
 //  _n      :   dot product length
-DOTPROD() DOTPROD(_create_rev)(TC *         _h,
+DOTPROD() DOTPROD(_create_rev)(const TC *   _h,
                                unsigned int _n)
 {
     DOTPROD() q = (DOTPROD()) malloc(sizeof(struct DOTPROD(_s)));
@@ -139,7 +139,7 @@ DOTPROD() DOTPROD(_create_rev)(TC *         _h,
 //  _h      :   new coefficients [size: 1 x _n]
 //  _n      :   new dot product size
 DOTPROD() DOTPROD(_recreate)(DOTPROD()    _q,
-                             TC *         _h,
+                             const TC *   _h,
                              unsigned int _n)
 {
     // check to see if length has changed
@@ -163,7 +163,7 @@ DOTPROD() DOTPROD(_recreate)(DOTPROD()    _q,
 //  _h      :   time-reversed new coefficients [size: 1 x _n]
 //  _n      :   new dot product size
 DOTPROD() DOTPROD(_recreate_rev)(DOTPROD()    _q,
-                                 TC *         _h,
+                                 const TC *   _h,
                                  unsigned int _n)
 {
     // check to see if length has changed
@@ -230,9 +230,9 @@ int DOTPROD(_print)(DOTPROD() _q)
 //  _q      :   dot product object
 //  _x      :   input array [size: 1 x _n]
 //  _y      :   output dot product
-int DOTPROD(_execute)(DOTPROD() _q,
-                      TI *      _x,
-                      TO *      _y)
+int DOTPROD(_execute)(DOTPROD()  _q,
+                      const TI * _x,
+                      TO *       _y)
 {
     // run basic dot product with unrolled loops
     DOTPROD(_run4)(_q->h, _x, _q->n, _y);

--- a/src/dotprod/src/dotprod_cccf.avx.c
+++ b/src/dotprod/src/dotprod_cccf.avx.c
@@ -33,19 +33,19 @@
 #define DEBUG_DOTPROD_CCCF_AVX   0
 
 // forward declaration of internal methods
-int dotprod_cccf_execute_avx(dotprod_cccf    _q,
-                             float complex * _x,
-                             float complex * _y);
+int dotprod_cccf_execute_avx(dotprod_cccf          _q,
+                             const float complex * _x,
+                             float complex *       _y);
 
-int dotprod_cccf_execute_avx4(dotprod_cccf    _q,
-                              float complex * _x,
-                              float complex * _y);
+int dotprod_cccf_execute_avx4(dotprod_cccf          _q,
+                              const float complex * _x,
+                              float complex *       _y);
 
 // basic dot product (ordinal calculation)
-int dotprod_cccf_run(float complex * _h,
-                     float complex * _x,
-                     unsigned int    _n,
-                     float complex * _y)
+int dotprod_cccf_run(const float complex * _h,
+                     const float complex * _x,
+                     unsigned int          _n,
+                     float complex *       _y)
 {
     float complex r = 0;
     unsigned int i;
@@ -56,10 +56,10 @@ int dotprod_cccf_run(float complex * _h,
 }
 
 // basic dot product (ordinal calculation) with loop unrolled
-int dotprod_cccf_run4(float complex * _h,
-                      float complex * _x,
-                      unsigned int    _n,
-                      float complex * _y)
+int dotprod_cccf_run4(const float complex * _h,
+                      const float complex * _x,
+                      unsigned int          _n,
+                      float complex *       _y)
 {
     float complex r = 0;
 
@@ -94,9 +94,9 @@ struct dotprod_cccf_s {
     float * hq;         // quadrature
 };
 
-dotprod_cccf dotprod_cccf_create_opt(float complex * _h,
-                                     unsigned int    _n,
-                                     int             _rev)
+dotprod_cccf dotprod_cccf_create_opt(const float complex * _h,
+                                     unsigned int          _n,
+                                     int                   _rev)
 {
     dotprod_cccf q = (dotprod_cccf)malloc(sizeof(struct dotprod_cccf_s));
     q->n = _n;
@@ -122,22 +122,22 @@ dotprod_cccf dotprod_cccf_create_opt(float complex * _h,
     return q;
 }
 
-dotprod_cccf dotprod_cccf_create(float complex * _h,
-                                 unsigned int    _n)
+dotprod_cccf dotprod_cccf_create(const float complex * _h,
+                                 unsigned int          _n)
 {
     return dotprod_cccf_create_opt(_h, _n, 0);
 }
 
-dotprod_cccf dotprod_cccf_create_rev(float complex * _h,
-                                     unsigned int    _n)
+dotprod_cccf dotprod_cccf_create_rev(const float complex * _h,
+                                     unsigned int          _n)
 {
     return dotprod_cccf_create_opt(_h, _n, 1);
 }
 
 // re-create the structured dotprod object
-dotprod_cccf dotprod_cccf_recreate(dotprod_cccf    _q,
-                                   float complex * _h,
-                                   unsigned int    _n)
+dotprod_cccf dotprod_cccf_recreate(dotprod_cccf          _q,
+                                   const float complex * _h,
+                                   unsigned int          _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_cccf_destroy(_q);
@@ -145,9 +145,9 @@ dotprod_cccf dotprod_cccf_recreate(dotprod_cccf    _q,
 }
 
 // re-create the structured dotprod object, coefficients reversed
-dotprod_cccf dotprod_cccf_recreate_rev(dotprod_cccf    _q,
-                                       float complex * _h,
-                                       unsigned int    _n)
+dotprod_cccf dotprod_cccf_recreate_rev(dotprod_cccf          _q,
+                                       const float complex * _h,
+                                       unsigned int          _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_cccf_destroy(_q);
@@ -198,9 +198,9 @@ int dotprod_cccf_print(dotprod_cccf _q)
 //  _q      :   dotprod object
 //  _x      :   input array
 //  _y      :   output sample
-int dotprod_cccf_execute(dotprod_cccf    _q,
-                         float complex * _x,
-                         float complex * _y)
+int dotprod_cccf_execute(dotprod_cccf          _q,
+                         const float complex * _x,
+                         float complex *       _y)
 {
     // switch based on size
     if (_q->n < 64) {
@@ -237,9 +237,9 @@ int dotprod_cccf_execute(dotprod_cccf    _q,
 //           x[3].real * h[3].imag,
 //           x[3].imag * h[3].imag };
 //
-int dotprod_cccf_execute_avx(dotprod_cccf    _q,
-                             float complex * _x,
-                             float complex * _y)
+int dotprod_cccf_execute_avx(dotprod_cccf          _q,
+                             const float complex * _x,
+                             float complex *       _y)
 {
     // type cast input as floating point array
     float * x = (float*) _x;
@@ -308,9 +308,9 @@ int dotprod_cccf_execute_avx(dotprod_cccf    _q,
 }
 
 // use AVX extensions
-int dotprod_cccf_execute_avx4(dotprod_cccf    _q,
-                              float complex * _x,
-                              float complex * _y)
+int dotprod_cccf_execute_avx4(dotprod_cccf          _q,
+                              const float complex * _x,
+                              float complex *       _y)
 {
     // type cast input as floating point array
     float * x = (float*) _x;

--- a/src/dotprod/src/dotprod_cccf.avx512f.c
+++ b/src/dotprod/src/dotprod_cccf.avx512f.c
@@ -36,19 +36,19 @@
 #define DEBUG_DOTPROD_CCCF_AVX   0
 
 // forward declaration of internal methods
-int dotprod_cccf_execute_avx512f(dotprod_cccf    _q,
-                             float complex * _x,
-                             float complex * _y);
+int dotprod_cccf_execute_avx512f(dotprod_cccf      _q,
+                             const float complex * _x,
+                             float complex *       _y);
 
-int dotprod_cccf_execute_avx512f4(dotprod_cccf    _q,
-                              float complex * _x,
-                              float complex * _y);
+int dotprod_cccf_execute_avx512f4(dotprod_cccf      _q,
+                              const float complex * _x,
+                              float complex *       _y);
 
 // basic dot product (ordinal calculation)
-int dotprod_cccf_run(float complex * _h,
-                     float complex * _x,
-                     unsigned int    _n,
-                     float complex * _y)
+int dotprod_cccf_run(const float complex * _h,
+                     const float complex * _x,
+                     unsigned int          _n,
+                     float complex *       _y)
 {
     float complex r = 0;
     unsigned int i;
@@ -59,10 +59,10 @@ int dotprod_cccf_run(float complex * _h,
 }
 
 // basic dot product (ordinal calculation) with loop unrolled
-int dotprod_cccf_run4(float complex * _h,
-                      float complex * _x,
-                      unsigned int    _n,
-                      float complex * _y)
+int dotprod_cccf_run4(const float complex * _h,
+                      const float complex * _x,
+                      unsigned int          _n,
+                      float complex *       _y)
 {
     float complex r = 0;
 
@@ -97,9 +97,9 @@ struct dotprod_cccf_s {
     float * hq;         // quadrature
 };
 
-dotprod_cccf dotprod_cccf_create_opt(float complex * _h,
-                                     unsigned int    _n,
-                                     int             _rev)
+dotprod_cccf dotprod_cccf_create_opt(const float complex * _h,
+                                     unsigned int          _n,
+                                     int                   _rev)
 {
     dotprod_cccf q = (dotprod_cccf)malloc(sizeof(struct dotprod_cccf_s));
     q->n = _n;
@@ -125,22 +125,22 @@ dotprod_cccf dotprod_cccf_create_opt(float complex * _h,
     return q;
 }
 
-dotprod_cccf dotprod_cccf_create(float complex * _h,
-                                 unsigned int    _n)
+dotprod_cccf dotprod_cccf_create(const float complex * _h,
+                                 unsigned int          _n)
 {
     return dotprod_cccf_create_opt(_h, _n, 0);
 }
 
-dotprod_cccf dotprod_cccf_create_rev(float complex * _h,
-                                     unsigned int    _n)
+dotprod_cccf dotprod_cccf_create_rev(const float complex * _h,
+                                     unsigned int          _n)
 {
     return dotprod_cccf_create_opt(_h, _n, 1);
 }
 
 // re-create the structured dotprod object
-dotprod_cccf dotprod_cccf_recreate(dotprod_cccf    _q,
-                                   float complex * _h,
-                                   unsigned int    _n)
+dotprod_cccf dotprod_cccf_recreate(dotprod_cccf          _q,
+                                   const float complex * _h,
+                                   unsigned int          _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_cccf_destroy(_q);
@@ -148,9 +148,9 @@ dotprod_cccf dotprod_cccf_recreate(dotprod_cccf    _q,
 }
 
 // re-create the structured dotprod object, coefficients reversed
-dotprod_cccf dotprod_cccf_recreate_rev(dotprod_cccf    _q,
-                                       float complex * _h,
-                                       unsigned int    _n)
+dotprod_cccf dotprod_cccf_recreate_rev(dotprod_cccf          _q,
+                                       const float complex * _h,
+                                       unsigned int          _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_cccf_destroy(_q);
@@ -201,9 +201,9 @@ int dotprod_cccf_print(dotprod_cccf _q)
 //  _q      :   dotprod object
 //  _x      :   input array
 //  _y      :   output sample
-int dotprod_cccf_execute(dotprod_cccf    _q,
-                         float complex * _x,
-                         float complex * _y)
+int dotprod_cccf_execute(dotprod_cccf          _q,
+                         const float complex * _x,
+                         float complex *       _y)
 {
     // switch based on size
     if (_q->n < 128) {
@@ -240,9 +240,9 @@ int dotprod_cccf_execute(dotprod_cccf    _q,
 //           x[3].real * h[3].imag,
 //           x[3].imag * h[3].imag };
 //
-int dotprod_cccf_execute_avx512f(dotprod_cccf    _q,
-                             float complex * _x,
-                             float complex * _y)
+int dotprod_cccf_execute_avx512f(dotprod_cccf      _q,
+                             const float complex * _x,
+                             float complex *       _y)
 {
     // type cast input as floating point array
     float * x = (float*) _x;
@@ -309,9 +309,9 @@ int dotprod_cccf_execute_avx512f(dotprod_cccf    _q,
 }
 
 // use AVX512-F extensions
-int dotprod_cccf_execute_avx512f4(dotprod_cccf    _q,
-                              float complex * _x,
-                              float complex * _y)
+int dotprod_cccf_execute_avx512f4(dotprod_cccf      _q,
+                              const float complex * _x,
+                              float complex *       _y)
 {
     // type cast input as floating point array
     float * x = (float*) _x;

--- a/src/dotprod/src/dotprod_crcf.avx.c
+++ b/src/dotprod/src/dotprod_crcf.avx.c
@@ -34,18 +34,18 @@
 #define DEBUG_DOTPROD_CRCF_AVX   0
 
 // forward declaration of internal methods
-int dotprod_crcf_execute_avx(dotprod_crcf    _q,
-                             float complex * _x,
-                             float complex * _y);
-int dotprod_crcf_execute_avx4(dotprod_crcf    _q,
-                              float complex * _x,
-                              float complex * _y);
+int dotprod_crcf_execute_avx(dotprod_crcf          _q,
+                             const float complex * _x,
+                             float complex *       _y);
+int dotprod_crcf_execute_avx4(dotprod_crcf          _q,
+                              const float complex * _x,
+                              float complex *       _y);
 
 // basic dot product (ordinal calculation)
-int dotprod_crcf_run(float *         _h,
-                     float complex * _x,
-                     unsigned int    _n,
-                     float complex * _y)
+int dotprod_crcf_run(const float *         _h,
+                     const float complex * _x,
+                     unsigned int          _n,
+                     float complex *       _y)
 {
     float complex r = 0;
     unsigned int i;
@@ -56,10 +56,10 @@ int dotprod_crcf_run(float *         _h,
 }
 
 // basic dot product (ordinal calculation) with loop unrolled
-int dotprod_crcf_run4(float *         _h,
-                      float complex * _x,
-                      unsigned int    _n,
-                      float complex * _y)
+int dotprod_crcf_run4(const float *         _h,
+                      const float complex * _x,
+                      unsigned int          _n,
+                      float complex *       _y)
 {
     float complex r = 0;
 
@@ -93,9 +93,9 @@ struct dotprod_crcf_s {
     float * h;          // coefficients array
 };
 
-dotprod_crcf dotprod_crcf_create_opt(float *      _h,
-                                     unsigned int _n,
-                                     int          _rev)
+dotprod_crcf dotprod_crcf_create_opt(const float * _h,
+                                     unsigned int  _n,
+                                     int           _rev)
 {
     dotprod_crcf q = (dotprod_crcf)malloc(sizeof(struct dotprod_crcf_s));
     q->n = _n;
@@ -116,22 +116,22 @@ dotprod_crcf dotprod_crcf_create_opt(float *      _h,
     return q;
 }
 
-dotprod_crcf dotprod_crcf_create(float *      _h,
-                                 unsigned int _n)
+dotprod_crcf dotprod_crcf_create(const float * _h,
+                                 unsigned int  _n)
 {
     return dotprod_crcf_create_opt(_h, _n, 0);
 }
 
-dotprod_crcf dotprod_crcf_create_rev(float *      _h,
-                                     unsigned int _n)
+dotprod_crcf dotprod_crcf_create_rev(const float * _h,
+                                     unsigned int  _n)
 {
     return dotprod_crcf_create_opt(_h, _n, 1);
 }
 
 // re-create the structured dotprod object
-dotprod_crcf dotprod_crcf_recreate(dotprod_crcf _q,
-                                   float *      _h,
-                                   unsigned int _n)
+dotprod_crcf dotprod_crcf_recreate(dotprod_crcf  _q,
+                                   const float * _h,
+                                   unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_crcf_destroy(_q);
@@ -139,9 +139,9 @@ dotprod_crcf dotprod_crcf_recreate(dotprod_crcf _q,
 }
 
 // re-create the structured dotprod object, coefficients reversed
-dotprod_crcf dotprod_crcf_recreate_rev(dotprod_crcf _q,
-                                       float *      _h,
-                                       unsigned int _n)
+dotprod_crcf dotprod_crcf_recreate_rev(dotprod_crcf  _q,
+                                       const float * _h,
+                                       unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_crcf_destroy(_q);
@@ -188,9 +188,9 @@ int dotprod_crcf_print(dotprod_crcf _q)
 }
 
 // 
-int dotprod_crcf_execute(dotprod_crcf    _q,
-                         float complex * _x,
-                         float complex * _y)
+int dotprod_crcf_execute(dotprod_crcf          _q,
+                         const float complex * _x,
+                         float complex *       _y)
 {
     // switch based on size
     if (_q->n < 64) {
@@ -200,9 +200,9 @@ int dotprod_crcf_execute(dotprod_crcf    _q,
 }
 
 // use AVX extensions
-int dotprod_crcf_execute_avx(dotprod_crcf    _q,
-                             float complex * _x,
-                             float complex * _y)
+int dotprod_crcf_execute_avx(dotprod_crcf          _q,
+                             const float complex * _x,
+                             float complex *       _y)
 {
     // type cast input as floating point array
     float * x = (float*) _x;
@@ -257,9 +257,9 @@ int dotprod_crcf_execute_avx(dotprod_crcf    _q,
 }
 
 // use AVX extensions
-int dotprod_crcf_execute_avx4(dotprod_crcf    _q,
-                              float complex * _x,
-                              float complex * _y)
+int dotprod_crcf_execute_avx4(dotprod_crcf          _q,
+                              const float complex * _x,
+                              float complex *       _y)
 {
     // type cast input as floating point array
     float * x = (float*) _x;

--- a/src/dotprod/src/dotprod_rrrf.av.c
+++ b/src/dotprod/src/dotprod_rrrf.av.c
@@ -38,10 +38,10 @@
 //  _x      :   input array [size: 1 x _n]
 //  _n      :   input lengths
 //  _y      :   output dot product
-int dotprod_rrrf_run(float *      _h,
-                     float *      _x,
-                     unsigned int _n,
-                     float *      _y)
+int dotprod_rrrf_run(const float * _h,
+                     const float * _x,
+                     unsigned int  _n,
+                     float *       _y)
 {
     float r=0;
     unsigned int i;
@@ -56,10 +56,10 @@ int dotprod_rrrf_run(float *      _h,
 //  _x      :   input array [size: 1 x _n]
 //  _n      :   input lengths
 //  _y      :   output dot product
-int dotprod_rrrf_run4(float *      _h,
-                      float *      _x,
-                      unsigned int _n,
-                      float *      _y)
+int dotprod_rrrf_run4(const float * _h,
+                      const float * _x,
+                      unsigned int  _n,
+                      float *       _y)
 {
     float r=0;
 
@@ -100,9 +100,9 @@ struct dotprod_rrrf_s {
 };
 
 // create the structured dotprod object
-dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
-                                     unsigned int _n,
-                                     int          _rev)
+dotprod_rrrf dotprod_rrrf_create_opt(const float * _h,
+                                     unsigned int  _n,
+                                     int           _rev)
 {
     dotprod_rrrf q = (dotprod_rrrf)malloc(sizeof(struct dotprod_rrrf_s));
     q->n = _n;
@@ -123,22 +123,22 @@ dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
     return q;
 }
 
-dotprod_rrrf dotprod_rrrf_create(float *      _h,
-                                 unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create(const float * _h,
+                                 unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h,_n,0);
 }
 
-dotprod_rrrf dotprod_rrrf_create_rev(float *      _h,
-                                     unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create_rev(const float * _h,
+                                     unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h,_n,1);
 }
 
 // re-create the structured dotprod object
-dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
-                                   float *      _h,
-                                   unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf  _q,
+                                   const float * _h,
+                                   unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -146,9 +146,9 @@ dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
 }
 
 // re-create the structured dotprod object
-dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf _q,
-                                       float *      _h,
-                                       unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf  _q,
+                                       const float * _h,
+                                       unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -179,9 +179,9 @@ int dotprod_rrrf_print(dotprod_rrrf _q)
 }
 
 // execute vectorized structured inner dot product
-int dotprod_rrrf_execute(dotprod_rrrf _q,
-                         float *      _x,
-                         float *      _r)
+int dotprod_rrrf_execute(dotprod_rrrf  _q,
+                         const float * _x,
+                         float *       _r)
 {
     int al; // input data alignment
 

--- a/src/dotprod/src/dotprod_rrrf.avx.c
+++ b/src/dotprod/src/dotprod_rrrf.avx.c
@@ -34,18 +34,18 @@
 #define DEBUG_DOTPROD_RRRF_AVX     0
 
 // internal methods
-int dotprod_rrrf_execute_avx(dotprod_rrrf _q,
-                              float *      _x,
-                              float *      _y);
-int dotprod_rrrf_execute_avxu(dotprod_rrrf _q,
-                               float *      _x,
-                               float *      _y);
+int dotprod_rrrf_execute_avx(dotprod_rrrf   _q,
+                              const float * _x,
+                              float *       _y);
+int dotprod_rrrf_execute_avxu(dotprod_rrrf   _q,
+                               const float * _x,
+                               float *       _y);
 
 // basic dot product (ordinal calculation)
-int dotprod_rrrf_run(float *      _h,
-                     float *      _x,
-                     unsigned int _n,
-                     float *      _y)
+int dotprod_rrrf_run(const float * _h,
+                     const float * _x,
+                     unsigned int  _n,
+                     float *       _y)
 {
     float r=0;
     unsigned int i;
@@ -56,10 +56,10 @@ int dotprod_rrrf_run(float *      _h,
 }
 
 // basic dot product (ordinal calculation) with loop unrolled
-int dotprod_rrrf_run4(float *      _h,
-                      float *      _x,
-                      unsigned int _n,
-                      float *      _y)
+int dotprod_rrrf_run4(const float * _h,
+                      const float * _x,
+                      unsigned int  _n,
+                      float *       _y)
 {
     float r=0;
 
@@ -93,8 +93,8 @@ struct dotprod_rrrf_s {
     float * h;          // coefficients array
 };
 
-dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
-                                     unsigned int _n,
+dotprod_rrrf dotprod_rrrf_create_opt(const float * _h,
+                                     unsigned int  _n,
                                      int          _rev)
 {
     dotprod_rrrf q = (dotprod_rrrf)malloc(sizeof(struct dotprod_rrrf_s));
@@ -112,22 +112,22 @@ dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
     return q;
 }
 
-dotprod_rrrf dotprod_rrrf_create(float *      _h,
-                                 unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create(const float * _h,
+                                 unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h, _n, 0);
 }
 
-dotprod_rrrf dotprod_rrrf_create_rev(float *      _h,
-                                     unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create_rev(const float * _h,
+                                     unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h, _n, 1);
 }
 
 // re-create the structured dotprod object
-dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
-                                   float *      _h,
-                                   unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf  _q,
+                                   const float * _h,
+                                   unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -135,9 +135,9 @@ dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
 }
 
 // re-create the structured dotprod object, coefficients reversed
-dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf _q,
-                                       float *      _h,
-                                       unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf  _q,
+                                       const float * _h,
+                                       unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -180,9 +180,9 @@ int dotprod_rrrf_print(dotprod_rrrf _q)
 }
 
 // 
-int dotprod_rrrf_execute(dotprod_rrrf _q,
-                          float *      _x,
-                          float *      _y)
+int dotprod_rrrf_execute(dotprod_rrrf   _q,
+                          const float * _x,
+                          float *       _y)
 {
     // switch based on size
     if (_q->n < 32) {
@@ -192,9 +192,9 @@ int dotprod_rrrf_execute(dotprod_rrrf _q,
 }
 
 // use AVX extensions
-int dotprod_rrrf_execute_avx(dotprod_rrrf _q,
-                             float *      _x,
-                             float *      _y)
+int dotprod_rrrf_execute_avx(dotprod_rrrf  _q,
+                             const float * _x,
+                             float *       _y)
 {
     __m256 v;   // input vector
     __m256 h;   // coefficients vector
@@ -242,9 +242,9 @@ int dotprod_rrrf_execute_avx(dotprod_rrrf _q,
 }
 
 // use AVX extensions (unrolled)
-int dotprod_rrrf_execute_avxu(dotprod_rrrf _q,
-                               float *      _x,
-                               float *      _y)
+int dotprod_rrrf_execute_avxu(dotprod_rrrf   _q,
+                               const float * _x,
+                               float *       _y)
 {
     __m256 v0, v1, v2, v3;
     __m256 h0, h1, h2, h3;

--- a/src/dotprod/src/dotprod_rrrf.avx512f.c
+++ b/src/dotprod/src/dotprod_rrrf.avx512f.c
@@ -40,17 +40,17 @@
 
 // internal methods
 int dotprod_rrrf_execute_avx512f(dotprod_rrrf _q,
-                              float *      _x,
-                              float *      _y);
+                              const float *   _x,
+                              float *         _y);
 int dotprod_rrrf_execute_avx512fu(dotprod_rrrf _q,
-                               float *      _x,
-                               float *      _y);
+                               const float *   _x,
+                               float *         _y);
 
 // basic dot product (ordinal calculation)
-int dotprod_rrrf_run(float *      _h,
-                     float *      _x,
-                     unsigned int _n,
-                     float *      _y)
+int dotprod_rrrf_run(const float * _h,
+                     const float * _x,
+                     unsigned int  _n,
+                     float *       _y)
 {
     float r=0;
     unsigned int i;
@@ -61,10 +61,10 @@ int dotprod_rrrf_run(float *      _h,
 }
 
 // basic dot product (ordinal calculation) with loop unrolled
-int dotprod_rrrf_run4(float *      _h,
-                      float *      _x,
-                      unsigned int _n,
-                      float *      _y)
+int dotprod_rrrf_run4(const float * _h,
+                      const float * _x,
+                      unsigned int  _n,
+                      float *       _y)
 {
     float r=0;
 
@@ -98,8 +98,8 @@ struct dotprod_rrrf_s {
     float * h;          // coefficients array
 };
 
-dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
-                                     unsigned int _n,
+dotprod_rrrf dotprod_rrrf_create_opt(const float * _h,
+                                     unsigned int  _n,
                                      int          _rev)
 {
     dotprod_rrrf q = (dotprod_rrrf)malloc(sizeof(struct dotprod_rrrf_s));
@@ -117,22 +117,22 @@ dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
     return q;
 }
 
-dotprod_rrrf dotprod_rrrf_create(float *      _h,
-                                 unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create(const float * _h,
+                                 unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h, _n, 0);
 }
 
-dotprod_rrrf dotprod_rrrf_create_rev(float *      _h,
-                                     unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create_rev(const float * _h,
+                                     unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h, _n, 1);
 }
 
 // re-create the structured dotprod object
-dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
-                                   float *      _h,
-                                   unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf  _q,
+                                   const float * _h,
+                                   unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -140,9 +140,9 @@ dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
 }
 
 // re-create the structured dotprod object, coefficients reversed
-dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf _q,
-                                       float *      _h,
-                                       unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf  _q,
+                                       const float * _h,
+                                       unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -185,9 +185,9 @@ int dotprod_rrrf_print(dotprod_rrrf _q)
 }
 
 // 
-int dotprod_rrrf_execute(dotprod_rrrf _q,
-                          float *      _x,
-                          float *      _y)
+int dotprod_rrrf_execute(dotprod_rrrf   _q,
+                          const float * _x,
+                          float *       _y)
 {
     // switch based on size
     if (_q->n < 64) {
@@ -198,8 +198,8 @@ int dotprod_rrrf_execute(dotprod_rrrf _q,
 
 // use AVX512-F extensions
 int dotprod_rrrf_execute_avx512f(dotprod_rrrf _q,
-                              float *      _x,
-                              float *      _y)
+                              const float *   _x,
+                              float *         _y)
 {
     __m512 v;   // input vector
     __m512 h;   // coefficients vector
@@ -239,8 +239,8 @@ int dotprod_rrrf_execute_avx512f(dotprod_rrrf _q,
 
 // use AVX512-F extensions (unrolled)
 int dotprod_rrrf_execute_avx512fu(dotprod_rrrf _q,
-                               float *      _x,
-                               float *      _y)
+                               const float *   _x,
+                               float *         _y)
 {
     __m512 v0, v1, v2, v3;
     __m512 h0, h1, h2, h3;

--- a/src/dotprod/src/dotprod_rrrf.neon.c
+++ b/src/dotprod/src/dotprod_rrrf.neon.c
@@ -37,10 +37,10 @@
 #define DEBUG_DOTPROD_RRRF_NEON   0
 
 // basic dot product (ordinal calculation) using neon extensions
-int dotprod_rrrf_run(float *      _h,
-                     float *      _x,
-                     unsigned int _n,
-                     float *      _y)
+int dotprod_rrrf_run(const float * _h,
+                     const float * _x,
+                     unsigned int  _n,
+                     float *       _y)
 {
     float32x4_t v;   // input vector
     float32x4_t h;   // coefficients vector
@@ -84,10 +84,10 @@ int dotprod_rrrf_run(float *      _h,
 }
 
 // basic dot product (ordinal calculation) with loop unrolled, neon extensions
-int dotprod_rrrf_run4(float *      _h,
-                      float *      _x,
-                      unsigned int _n,
-                      float *      _y)
+int dotprod_rrrf_run4(const float * _h,
+                      const float * _x,
+                      unsigned int  _n,
+                      float *       _y)
 {
     float32x4_t v0, v1, v2, v3;
     float32x4_t h0, h1, h2, h3;
@@ -164,8 +164,8 @@ struct dotprod_rrrf_s {
 };
 
 // create dotprod object
-dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
-                                     unsigned int _n,
+dotprod_rrrf dotprod_rrrf_create_opt(const float * _h,
+                                     unsigned int  _n,
                                      int          _rev)
 {
     dotprod_rrrf q = (dotprod_rrrf)malloc(sizeof(struct dotprod_rrrf_s));
@@ -183,22 +183,22 @@ dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
     return q;
 }
 
-dotprod_rrrf dotprod_rrrf_create(float *      _h,
-                                 unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create(const float * _h,
+                                 unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h,_n,0);
 }
 
-dotprod_rrrf dotprod_rrrf_create_rev(float *      _h,
-                                     unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create_rev(const float * _h,
+                                     unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h,_n,1);
 }
 
 // re-create the structured dotprod object
-dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
-                                   float *      _h,
-                                   unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf  _q,
+                                   const float * _h,
+                                   unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -206,9 +206,9 @@ dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
 }
 
 // re-create the structured dotprod object, reversing coefficients
-dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf _q,
-                                       float *      _h,
-                                        unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf  _q,
+                                       const float * _h,
+                                       unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -253,9 +253,9 @@ int dotprod_rrrf_print(dotprod_rrrf _q)
 }
 
 // execute dot product on input vector
-int dotprod_rrrf_execute(dotprod_rrrf _q,
-                         float *      _x,
-                         float *      _y)
+int dotprod_rrrf_execute(dotprod_rrrf  _q,
+                         const float * _x,
+                         float *       _y)
 {
     // switch based on size
     if (_q->n < 16) {

--- a/src/dotprod/src/dotprod_rrrf.sse.c
+++ b/src/dotprod/src/dotprod_rrrf.sse.c
@@ -35,16 +35,16 @@
 #define DEBUG_DOTPROD_RRRF_SSE   0
 
 // internal methods
-int dotprod_rrrf_execute_sse(dotprod_rrrf _q,
-                             float *      _x,
-                             float *      _y);
-int dotprod_rrrf_execute_sse4(dotprod_rrrf _q,
-                              float *      _x,
-                              float *      _y);
+int dotprod_rrrf_execute_sse(dotprod_rrrf  _q,
+                             const float * _x,
+                             float *       _y);
+int dotprod_rrrf_execute_sse4(dotprod_rrrf  _q,
+                              const float * _x,
+                              float *       _y);
 
 // basic dot product (ordinal calculation)
-int dotprod_rrrf_run(float *      _h,
-                     float *      _x,
+int dotprod_rrrf_run(const float * _h,
+                     const float * _x,
                      unsigned int _n,
                      float *      _y)
 {
@@ -57,10 +57,10 @@ int dotprod_rrrf_run(float *      _h,
 }
 
 // basic dot product (ordinal calculation) with loop unrolled
-int dotprod_rrrf_run4(float *      _h,
-                      float *      _x,
-                      unsigned int _n,
-                      float *      _y)
+int dotprod_rrrf_run4(const float * _h,
+                      const float * _x,
+                      unsigned int  _n,
+                      float *       _y)
 {
     float r=0;
 
@@ -94,9 +94,9 @@ struct dotprod_rrrf_s {
     float * h;          // coefficients array
 };
 
-dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
-                                     unsigned int _n,
-                                     int          _rev)
+dotprod_rrrf dotprod_rrrf_create_opt(const float * _h,
+                                     unsigned int  _n,
+                                     int           _rev)
 {
     dotprod_rrrf q = (dotprod_rrrf)malloc(sizeof(struct dotprod_rrrf_s));
     q->n = _n;
@@ -113,22 +113,22 @@ dotprod_rrrf dotprod_rrrf_create_opt(float *      _h,
     return q;
 }
 
-dotprod_rrrf dotprod_rrrf_create(float *      _h,
-                                 unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create(const float * _h,
+                                 unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h, _n, 0);
 }
 
-dotprod_rrrf dotprod_rrrf_create_rev(float *      _h,
-                                     unsigned int _n)
+dotprod_rrrf dotprod_rrrf_create_rev(const float * _h,
+                                     unsigned int  _n)
 {
     return dotprod_rrrf_create_opt(_h, _n, 1);
 }
 
 // re-create the structured dotprod object
-dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
-                                   float *      _h,
-                                   unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf  _q,
+                                   const float * _h,
+                                   unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -136,9 +136,9 @@ dotprod_rrrf dotprod_rrrf_recreate(dotprod_rrrf _q,
 }
 
 // re-create the structured dotprod object, coefficients reversed
-dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf _q,
-                                       float *      _h,
-                                       unsigned int _n)
+dotprod_rrrf dotprod_rrrf_recreate_rev(dotprod_rrrf  _q,
+                                       const float * _h,
+                                       unsigned int  _n)
 {
     // completely destroy and re-create dotprod object
     dotprod_rrrf_destroy(_q);
@@ -181,9 +181,9 @@ int dotprod_rrrf_print(dotprod_rrrf _q)
 }
 
 // 
-int dotprod_rrrf_execute(dotprod_rrrf _q,
-                          float *      _x,
-                          float *      _y)
+int dotprod_rrrf_execute(dotprod_rrrf   _q,
+                          const float * _x,
+                          float *       _y)
 {
     // switch based on size
     if (_q->n < 16) {
@@ -193,9 +193,9 @@ int dotprod_rrrf_execute(dotprod_rrrf _q,
 }
 
 // use SSE extensions
-int dotprod_rrrf_execute_sse(dotprod_rrrf _q,
-                             float *      _x,
-                             float *      _y)
+int dotprod_rrrf_execute_sse(dotprod_rrrf  _q,
+                             const float * _x,
+                             float *       _y)
 {
     // first cut: ...
     __m128 v;   // input vector
@@ -250,9 +250,9 @@ int dotprod_rrrf_execute_sse(dotprod_rrrf _q,
 }
 
 // use SSE extensions, unrolled loop
-int dotprod_rrrf_execute_sse4(dotprod_rrrf _q,
-                              float *      _x,
-                              float *      _y)
+int dotprod_rrrf_execute_sse4(dotprod_rrrf  _q,
+                              const float * _x,
+                              float *       _y)
 {
     // first cut: ...
     __m128 v0, v1, v2, v3;

--- a/src/dotprod/src/sumsq.avx.c
+++ b/src/dotprod/src/sumsq.avx.c
@@ -33,8 +33,8 @@
 // sum squares, basic loop
 //  _v      :   input array [size: 1 x _n]
 //  _n      :   input length
-float liquid_sumsqf_avx(float *      _v,
-                        unsigned int _n)
+float liquid_sumsqf_avx(const float * _v,
+                        unsigned int  _n)
 {
     // first cut: ...
     __m256 v;   // input vector
@@ -79,8 +79,8 @@ float liquid_sumsqf_avx(float *      _v,
 // sum squares, unrolled loop
 //  _v      :   input array [size: 1 x _n]
 //  _n      :   input length
-float liquid_sumsqf_avxu(float *      _v,
-                         unsigned int _n)
+float liquid_sumsqf_avxu(const float * _v,
+                         unsigned int  _n)
 {
     // first cut: ...
     __m256 v0, v1, v2, v3;   // input vector
@@ -134,8 +134,8 @@ float liquid_sumsqf_avxu(float *      _v,
 // sum squares
 //  _v      :   input array [size: 1 x _n]
 //  _n      :   input length
-float liquid_sumsqf(float *      _v,
-                    unsigned int _n)
+float liquid_sumsqf(const float * _v,
+                    unsigned int  _n)
 {
     // switch based on size
     if (_n < 32) {
@@ -147,8 +147,8 @@ float liquid_sumsqf(float *      _v,
 // sum squares, complex
 //  _v      :   input array [size: 1 x _n]
 //  _n      :   input length
-float liquid_sumsqcf(float complex * _v,
-                     unsigned int    _n)
+float liquid_sumsqcf(const float complex * _v,
+                     unsigned int          _n)
 {
     // simple method: type cast input as real pointer, run double
     // length sumsqf method

--- a/src/dotprod/src/sumsq.c
+++ b/src/dotprod/src/sumsq.c
@@ -33,7 +33,7 @@
 // sum squares, basic loop
 //  _v      :   input array [size: 1 x _n]
 //  _n      :   input length
-float liquid_sumsqf(float *      _v,
+float liquid_sumsqf(const float * _v,
                     unsigned int _n)
 {
     // initialize accumulator
@@ -62,12 +62,12 @@ float liquid_sumsqf(float *      _v,
 // sum squares, basic loop
 //  _v      :   input array [size: 1 x _n]
 //  _n      :   input length
-float liquid_sumsqcf(float complex * _v,
-                     unsigned int    _n)
+float liquid_sumsqcf(const float complex * _v,
+                     unsigned int           _n)
 {
     // simple method: type cast input as real pointer, run double
     // length sumsqf method
-    float * v = (float*) _v;
+    const float * v = (const float*) _v;
     return liquid_sumsqf(v, 2*_n);
 }
 

--- a/src/equalization/src/eqlms.proto.c
+++ b/src/equalization/src/eqlms.proto.c
@@ -53,7 +53,7 @@ int EQLMS(_update_sumsq)(EQLMS() _q, T _x);
 // create least mean-squares (LMS) equalizer object
 //  _h      :   initial coefficients [size: _h_len x 1], default if NULL
 //  _p      :   equalizer length (number of taps)
-EQLMS() EQLMS(_create)(T *          _h,
+EQLMS() EQLMS(_create)(const T *    _h,
                        unsigned int _h_len)
 {
     EQLMS() q = (EQLMS()) malloc(sizeof(struct EQLMS(_s)));
@@ -156,7 +156,7 @@ EQLMS() EQLMS(_create_lowpass)(unsigned int _h_len,
 //  _h      :   initial coefficients [size: _h_len x 1], default if NULL
 //  _p      :   equalizer length (number of taps)
 EQLMS() EQLMS(_recreate)(EQLMS()      _q,
-                         T *          _h,
+                         const T *    _h,
                          unsigned int _h_len)
 {
     // only destroy when length differs
@@ -311,7 +311,7 @@ int EQLMS(_push)(EQLMS() _q,
 //  _x      :   input sample array
 //  _n      :   input sample array length
 int EQLMS(_push_block)(EQLMS()      _q,
-                       T *          _x,
+                       const T *    _x,
                        unsigned int _n)
 {
     unsigned int i;
@@ -349,7 +349,7 @@ int EQLMS(_execute)(EQLMS() _q,
 //  _y      :   output sample
 //  _k      :   down-sampling rate
 int EQLMS(_decim_execute)(EQLMS()      _q,
-                          T *          _x,
+                          const T *    _x,
                           T *          _y,
                           unsigned int _k)
 {
@@ -374,7 +374,7 @@ int EQLMS(_decim_execute)(EQLMS()      _q,
 //  _y      :   output sample array [size: _n x 1]
 int EQLMS(_execute_block)(EQLMS()      _q,
                           unsigned int _k,
-                          T *          _x,
+                          const T *    _x,
                           unsigned int _n,
                           T *          _y)
 {
@@ -474,8 +474,8 @@ int EQLMS(_step_blind)(EQLMS() _q,
 //  _n      :   vector length
 int EQLMS(_train)(EQLMS()      _q,
                   T *          _w,
-                  T *          _x,
-                  T *          _d,
+                  const T *    _x,
+                  const T *    _d,
                   unsigned int _n)
 {
     unsigned int p=_q->h_len;

--- a/src/equalization/src/eqrls.proto.c
+++ b/src/equalization/src/eqrls.proto.c
@@ -54,7 +54,7 @@ struct EQRLS(_s) {
 // create recursive least-squares (RLS) equalizer object
 //  _h      :   initial coefficients [size: _p x 1], default if NULL
 //  _p      :   equalizer length (number of taps)
-EQRLS() EQRLS(_create)(T *          _h,
+EQRLS() EQRLS(_create)(const T *    _h,
                        unsigned int _p)
 {
     if (_p==0)
@@ -105,7 +105,7 @@ EQRLS() EQRLS(_create)(T *          _h,
 //  _h  : filter coefficients (NULL for {1,0,0...})
 //  _p  : equalizer length (number of taps)
 EQRLS() EQRLS(_recreate)(EQRLS()      _q,
-                         T *          _h,
+                         const T *    _h,
                          unsigned int _p)
 {
     if (_q->p == _p) {
@@ -381,8 +381,8 @@ int EQRLS(_get_weights)(EQRLS() _q,
 //  _n      :   vector length
 int EQRLS(_train)(EQRLS()      _q,
                   T *          _w,
-                  T *          _x,
-                  T *          _d,
+                  const T *    _x,
+                  const T *    _d,
                   unsigned int _n)
 {
     unsigned int i;

--- a/src/fec/src/crc.c
+++ b/src/fec/src/crc.c
@@ -35,11 +35,11 @@
 #define CRC24_POLY 0x5D6DCB
 #define CRC32_POLY 0x04C11DB7
 
-unsigned int checksum_generate_key(unsigned char * _msg, unsigned int _msg_len);
-unsigned int crc8_generate_key(unsigned char * _msg, unsigned int _msg_len);
-unsigned int crc16_generate_key(unsigned char * _msg, unsigned int _msg_len);
-unsigned int crc24_generate_key(unsigned char * _msg, unsigned int _msg_len);
-unsigned int crc32_generate_key(unsigned char * _msg, unsigned int _msg_len);
+unsigned int checksum_generate_key(const unsigned char * _msg, unsigned int _msg_len);
+unsigned int crc8_generate_key(const unsigned char * _msg, unsigned int _msg_len);
+unsigned int crc16_generate_key(const unsigned char * _msg, unsigned int _msg_len);
+unsigned int crc24_generate_key(const unsigned char * _msg, unsigned int _msg_len);
+unsigned int crc32_generate_key(const unsigned char * _msg, unsigned int _msg_len);
 
 // object-independent methods
 
@@ -114,9 +114,9 @@ unsigned int crc_get_length(crc_scheme _scheme)
 //  _scheme     :   error-detection scheme
 //  _msg        :   input data message, [size: _n x 1]
 //  _n          :   input data message size
-unsigned int crc_generate_key(crc_scheme      _scheme,
-                              unsigned char * _msg,
-                              unsigned int    _n)
+unsigned int crc_generate_key(crc_scheme            _scheme,
+                              const unsigned char * _msg,
+                              unsigned int          _n)
 {
     switch (_scheme) {
     case LIQUID_CRC_UNKNOWN:
@@ -161,10 +161,10 @@ int crc_append_key(crc_scheme      _scheme,
 //  _msg        :   input data message, [size: _n x 1]
 //  _n          :   input data message size
 //  _key        :   error-detection key
-int crc_validate_message(crc_scheme      _scheme,
-                         unsigned char * _msg,
-                         unsigned int    _n,
-                         unsigned int    _key)
+int crc_validate_message(crc_scheme            _scheme,
+                         const unsigned char * _msg,
+                         unsigned int          _n,
+                         unsigned int          _key)
 {
     if (_scheme == LIQUID_CRC_UNKNOWN) {
         liquid_error(LIQUID_EIMODE,"crc_validate_message(), cannot validate with CRC unknown type");
@@ -180,9 +180,9 @@ int crc_validate_message(crc_scheme      _scheme,
 //  _scheme     :   error-detection scheme (resulting in 'p' bytes)
 //  _msg        :   input data message, [size: _n+p x 1]
 //  _n          :   input data message size (excluding key at end)
-int crc_check_key(crc_scheme      _scheme,
-                  unsigned char * _msg,
-                  unsigned int    _n)
+int crc_check_key(crc_scheme            _scheme,
+                  const unsigned char * _msg,
+                  unsigned int          _n)
 {
     // get key size
     unsigned int len = crc_sizeof_key(_scheme);
@@ -229,7 +229,7 @@ unsigned int crc_sizeof_key(crc_scheme _scheme)
 //  _scheme     :   error-detection scheme
 //  _msg        :   input data message, [size: _n x 1]
 //  _n          :   input data message size
-unsigned int checksum_generate_key(unsigned char *_data,
+unsigned int checksum_generate_key(const unsigned char *_data,
                                    unsigned int _n)
 {
     unsigned int i, sum=0;
@@ -254,7 +254,7 @@ unsigned int checksum_generate_key(unsigned char *_data,
 //
 //  _msg    :   input data message [size: _n x 1]
 //  _n      :   input data message size
-unsigned int crc8_generate_key(unsigned char *_msg,
+unsigned int crc8_generate_key(const unsigned char *_msg,
                                unsigned int _n)
 {
     unsigned int i, j, b, mask, key8=~0;
@@ -282,7 +282,7 @@ unsigned int crc8_generate_key(unsigned char *_msg,
 //
 //  _msg    :   input data message [size: _n x 1]
 //  _n      :   input data message size
-unsigned int crc16_generate_key(unsigned char *_msg,
+unsigned int crc16_generate_key(const unsigned char *_msg,
                                 unsigned int _n)
 {
     unsigned int i, j, b, mask, key16=~0;
@@ -310,7 +310,7 @@ unsigned int crc16_generate_key(unsigned char *_msg,
 //
 //  _msg    :   input data message [size: _n x 1]
 //  _n      :   input data message size
-unsigned int crc24_generate_key(unsigned char *_msg,
+unsigned int crc24_generate_key(const unsigned char *_msg,
                                 unsigned int _n)
 {
     unsigned int i, j, b, mask, key24=~0;
@@ -338,7 +338,7 @@ unsigned int crc24_generate_key(unsigned char *_msg,
 //
 //  _msg    :   input data message [size: _n x 1]
 //  _n      :   input data message size
-unsigned int crc32_generate_key(unsigned char *_msg,
+unsigned int crc32_generate_key(const unsigned char *_msg,
                                 unsigned int _n)
 {
     unsigned int i, j, b, mask, key32=~0;

--- a/src/fec/src/fec.c
+++ b/src/fec/src/fec.c
@@ -663,10 +663,10 @@ int fec_print(fec _q)
 //  _dec_msg_len    :   decoded message length
 //  _msg_dec        :   decoded message
 //  _msg_enc        :   encoded message
-int fec_encode(fec _q,
-               unsigned int _dec_msg_len,
-               unsigned char * _msg_dec,
-               unsigned char * _msg_enc)
+int fec_encode(fec                    _q,
+               unsigned int           _dec_msg_len,
+               const unsigned char * _msg_dec,
+               unsigned char *       _msg_enc)
 {
     // call internal encoding method
     return _q->encode_func(_q, _dec_msg_len, _msg_dec, _msg_enc);
@@ -677,10 +677,10 @@ int fec_encode(fec _q,
 //  _dec_msg_len    :   decoded message length
 //  _msg_enc        :   encoded message
 //  _msg_dec        :   decoded message
-int fec_decode(fec _q,
-               unsigned int _dec_msg_len,
-               unsigned char * _msg_enc,
-               unsigned char * _msg_dec)
+int fec_decode(fec                    _q,
+               unsigned int           _dec_msg_len,
+               const unsigned char * _msg_enc,
+               unsigned char *       _msg_dec)
 {
     // call internal decoding method
     return _q->decode_func(_q, _dec_msg_len, _msg_enc, _msg_dec);
@@ -691,10 +691,10 @@ int fec_decode(fec _q,
 //  _dec_msg_len    :   decoded message length
 //  _msg_enc        :   encoded message
 //  _msg_dec        :   decoded message
-int fec_decode_soft(fec _q,
-                    unsigned int _dec_msg_len,
-                    unsigned char * _msg_enc,
-                    unsigned char * _msg_dec)
+int fec_decode_soft(fec                    _q,
+                    unsigned int           _dec_msg_len,
+                    const unsigned char * _msg_enc,
+                    unsigned char *       _msg_dec)
 {
     if (_q->decode_soft_func != NULL) {
         // call internal decoding method

--- a/src/fec/src/fec_conv.c
+++ b/src/fec/src/fec_conv.c
@@ -78,7 +78,7 @@ int fec_conv_destroy(fec _q)
 
 int fec_conv_encode(fec _q,
                     unsigned int _dec_msg_len,
-                    unsigned char *_msg_dec,
+                    const unsigned char *_msg_dec,
                     unsigned char *_msg_enc)
 {
     unsigned int i,j,r; // bookkeeping
@@ -172,7 +172,7 @@ int fec_conv_decode_hard(fec _q,
 //unsigned int
 int fec_conv_decode_soft(fec _q,
                          unsigned int _dec_msg_len,
-                         unsigned char *_msg_enc,
+                         const unsigned char *_msg_enc,
                          unsigned char *_msg_dec)
 {
     // re-allocate resources if necessary

--- a/src/fec/src/fec_conv_punctured.c
+++ b/src/fec/src/fec_conv_punctured.c
@@ -87,7 +87,7 @@ int fec_conv_punctured_destroy(fec _q)
 
 int fec_conv_punctured_encode(fec _q,
                               unsigned int _dec_msg_len,
-                              unsigned char *_msg_dec,
+                              const unsigned char *_msg_dec,
                               unsigned char *_msg_enc)
 {
     unsigned int i,j,r; // bookkeeping
@@ -222,10 +222,10 @@ int fec_conv_punctured_decode_hard(fec             _q,
     return LIQUID_OK;
 }
 
-int fec_conv_punctured_decode_soft(fec             _q,
-                                   unsigned int    _dec_msg_len,
-                                   unsigned char * _msg_enc,
-                                   unsigned char * _msg_dec)
+int fec_conv_punctured_decode_soft(fec                   _q,
+                                   unsigned int          _dec_msg_len,
+                                   const unsigned char * _msg_enc,
+                                   unsigned char *       _msg_dec)
 {
     // re-allocate resources if necessary
     fec_conv_punctured_setlength(_q, _dec_msg_len);
@@ -453,19 +453,19 @@ int fec_conv_punctured_destroy(fec _q)
     return liquid_error(LIQUID_EUMODE,"fec_conv_punctured_destroy(), libfec not installed");
 }
 
-int fec_conv_punctured_encode(fec             _q,
-                              unsigned int    _dec_msg_len,
-                              unsigned char * _msg_dec,
-                              unsigned char * _msg_enc)
+int fec_conv_punctured_encode(fec                   _q,
+                              unsigned int          _dec_msg_len,
+                              const unsigned char * _msg_dec,
+                              unsigned char *       _msg_enc)
 {
     return liquid_error(LIQUID_EUMODE,"fec_conv_punctured_encode(), libfec not installed");
 }
 
 //unsigned int
-int fec_conv_punctured_decode(fec             _q,
-                              unsigned int    _dec_msg_len,
-                              unsigned char * _msg_enc,
-                              unsigned char * _msg_dec)
+int fec_conv_punctured_decode(fec                   _q,
+                              unsigned int          _dec_msg_len,
+                              const unsigned char * _msg_enc,
+                              unsigned char *       _msg_dec)
 {
     return liquid_error(LIQUID_EUMODE,"fec_conv_punctured_decode(), libfec not installed");
 }

--- a/src/fec/src/fec_golay2412.c
+++ b/src/fec/src/fec_golay2412.c
@@ -264,10 +264,10 @@ int fec_golay2412_destroy(fec _q)
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //  _msg_enc        :   encoded message [size: 1 x 2*_dec_msg_len]
-int fec_golay2412_encode(fec             _q,
-                         unsigned int    _dec_msg_len,
-                         unsigned char * _msg_dec,
-                         unsigned char * _msg_enc)
+int fec_golay2412_encode(fec                   _q,
+                         unsigned int          _dec_msg_len,
+                         const unsigned char * _msg_dec,
+                         unsigned char *       _msg_enc)
 {
     unsigned int i=0;           // decoded byte counter
     unsigned int j=0;           // encoded byte counter
@@ -337,10 +337,10 @@ int fec_golay2412_encode(fec             _q,
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //
 //unsigned int
-int fec_golay2412_decode(fec             _q,
-                         unsigned int    _dec_msg_len,
-                         unsigned char * _msg_enc,
-                         unsigned char * _msg_dec)
+int fec_golay2412_decode(fec                   _q,
+                         unsigned int          _dec_msg_len,
+                         const unsigned char * _msg_enc,
+                         unsigned char *       _msg_dec)
 {
     unsigned int i=0;                       // decoded byte counter
     unsigned int j=0;                       // encoded byte counter

--- a/src/fec/src/fec_hamming128.c
+++ b/src/fec/src/fec_hamming128.c
@@ -170,10 +170,10 @@ int fec_hamming128_destroy(fec _q)
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //  _msg_enc        :   encoded message [size: 1 x 2*_dec_msg_len]
-int fec_hamming128_encode(fec             _q,
-                          unsigned int    _dec_msg_len,
-                          unsigned char * _msg_dec,
-                          unsigned char * _msg_enc)
+int fec_hamming128_encode(fec                   _q,
+                          unsigned int          _dec_msg_len,
+                          const unsigned char * _msg_dec,
+                          unsigned char *       _msg_enc)
 {
     unsigned int i, j=0;    // input/output symbol counters
     unsigned char s0, s1;   // input 8-bit symbols
@@ -236,10 +236,10 @@ int fec_hamming128_encode(fec             _q,
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //
 //unsigned int
-int fec_hamming128_decode(fec             _q,
-                          unsigned int    _dec_msg_len,
-                          unsigned char * _msg_enc,
-                          unsigned char * _msg_dec)
+int fec_hamming128_decode(fec                   _q,
+                          unsigned int          _dec_msg_len,
+                          const unsigned char * _msg_enc,
+                          unsigned char *       _msg_dec)
 {
     unsigned int i=0,j=0;
     unsigned int r = _dec_msg_len % 2;
@@ -292,10 +292,10 @@ int fec_hamming128_decode(fec             _q,
 //  _msg_dec        :   decoded message [size: _dec_msg_len x 1]
 //
 //unsigned int
-int fec_hamming128_decode_soft(fec             _q,
-                               unsigned int    _dec_msg_len,
-                               unsigned char * _msg_enc,
-                               unsigned char * _msg_dec)
+int fec_hamming128_decode_soft(fec                   _q,
+                               unsigned int          _dec_msg_len,
+                               const unsigned char * _msg_enc,
+                               unsigned char *       _msg_dec)
 {
     unsigned int i;
     unsigned int k=0;       // array bit index
@@ -336,7 +336,7 @@ int fec_hamming128_decode_soft(fec             _q,
 // NOTE : because this method compares the received symbol to every
 //        possible (256) encoded symbols, it is painfully slow to
 //        run.
-unsigned int fecsoft_hamming128_decode(unsigned char * _soft_bits)
+unsigned int fecsoft_hamming128_decode(const unsigned char * _soft_bits)
 {
     // find symbol with minimum distance from all 2^8 possible
     unsigned int d;             // distance metric
@@ -377,7 +377,7 @@ unsigned int fecsoft_hamming128_decode(unsigned char * _soft_bits)
 }
 
 // soft decoding of one symbol using nearest neighbors
-unsigned int fecsoft_hamming128_decode_n3(unsigned char * _soft_bits)
+unsigned int fecsoft_hamming128_decode_n3(const unsigned char * _soft_bits)
 {
     // find symbol with minimum distance from 17 nearest neighbors
     unsigned int d;             // distance metric

--- a/src/fec/src/fec_hamming74.c
+++ b/src/fec/src/fec_hamming74.c
@@ -84,10 +84,10 @@ int fec_hamming74_destroy(fec _q)
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_dec        :   decoded message [size: _dec_msg_len x 1]
 //  _msg_enc        :   encoded message [size: ...]
-int fec_hamming74_encode(fec             _q,
-                         unsigned int    _dec_msg_len,
-                         unsigned char * _msg_dec,
-                         unsigned char * _msg_enc)
+int fec_hamming74_encode(fec                   _q,
+                         unsigned int          _dec_msg_len,
+                         const unsigned char * _msg_dec,
+                         unsigned char *       _msg_enc)
 {
     unsigned int i;         // input byte counter
     unsigned int k=0;       // array bit index
@@ -126,10 +126,10 @@ int fec_hamming74_encode(fec             _q,
 //  _msg_dec        :   decoded message [size: _dec_msg_len x 1]
 //
 //unsigned int
-int fec_hamming74_decode(fec             _q,
-                         unsigned int    _dec_msg_len,
-                         unsigned char * _msg_enc,
-                         unsigned char * _msg_dec)
+int fec_hamming74_decode(fec                   _q,
+                         unsigned int          _dec_msg_len,
+                         const unsigned char * _msg_enc,
+                         unsigned char *       _msg_dec)
 {
     unsigned int i;
     unsigned int k=0;       // array bit index
@@ -166,10 +166,10 @@ int fec_hamming74_decode(fec             _q,
 //  _msg_dec        :   decoded message [size: _dec_msg_len x 1]
 //
 //unsigned int
-int fec_hamming74_decode_soft(fec             _q,
-                              unsigned int    _dec_msg_len,
-                              unsigned char * _msg_enc,
-                              unsigned char * _msg_dec)
+int fec_hamming74_decode_soft(fec                   _q,
+                              unsigned int          _dec_msg_len,
+                              const unsigned char * _msg_enc,
+                              unsigned char *       _msg_dec)
 {
     unsigned int i;
     unsigned int k=0;       // array bit index
@@ -201,7 +201,7 @@ int fec_hamming74_decode_soft(fec             _q,
 //
 
 // soft decoding of one symbol
-unsigned char fecsoft_hamming74_decode(unsigned char * _soft_bits)
+unsigned char fecsoft_hamming74_decode(const unsigned char * _soft_bits)
 {
     // find symbol with minimum distance from all 2^4 possible
     unsigned int d;             // distance metric

--- a/src/fec/src/fec_hamming84.c
+++ b/src/fec/src/fec_hamming84.c
@@ -100,10 +100,10 @@ int fec_hamming84_destroy(fec _q)
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //  _msg_enc        :   encoded message [size: 1 x 2*_dec_msg_len]
-int fec_hamming84_encode(fec              _q,
-                          unsigned int    _dec_msg_len,
-                          unsigned char * _msg_dec,
-                          unsigned char * _msg_enc)
+int fec_hamming84_encode(fec                    _q,
+                          unsigned int          _dec_msg_len,
+                          const unsigned char * _msg_dec,
+                          unsigned char *       _msg_enc)
 {
     unsigned int i, j=0;
     unsigned char s0, s1;
@@ -125,10 +125,10 @@ int fec_hamming84_encode(fec              _q,
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //
 //unsigned int
-int fec_hamming84_decode(fec             _q,
-                         unsigned int    _dec_msg_len,
-                         unsigned char * _msg_enc,
-                         unsigned char * _msg_dec)
+int fec_hamming84_decode(fec                    _q,
+                         unsigned int           _dec_msg_len,
+                         const unsigned char * _msg_enc,
+                         unsigned char *        _msg_dec)
 {
     unsigned int i;
     unsigned char r0, r1;   // received 8-bit symbols
@@ -154,10 +154,10 @@ int fec_hamming84_decode(fec             _q,
 //  _msg_dec        :   decoded message [size: _dec_msg_len x 1]
 //
 //unsigned int
-int fec_hamming84_decode_soft(fec             _q,
-                              unsigned int    _dec_msg_len,
-                              unsigned char * _msg_enc,
-                              unsigned char * _msg_dec)
+int fec_hamming84_decode_soft(fec                   _q,
+                              unsigned int          _dec_msg_len,
+                              const unsigned char * _msg_enc,
+                              unsigned char *       _msg_dec)
 {
     unsigned int i;
     unsigned int k=0;       // array bit index
@@ -189,7 +189,7 @@ int fec_hamming84_decode_soft(fec             _q,
 //
 
 // soft decoding of one symbol
-unsigned char fecsoft_hamming84_decode(unsigned char * _soft_bits)
+unsigned char fecsoft_hamming84_decode(const unsigned char * _soft_bits)
 {
     // find symbol with minimum distance from all 2^4 possible
     unsigned int d;             // distance metric

--- a/src/fec/src/fec_pass.c
+++ b/src/fec/src/fec_pass.c
@@ -55,13 +55,13 @@ int fec_pass_print(fec _q)
     return LIQUID_OK;
 }
 
-int fec_pass_encode(fec _q, unsigned int _dec_msg_len, unsigned char *_msg_dec, unsigned char *_msg_enc)
+int fec_pass_encode(fec _q, unsigned int _dec_msg_len, const unsigned char *_msg_dec, unsigned char *_msg_enc)
 {
     memmove(_msg_enc, _msg_dec, _dec_msg_len);
     return LIQUID_OK;
 }
 
-int fec_pass_decode(fec _q, unsigned int _dec_msg_len, unsigned char *_msg_enc, unsigned char *_msg_dec)
+int fec_pass_decode(fec _q, unsigned int _dec_msg_len, const unsigned char *_msg_enc, unsigned char *_msg_dec)
 {
     memmove(_msg_dec, _msg_enc, _dec_msg_len);
     return LIQUID_OK;

--- a/src/fec/src/fec_rep3.c
+++ b/src/fec/src/fec_rep3.c
@@ -64,10 +64,10 @@ int fec_rep3_print(fec _q)
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //  _msg_enc        :   encoded message [size: 1 x 3*_dec_msg_len]
-int fec_rep3_encode(fec             _q,
-                    unsigned int    _dec_msg_len,
-                    unsigned char * _msg_dec,
-                    unsigned char * _msg_enc)
+int fec_rep3_encode(fec                   _q,
+                    unsigned int          _dec_msg_len,
+                    const unsigned char * _msg_dec,
+                    unsigned char *       _msg_enc)
 {
     unsigned int i;
     for (i=0; i<3; i++) {
@@ -82,10 +82,10 @@ int fec_rep3_encode(fec             _q,
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_enc        :   encoded message [size: 1 x 3*_dec_msg_len]
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
-int fec_rep3_decode(fec             _q,
-                    unsigned int    _dec_msg_len,
-                    unsigned char * _msg_enc,
-                    unsigned char * _msg_dec)
+int fec_rep3_decode(fec                   _q,
+                    unsigned int          _dec_msg_len,
+                    const unsigned char * _msg_enc,
+                    unsigned char *       _msg_dec)
 {
     unsigned char s0, s1, s2;
     unsigned int i;
@@ -120,10 +120,10 @@ int fec_rep3_decode(fec             _q,
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_enc        :   encoded message [size: 1 x 3*_dec_msg_len]
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
-int fec_rep3_decode_soft(fec             _q,
-                         unsigned int    _dec_msg_len,
-                         unsigned char * _msg_enc,
-                         unsigned char * _msg_dec)
+int fec_rep3_decode_soft(fec                   _q,
+                         unsigned int          _dec_msg_len,
+                         const unsigned char * _msg_enc,
+                         unsigned char *       _msg_dec)
 {
     unsigned char s0, s1, s2;
     unsigned int i;

--- a/src/fec/src/fec_rep5.c
+++ b/src/fec/src/fec_rep5.c
@@ -64,10 +64,10 @@ int fec_rep5_print(fec _q)
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //  _msg_enc        :   encoded message [size: 1 x 5*_dec_msg_len]
-int fec_rep5_encode(fec             _q,
-                    unsigned int    _dec_msg_len,
-                    unsigned char * _msg_dec,
-                    unsigned char * _msg_enc)
+int fec_rep5_encode(fec                   _q,
+                    unsigned int          _dec_msg_len,
+                    const unsigned char * _msg_dec,
+                    unsigned char *       _msg_enc)
 {
     unsigned int i;
     for (i=0; i<5; i++) {
@@ -82,10 +82,10 @@ int fec_rep5_encode(fec             _q,
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_enc        :   encoded message [size: 1 x 5*_dec_msg_len]
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
-int fec_rep5_decode(fec             _q,
-                    unsigned int    _dec_msg_len,
-                    unsigned char * _msg_enc,
-                    unsigned char * _msg_dec)
+int fec_rep5_decode(fec                   _q,
+                    unsigned int          _dec_msg_len,
+                    const unsigned char * _msg_enc,
+                    unsigned char *       _msg_dec)
 {
     unsigned char s0, s1, s2, s3, s4;
     unsigned int i;
@@ -121,10 +121,10 @@ int fec_rep5_decode(fec             _q,
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_enc        :   encoded message [size: 1 x 5*_dec_msg_len]
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
-int fec_rep5_decode_soft(fec             _q,
-                         unsigned int    _dec_msg_len,
-                         unsigned char * _msg_enc,
-                         unsigned char * _msg_dec)
+int fec_rep5_decode_soft(fec                   _q,
+                         unsigned int          _dec_msg_len,
+                         const unsigned char * _msg_enc,
+                         unsigned char *       _msg_dec)
 {
     unsigned char s0, s1, s2, s3, s4;
     unsigned int i;

--- a/src/fec/src/fec_rs.c
+++ b/src/fec/src/fec_rs.c
@@ -85,10 +85,10 @@ int fec_rs_destroy(fec _q)
     return LIQUID_OK;
 }
 
-int fec_rs_encode(fec             _q,
-                  unsigned int    _dec_msg_len,
-                  unsigned char * _msg_dec,
-                  unsigned char * _msg_enc)
+int fec_rs_encode(fec                   _q,
+                  unsigned int          _dec_msg_len,
+                  const unsigned char * _msg_dec,
+                  unsigned char *       _msg_enc)
 {
     // validate input
     if (_dec_msg_len == 0)
@@ -131,10 +131,10 @@ int fec_rs_encode(fec             _q,
 }
 
 //unsigned int
-int fec_rs_decode(fec             _q,
-                  unsigned int    _dec_msg_len,
-                  unsigned char * _msg_enc,
-                  unsigned char * _msg_dec)
+int fec_rs_decode(fec                   _q,
+                  unsigned int          _dec_msg_len,
+                  const unsigned char * _msg_enc,
+                  unsigned char *       _msg_dec)
 {
     // validate input
     if (_dec_msg_len == 0)
@@ -297,18 +297,18 @@ int fec_rs_destroy(fec _q)
 }
 
 int fec_rs_encode(fec _q,
-                   unsigned int _dec_msg_len,
-                   unsigned char *_msg_dec,
-                   unsigned char *_msg_enc)
+                   unsigned int         _dec_msg_len,
+                   const unsigned char *_msg_dec,
+                   unsigned char *      _msg_enc)
 {
     return liquid_error(LIQUID_EUMODE,"fec_rs_encode(), libfec not installed");
 }
 
 //unsigned int
 int fec_rs_decode(fec _q,
-                   unsigned int _dec_msg_len,
-                   unsigned char *_msg_enc,
-                   unsigned char *_msg_dec)
+                   unsigned int         _dec_msg_len,
+                   const unsigned char *_msg_enc,
+                   unsigned char *      _msg_dec)
 {
     return liquid_error(LIQUID_EUMODE,"fec_rs_decode(), libfec not installed");
 }

--- a/src/fec/src/fec_secded2216.c
+++ b/src/fec/src/fec_secded2216.c
@@ -62,7 +62,7 @@ unsigned char secded2216_syndrome_w1[22] = {
     0x10, 0x20};
 
 // compute parity on 16-bit input
-unsigned char fec_secded2216_compute_parity(unsigned char * _m)
+unsigned char fec_secded2216_compute_parity(const unsigned char * _m)
 {
     // compute encoded/transmitted message: v = m*G
     unsigned char parity = 0x00;
@@ -82,7 +82,7 @@ unsigned char fec_secded2216_compute_parity(unsigned char * _m)
 }
 
 // compute syndrome on 22-bit input
-unsigned char fec_secded2216_compute_syndrome(unsigned char * _v)
+unsigned char fec_secded2216_compute_syndrome(const unsigned char * _v)
 {
     // TODO : unwrap this loop
     unsigned int i;
@@ -104,8 +104,8 @@ unsigned char fec_secded2216_compute_syndrome(unsigned char * _v)
 // encode symbol
 //  _sym_dec    :   decoded symbol [size: 2 x 1]
 //  _sym_enc    :   encoded symbol [size: 3 x 1], _sym_enc[0] has only 6 bits
-int fec_secded2216_encode_symbol(unsigned char * _sym_dec,
-                                 unsigned char * _sym_enc)
+int fec_secded2216_encode_symbol(const unsigned char * _sym_dec,
+                                 unsigned char *       _sym_enc)
 {
     // first six bits is parity block
     _sym_enc[0] = fec_secded2216_compute_parity(_sym_dec);
@@ -120,8 +120,8 @@ int fec_secded2216_encode_symbol(unsigned char * _sym_dec,
 // detected, respectively
 //  _sym_enc    :   encoded symbol [size: 3 x 1], _sym_enc[0] has only 6 bits
 //  _sym_dec    :   decoded symbol [size: 2 x 1]
-int fec_secded2216_decode_symbol(unsigned char * _sym_enc,
-                                 unsigned char * _sym_dec)
+int fec_secded2216_decode_symbol(const unsigned char * _sym_enc,
+                                 unsigned char *       _sym_dec)
 {
 #if 0
     // validate input
@@ -156,8 +156,8 @@ int fec_secded2216_decode_symbol(unsigned char * _sym_enc,
 // detected, respectively
 //  _sym_enc    :   encoded symbol [size: 3 x 1], _sym_enc[0] has only 6 bits
 //  _e_hat      :   estimated error vector [size: 3 x 1]
-int fec_secded2216_estimate_ehat(unsigned char * _sym_enc,
-                                 unsigned char * _e_hat)
+int fec_secded2216_estimate_ehat(const unsigned char * _sym_enc,
+                                 unsigned char *       _e_hat)
 {
     // clear output array
     _e_hat[0] = 0x00;
@@ -225,10 +225,10 @@ int fec_secded2216_destroy(fec _q)
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //  _msg_enc        :   encoded message [size: 1 x 2*_dec_msg_len]
-int fec_secded2216_encode(fec             _q,
-                          unsigned int    _dec_msg_len,
-                          unsigned char * _msg_dec,
-                          unsigned char * _msg_enc)
+int fec_secded2216_encode(fec                   _q,
+                          unsigned int          _dec_msg_len,
+                          const unsigned char * _msg_dec,
+                          unsigned char *       _msg_enc)
 {
     unsigned int i=0;       // decoded byte counter
     unsigned int j=0;       // encoded byte counter
@@ -286,10 +286,10 @@ int fec_secded2216_encode(fec             _q,
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //
 //unsigned int
-int fec_secded2216_decode(fec             _q,
-                          unsigned int    _dec_msg_len,
-                          unsigned char * _msg_enc,
-                          unsigned char * _msg_dec)
+int fec_secded2216_decode(fec                   _q,
+                          unsigned int          _dec_msg_len,
+                          const unsigned char * _msg_enc,
+                          unsigned char *       _msg_dec)
 {
     unsigned int i=0;       // decoded byte counter
     unsigned int j=0;       // encoded byte counter

--- a/src/fec/src/fec_secded3932.c
+++ b/src/fec/src/fec_secded3932.c
@@ -69,7 +69,7 @@ unsigned char secded3932_syndrome_w1[39] = {
     0x10, 0x20, 0x40};
 
 // compute parity on 32-bit input
-unsigned char fec_secded3932_compute_parity(unsigned char * _m)
+unsigned char fec_secded3932_compute_parity(const unsigned char * _m)
 {
     // compute encoded/transmitted message: v = m*G
     unsigned char parity = 0x00;
@@ -91,7 +91,7 @@ unsigned char fec_secded3932_compute_parity(unsigned char * _m)
 }
 
 // compute syndrome on 39-bit input
-unsigned char fec_secded3932_compute_syndrome(unsigned char * _v)
+unsigned char fec_secded3932_compute_syndrome(const unsigned char * _v)
 {
     // TODO : unwrap this loop
     unsigned int i;
@@ -115,8 +115,8 @@ unsigned char fec_secded3932_compute_syndrome(unsigned char * _v)
 // encode symbol
 //  _sym_dec    :   decoded symbol [size: 4 x 1]
 //  _sym_enc    :   encoded symbol [size: 5 x 1], _sym_enc[0] has only 7 bits
-int fec_secded3932_encode_symbol(unsigned char * _sym_dec,
-                                 unsigned char * _sym_enc)
+int fec_secded3932_encode_symbol(const unsigned char * _sym_dec,
+                                 unsigned char *       _sym_enc)
 {
     // first six bits is parity block
     _sym_enc[0] = fec_secded3932_compute_parity(_sym_dec);
@@ -132,8 +132,8 @@ int fec_secded3932_encode_symbol(unsigned char * _sym_dec,
 // decode symbol, returning 0/1/2 for zero/one/multiple errors detected
 //  _sym_enc    :   encoded symbol [size: 5 x 1], _sym_enc[0] has only 7 bits
 //  _sym_dec    :   decoded symbol [size: 4 x 1]
-int fec_secded3932_decode_symbol(unsigned char * _sym_enc,
-                                 unsigned char * _sym_dec)
+int fec_secded3932_decode_symbol(const unsigned char * _sym_enc,
+                                 unsigned char *       _sym_dec)
 {
 #if 0
     // validate input
@@ -170,8 +170,8 @@ int fec_secded3932_decode_symbol(unsigned char * _sym_enc,
 // detected, respectively
 //  _sym_enc    :   encoded symbol [size: 5 x 1], _sym_enc[0] has only 6 bits
 //  _e_hat      :   estimated error vector [size: 5 x 1]
-int fec_secded3932_estimate_ehat(unsigned char * _sym_enc,
-                                 unsigned char * _e_hat)
+int fec_secded3932_estimate_ehat(const unsigned char * _sym_enc,
+                                 unsigned char *       _e_hat)
 {
     // clear output array
     _e_hat[0] = 0x00;
@@ -241,10 +241,10 @@ int fec_secded3932_destroy(fec _q)
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //  _msg_enc        :   encoded message [size: 1 x 2*_dec_msg_len]
-int fec_secded3932_encode(fec             _q,
-                          unsigned int    _dec_msg_len,
-                          unsigned char * _msg_dec,
-                          unsigned char * _msg_enc)
+int fec_secded3932_encode(fec                   _q,
+                          unsigned int          _dec_msg_len,
+                          const unsigned char * _msg_dec,
+                          unsigned char *       _msg_enc)
 {
     unsigned int i=0;       // decoded byte counter
     unsigned int j=0;       // encoded byte counter
@@ -308,10 +308,10 @@ int fec_secded3932_encode(fec             _q,
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //
 //unsigned int
-int fec_secded3932_decode(fec             _q,
-                          unsigned int    _dec_msg_len,
-                          unsigned char * _msg_enc,
-                          unsigned char * _msg_dec)
+int fec_secded3932_decode(fec                   _q,
+                          unsigned int          _dec_msg_len,
+                          const unsigned char * _msg_enc,
+                          unsigned char *       _msg_dec)
 {
     unsigned int i=0;       // decoded byte counter
     unsigned int j=0;       // encoded byte counter

--- a/src/fec/src/fec_secded7264.c
+++ b/src/fec/src/fec_secded7264.c
@@ -70,7 +70,7 @@ unsigned char secded7264_syndrome_w1[72] = {
 
 
 // compute parity byte on 64-byte input
-unsigned char fec_secded7264_compute_parity(unsigned char * _v)
+unsigned char fec_secded7264_compute_parity(const unsigned char * _v)
 {
     // compute parity byte on message
     unsigned int i;
@@ -95,7 +95,7 @@ unsigned char fec_secded7264_compute_parity(unsigned char * _v)
 }
 
 // compute syndrome on 72-bit input
-unsigned char fec_secded7264_compute_syndrome(unsigned char * _v)
+unsigned char fec_secded7264_compute_syndrome(const unsigned char * _v)
 {
     // TODO : unwrap this loop
     unsigned int i;
@@ -121,8 +121,8 @@ unsigned char fec_secded7264_compute_syndrome(unsigned char * _v)
     return syndrome;
 }
 
-int fec_secded7264_encode_symbol(unsigned char * _sym_dec,
-                                 unsigned char * _sym_enc)
+int fec_secded7264_encode_symbol(const unsigned char * _sym_dec,
+                                 unsigned char *       _sym_enc)
 {
     // compute parity on input
     _sym_enc[0] = fec_secded7264_compute_parity(_sym_dec);
@@ -142,8 +142,8 @@ int fec_secded7264_encode_symbol(unsigned char * _sym_dec,
 // decode symbol, returning 0/1/2 for zero/one/multiple errors detected
 //  _sym_enc    :   encoded symbol [size: 9 x 1]
 //  _sym_dec    :   decoded symbol [size: 8 x 1]
-int fec_secded7264_decode_symbol(unsigned char * _sym_enc,
-                                 unsigned char * _sym_dec)
+int fec_secded7264_decode_symbol(const unsigned char * _sym_enc,
+                                 unsigned char *       _sym_dec)
 {
     // estimate error vector
     unsigned char e_hat[9] = {0,0,0,0,0,0,0,0,0};
@@ -177,8 +177,8 @@ int fec_secded7264_decode_symbol(unsigned char * _sym_enc,
 // detected, respectively
 //  _sym_enc    :   encoded symbol [size: 9 x 1],
 //  _e_hat      :   estimated error vector [size: 9 x 1]
-int fec_secded7264_estimate_ehat(unsigned char * _sym_enc,
-                                 unsigned char * _e_hat)
+int fec_secded7264_estimate_ehat(const unsigned char * _sym_enc,
+                                 unsigned char *       _e_hat)
 {
     // clear output array
     memset(_e_hat, 0x00, 9*sizeof(unsigned char));
@@ -244,10 +244,10 @@ int fec_secded7264_destroy(fec _q)
 //  _dec_msg_len    :   decoded message length (number of bytes)
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //  _msg_enc        :   encoded message [size: 1 x 2*_dec_msg_len]
-int fec_secded7264_encode(fec             _q,
-                          unsigned int    _dec_msg_len,
-                          unsigned char * _msg_dec,
-                          unsigned char * _msg_enc)
+int fec_secded7264_encode(fec                   _q,
+                          unsigned int          _dec_msg_len,
+                          const unsigned char * _msg_dec,
+                          unsigned char *       _msg_enc)
 {
     unsigned int i=0;       // decoded byte counter
     unsigned int j=0;       // encoded byte counter
@@ -298,10 +298,10 @@ int fec_secded7264_encode(fec             _q,
 //  _msg_dec        :   decoded message [size: 1 x _dec_msg_len]
 //
 //unsigned int
-int fec_secded7264_decode(fec             _q,
-                          unsigned int    _dec_msg_len,
-                          unsigned char * _msg_enc,
-                          unsigned char * _msg_dec)
+int fec_secded7264_decode(fec                   _q,
+                          unsigned int          _dec_msg_len,
+                          const unsigned char * _msg_enc,
+                          unsigned char *       _msg_dec)
 {
     unsigned int i=0;       // decoded byte counter
     unsigned int j=0;       // encoded byte counter

--- a/src/fec/src/interleaver.c
+++ b/src/fec/src/interleaver.c
@@ -132,9 +132,9 @@ int interleaver_set_depth(interleaver  _q,
 //  _q          :   interleaver object
 //  _msg_dec    :   decoded (un-interleaved) message
 //  _msg_enc    :   encoded (interleaved) message
-int interleaver_encode(interleaver     _q,
-                       unsigned char * _msg_dec,
-                       unsigned char * _msg_enc)
+int interleaver_encode(interleaver           _q,
+                       const unsigned char * _msg_dec,
+                       unsigned char *       _msg_enc)
 {
     // copy data to output
     memmove(_msg_enc, _msg_dec, _q->n);
@@ -151,9 +151,9 @@ int interleaver_encode(interleaver     _q,
 //  _q          :   interleaver object
 //  _msg_dec    :   decoded (un-interleaved) message
 //  _msg_enc    :   encoded (interleaved) message
-int interleaver_encode_soft(interleaver     _q,
-                            unsigned char * _msg_dec,
-                            unsigned char * _msg_enc)
+int interleaver_encode_soft(interleaver           _q,
+                            const unsigned char * _msg_dec,
+                            unsigned char *       _msg_enc)
 {
     // copy data to output
     memmove(_msg_enc, _msg_dec, 8*_q->n);
@@ -170,9 +170,9 @@ int interleaver_encode_soft(interleaver     _q,
 //  _q          :   interleaver object
 //  _msg_enc    :   encoded (interleaved) message
 //  _msg_dec    :   decoded (un-interleaved) message
-int interleaver_decode(interleaver     _q,
-                       unsigned char * _msg_enc,
-                       unsigned char * _msg_dec)
+int interleaver_decode(interleaver           _q,
+                       const unsigned char * _msg_enc,
+                       unsigned char *       _msg_dec)
 {
     // copy data to output
     memmove(_msg_dec, _msg_enc, _q->n);
@@ -189,9 +189,9 @@ int interleaver_decode(interleaver     _q,
 //  _q          :   interleaver object
 //  _msg_enc    :   encoded (interleaved) message
 //  _msg_dec    :   decoded (un-interleaved) message
-int interleaver_decode_soft(interleaver     _q,
-                            unsigned char * _msg_enc,
-                            unsigned char * _msg_dec)
+int interleaver_decode_soft(interleaver           _q,
+                            const unsigned char * _msg_enc,
+                            unsigned char *       _msg_dec)
 {
     // copy data to output
     memmove(_msg_dec, _msg_enc, 8*_q->n);

--- a/src/fft/src/asgram.proto.c
+++ b/src/fft/src/asgram.proto.c
@@ -194,7 +194,7 @@ int ASGRAM(_push)(ASGRAM() _q,
 //  _x      :   input buffer [size: _n x 1]
 //  _n      :   input buffer length
 int ASGRAM(_write)(ASGRAM()     _q,
-                   TI *         _x,
+                   const TI *   _x,
                    unsigned int _n)
 {
     // write samples to internal spectral periodogram

--- a/src/fft/src/spgram.proto.c
+++ b/src/fft/src/spgram.proto.c
@@ -395,7 +395,7 @@ int SPGRAM(_push)(SPGRAM() _q,
 //  _x      :   input buffer [size: _n x 1]
 //  _n      :   input buffer length
 int SPGRAM(_write)(SPGRAM()     _q,
-                   TI *         _x,
+                   const TI *   _x,
                    unsigned int _n)
 {
 #if 0
@@ -544,7 +544,7 @@ int SPGRAM(_export_gnuplot)(SPGRAM()     _q,
 //  _n      :   input signal length
 //  _psd    :   output spectrum, [size: _nfft x 1]
 int SPGRAM(_estimate_psd)(unsigned int _nfft,
-                          TI *         _x,
+                          const TI *   _x,
                           unsigned int _n,
                           T *          _psd)
 {

--- a/src/fft/src/spwaterfall.proto.c
+++ b/src/fft/src/spwaterfall.proto.c
@@ -316,7 +316,7 @@ int SPWATERFALL(_push)(SPWATERFALL() _q,
 //  _x      :   input buffer [size: _n x 1]
 //  _n      :   input buffer length
 int SPWATERFALL(_write)(SPWATERFALL() _q,
-                        TI *          _x,
+                        const TI *    _x,
                         unsigned int  _n)
 {
     // TODO: be smarter about how to write and execute samples

--- a/src/filter/src/autocorr.proto.c
+++ b/src/filter/src/autocorr.proto.c
@@ -136,7 +136,7 @@ int AUTOCORR(_push)(AUTOCORR() _q, TI _x)
 //  _x      :   input array [size: _n x 1]
 //  _n      :   number of input samples
 int AUTOCORR(_write)(AUTOCORR()   _q,
-                     TI *         _x,
+                     const TI *   _x,
                      unsigned int _n)
 {
     unsigned int i;
@@ -168,7 +168,7 @@ int AUTOCORR(_execute)(AUTOCORR() _q, TO *_rxx)
 //  _n      :   number of input, output samples
 //  _rxx    :   input array [size: _n x 1]
 int AUTOCORR(_execute_block)(AUTOCORR()   _q,
-                             TI *         _x,
+                             const TI *   _x,
                              unsigned int _n,
                              TO *         _rxx)
 {

--- a/src/filter/src/dds.proto.c
+++ b/src/filter/src/dds.proto.c
@@ -285,9 +285,9 @@ float DDS(_get_delay_decim)(DDS() _q)
 //  _q      :   dds object
 //  _x      :   input sample array [size: 2^num_stages x 1]
 //  _y      :   output sample
-int DDS(_decim_execute)(DDS() _q,
-                        T *   _x,
-                        T *   _y)
+int DDS(_decim_execute)(DDS()     _q,
+                        const T * _x,
+                        T *       _y)
 {
     // copy input data
     memmove(_q->buffer0, _x, (_q->rate)*sizeof(T));

--- a/src/filter/src/fdelay.proto.c
+++ b/src/filter/src/fdelay.proto.c
@@ -194,7 +194,7 @@ int FDELAY(_push)(FDELAY() _q,
 //  _x      : buffer of input samples, [size: _n x 1]
 //  _n      : number of input samples
 int FDELAY(_write)(FDELAY()     _q,
-                   TI *         _x,
+                   const TI *   _x,
                    unsigned int _n)
 {
     unsigned int i;
@@ -224,7 +224,7 @@ int FDELAY(_execute)(FDELAY() _q,
 //  _n      : number of input, output samples
 //  _y      : pointer to output array, [size: _n x 1]
 int FDELAY(_execute_block)(FDELAY()     _q,
-                           TI *         _x,
+                           const TI *   _x,
                            unsigned int _n,
                            TO *         _y)
 {

--- a/src/filter/src/fftfilt.proto.c
+++ b/src/filter/src/fftfilt.proto.c
@@ -50,7 +50,7 @@ struct FFTFILT(_s) {
 //  _h      : filter coefficients [size: _h_len x 1]
 //  _h_len  : filter length, _h_len > 0
 //  _n      : block size = nfft/2, at least _h_len-1
-FFTFILT() FFTFILT(_create)(TC *         _h,
+FFTFILT() FFTFILT(_create)(const TC *   _h,
                            unsigned int _h_len,
                            unsigned int _n)
 {
@@ -192,7 +192,7 @@ int FFTFILT(_get_scale)(FFTFILT() _q,
 //  _x      : pointer to input data array  [size: _n x 1]
 //  _y      : pointer to output data array [size: _n x 1]
 int FFTFILT(_execute)(FFTFILT() _q,
-                      TI *      _x,
+                      const TI * _x,
                       TO *      _y)
 {
     unsigned int i;

--- a/src/filter/src/firdecim.proto.c
+++ b/src/filter/src/firdecim.proto.c
@@ -42,7 +42,7 @@ struct FIRDECIM(_s) {
 //  _h      :   filter coefficients [size: _h_len x 1]
 //  _h_len  :   filter coefficients length
 FIRDECIM() FIRDECIM(_create)(unsigned int _M,
-                             TC *         _h,
+                             const TC *   _h,
                              unsigned int _h_len)
 {
     // validate input
@@ -249,7 +249,7 @@ int FIRDECIM(_freqresp)(FIRDECIM()             _q,
 //  _x      :   input sample array [size: _M x 1]
 //  _y      :   output sample pointer
 int FIRDECIM(_execute)(FIRDECIM() _q,
-                       TI *       _x,
+                       const TI * _x,
                        TO *       _y)
 {
     TI * r; // read pointer
@@ -277,7 +277,7 @@ int FIRDECIM(_execute)(FIRDECIM() _q,
 //  _n      : number of _output_ samples
 //  _y      : output array [_size: _n x 1]
 int FIRDECIM(_execute_block)(FIRDECIM()   _q,
-                             TI *         _x,
+                             const TI *   _x,
                              unsigned int _n,
                              TO *         _y)
 {

--- a/src/filter/src/firdes.c
+++ b/src/filter/src/firdes.c
@@ -494,9 +494,9 @@ int liquid_firdes_doppler(unsigned int _n,
 //  _h      :   filter coefficients [size: _h_len x 1]
 //  _h_len  :   filter length
 //  _lag    :   auto-correlation lag (samples)
-float liquid_filter_autocorr(float *      _h,
-                             unsigned int _h_len,
-                             int          _lag)
+float liquid_filter_autocorr(const float * _h,
+                             unsigned int  _h_len,
+                             int           _lag)
 {
     // auto-correlation is even symmetric
     _lag = abs(_lag);
@@ -522,11 +522,11 @@ float liquid_filter_autocorr(float *      _h,
 //  _g      :   filter coefficients [size: _g_len]
 //  _g_len  :   filter length
 //  _lag    :   cross-correlation lag (samples)
-float liquid_filter_crosscorr(float *      _h,
-                              unsigned int _h_len,
-                              float *      _g,
-                              unsigned int _g_len,
-                              int          _lag)
+float liquid_filter_crosscorr(const float * _h,
+                              unsigned int  _h_len,
+                              const float * _g,
+                              unsigned int  _g_len,
+                              int           _lag)
 {
     // cross-correlation is odd symmetric
     if (_h_len < _g_len) {
@@ -577,11 +577,11 @@ float liquid_filter_crosscorr(float *      _h,
 //  _m      :   filter delay (symbols)
 //  _rms    :   output root mean-squared ISI
 //  _max    :   maximum ISI
-void liquid_filter_isi(float *      _h,
-                       unsigned int _k,
-                       unsigned int _m,
-                       float *      _rms,
-                       float *      _max)
+void liquid_filter_isi(const float * _h,
+                       unsigned int  _k,
+                       unsigned int  _m,
+                       float *       _rms,
+                       float *       _max)
 {
     unsigned int h_len = 2*_k*_m+1;
 
@@ -613,10 +613,10 @@ void liquid_filter_isi(float *      _h,
 //  _h_len  :   filter length
 //  _fc     :   analysis cut-off frequency
 //  _nfft   :   fft size
-float liquid_filter_energy(float *      _h,
-                           unsigned int _h_len,
-                           float        _fc,
-                           unsigned int _nfft)
+float liquid_filter_energy(const float * _h,
+                           unsigned int  _h_len,
+                           float         _fc,
+                           unsigned int  _nfft)
 {
     // validate input
     if (_fc < 0.0f || _fc > 0.5f) {
@@ -672,7 +672,7 @@ float liquid_filter_energy(float *      _h,
 //  _h_len  : length of coefficients array
 //  _fc     : center frequency for analysis, -0.5 <= _fc <= 0.5
 //  _H      : pointer to output value
-int liquid_freqrespf(float *         _h,
+int liquid_freqrespf(const float *   _h,
                      unsigned int    _h_len,
                      float           _fc,
                      float complex * _H)
@@ -694,10 +694,10 @@ int liquid_freqrespf(float *         _h,
 //  _h_len  : length of coefficients array
 //  _fc     : center frequency for analysis, -0.5 <= _fc <= 0.5
 //  _H      : pointer to output value
-int liquid_freqrespcf(float complex * _h,
-                      unsigned int    _h_len,
-                      float           _fc,
-                      float complex * _H)
+int liquid_freqrespcf(const float complex * _h,
+                      unsigned int          _h_len,
+                      float                 _fc,
+                      float complex *       _H)
 {
     // compute dot product between coefficients and exp{ 2 pi fc {0..n-1} }
     float complex H = 0.0f;

--- a/src/filter/src/firdespm.c
+++ b/src/filter/src/firdespm.c
@@ -141,14 +141,14 @@ struct firdespm_s {
 //  _wtype      :   weight types (e.g. LIQUID_FIRDESPM_FLATWEIGHT) [size: _num_bands x 1]
 //  _btype      :   band type (e.g. LIQUID_FIRDESPM_BANDPASS)
 //  _h          :   output coefficients array [size: _h_len x 1]
-int firdespm_run(unsigned int            _h_len,
-                 unsigned int            _num_bands,
-                 float *                 _bands,
-                 float *                 _des,
-                 float *                 _weights,
-                 liquid_firdespm_wtype * _wtype,
-                 liquid_firdespm_btype   _btype,
-                 float *                 _h)
+int firdespm_run(unsigned int                  _h_len,
+                 unsigned int                  _num_bands,
+                 const float *                 _bands,
+                 const float *                 _des,
+                 const float *                 _weights,
+                 const liquid_firdespm_wtype * _wtype,
+                 liquid_firdespm_btype         _btype,
+                 float *                       _h)
 {
     // create object
     firdespm q = firdespm_create(_h_len,_num_bands,_bands,_des,_weights,_wtype,_btype);
@@ -209,13 +209,13 @@ int firdespm_lowpass(unsigned int _n,
 //  _weights    :   response weighting [size: _num_bands x 1]
 //  _wtype      :   weight types (e.g. LIQUID_FIRDESPM_FLATWEIGHT) [size: _num_bands x 1]
 //  _btype      :   band type (e.g. LIQUID_FIRDESPM_BANDPASS)
-firdespm firdespm_create(unsigned int            _h_len,
-                         unsigned int            _num_bands,
-                         float *                 _bands,
-                         float *                 _des,
-                         float *                 _weights,
-                         liquid_firdespm_wtype * _wtype,
-                         liquid_firdespm_btype   _btype)
+firdespm firdespm_create(unsigned int                  _h_len,
+                         unsigned int                  _num_bands,
+                         const float *                 _bands,
+                         const float *                 _des,
+                         const float *                 _weights,
+                         const liquid_firdespm_wtype * _wtype,
+                         liquid_firdespm_btype         _btype)
 {
     // basic validation
     if (_h_len==0)
@@ -319,7 +319,7 @@ firdespm firdespm_create(unsigned int            _h_len,
 //  _userdata   :   user-defined data structure for callback function
 firdespm firdespm_create_callback(unsigned int          _h_len,
                                   unsigned int          _num_bands,
-                                  float *               _bands,
+                                  const float *         _bands,
                                   liquid_firdespm_btype _btype,
                                   firdespm_callback     _callback,
                                   void *                _userdata)

--- a/src/filter/src/firfarrow.proto.c
+++ b/src/filter/src/firfarrow.proto.c
@@ -243,10 +243,10 @@ int FIRFARROW(_execute)(FIRFARROW() _q,
 //  _x      : input array [size: _n x 1]
 //  _n      : input, output array size
 //  _y      : output array [size: _n x 1]
-int FIRFARROW(_execute_block)(FIRFARROW()  _q,
-                              TI *         _x,
-                              unsigned int _n,
-                              TO *         _y)
+int FIRFARROW(_execute_block)(FIRFARROW()    _q,
+                              const TI *     _x,
+                              unsigned int   _n,
+                              TO *           _y)
 {
     unsigned int i;
 

--- a/src/filter/src/firfilt.proto.c
+++ b/src/filter/src/firfilt.proto.c
@@ -60,7 +60,7 @@ struct FIRFILT(_s) {
 // create firfilt object
 //  _h      :   coefficients (filter taps) [size: _n x 1]
 //  _n      :   filter length
-FIRFILT() FIRFILT(_create)(TC * _h,
+FIRFILT() FIRFILT(_create)(const TC * _h,
                            unsigned int _n)
 {
     // validate input
@@ -253,7 +253,7 @@ FIRFILT() FIRFILT(_create_notch)(unsigned int _m,
 //  _h      :   new coefficients [size: _n x 1]
 //  _n      :   new filter length
 FIRFILT() FIRFILT(_recreate)(FIRFILT() _q,
-                             TC * _h,
+                             const TC * _h,
                              unsigned int _n)
 {
     unsigned int i;
@@ -401,7 +401,7 @@ int FIRFILT(_push)(FIRFILT() _q,
 //  _x      : buffer of input samples, [size: _n x 1]
 //  _n      : number of input samples
 int FIRFILT(_write)(FIRFILT()    _q,
-                    TI *         _x,
+                    const TI *   _x,
                     unsigned int _n)
 {
 #if LIQUID_FIRFILT_USE_WINDOW
@@ -457,7 +457,7 @@ int FIRFILT(_execute_one)(FIRFILT() _q,
 //  _n      : number of input, output samples
 //  _y      : pointer to output array [size: _n x 1]
 int FIRFILT(_execute_block)(FIRFILT()    _q,
-                            TI *         _x,
+                            const TI *   _x,
                             unsigned int _n,
                             TO *         _y)
 {

--- a/src/filter/src/firhilb.proto.c
+++ b/src/filter/src/firhilb.proto.c
@@ -273,7 +273,7 @@ int FIRHILB(_c2r_execute)(FIRHILB() _q,
 //  _x      :   real-valued input array [size: 2 x 1]
 //  _y      :   complex-valued output sample
 int FIRHILB(_decim_execute)(FIRHILB()   _q,
-                            T *         _x,
+                            const T *   _x,
                             T complex * _y)
 {
     T * r;  // buffer read pointer
@@ -305,7 +305,7 @@ int FIRHILB(_decim_execute)(FIRHILB()   _q,
 //  _n      :   number of *output* samples
 //  _y      :   complex-valued output array [size: _n x 1]
 int FIRHILB(_decim_execute_block)(FIRHILB()    _q,
-                                  T *          _x,
+                                  const T *    _x,
                                   unsigned int _n,
                                   T complex *  _y)
 {
@@ -351,10 +351,10 @@ int FIRHILB(_interp_execute)(FIRHILB() _q,
 //  _x      :   complex-valued input array [size: _n x 1]
 //  _n      :   number of *input* samples
 //  _y      :   real-valued output array [size: 2*_n x 1]
-int FIRHILB(_interp_execute_block)(FIRHILB()    _q,
-                                   T complex *  _x,
-                                   unsigned int _n,
-                                   T *          _y)
+int FIRHILB(_interp_execute_block)(FIRHILB()          _q,
+                                   const T complex *  _x,
+                                   unsigned int       _n,
+                                   T *                _y)
 {
     unsigned int i;
     for (i=0; i<_n; i++) {

--- a/src/filter/src/firinterp.proto.c
+++ b/src/filter/src/firinterp.proto.c
@@ -39,7 +39,7 @@ struct FIRINTERP(_s) {
 //  _h      :   filter coefficients array [size: _h_len x 1]
 //  _h_len  :   filter length
 FIRINTERP() FIRINTERP(_create)(unsigned int _interp,
-                               TC *         _h,
+                               const TC *   _h,
                                unsigned int _h_len)
 {
     // validate input
@@ -280,7 +280,7 @@ int FIRINTERP(_execute)(FIRINTERP() _q,
 //  _n      : size of input array
 //  _y      : output sample array [size: M*_n x 1]
 int FIRINTERP(_execute_block)(FIRINTERP()  _q,
-                              TI *         _x,
+                              const TI *   _x,
                               unsigned int _n,
                               TO *         _y)
 {

--- a/src/filter/src/firpfb.proto.c
+++ b/src/filter/src/firpfb.proto.c
@@ -43,7 +43,7 @@ struct FIRPFB(_s) {
 //  _h           : coefficients [size: _num_filters*_h_len x 1]
 //  _h_len       : filter delay (symbols)
 FIRPFB() FIRPFB(_create)(unsigned int _num_filters,
-                         TC *         _h,
+                         const TC *   _h,
                          unsigned int _h_len)
 {
     // validate input
@@ -233,7 +233,7 @@ FIRPFB() FIRPFB(_create_drnyquist)(int          _type,
 //  _h_len       : length of each filter
 FIRPFB() FIRPFB(_recreate)(FIRPFB()     _q,
                            unsigned int _num_filters,
-                           TC *         _h,
+                           const TC *   _h,
                            unsigned int _h_len)
 {
     // check to see if filter length has changed
@@ -336,7 +336,7 @@ int FIRPFB(_push)(FIRPFB() _q, TI _x)
 
 // Write a block of samples into object's internal buffer
 int FIRPFB(_write)(FIRPFB()     _q,
-                    TI *         _x,
+                    const TI *   _x,
                     unsigned int _n)
 {
     return WINDOW(_write)(_q->w, _x, _n);
@@ -376,7 +376,7 @@ int FIRPFB(_execute)(FIRPFB()     _q,
 //  _y      : pointer to output array [size: _n x 1]
 int FIRPFB(_execute_block)(FIRPFB()     _q,
                            unsigned int _i,
-                           TI *         _x,
+                           const TI *   _x,
                            unsigned int _n,
                            TO *         _y)
 {

--- a/src/filter/src/group_delay.c
+++ b/src/filter/src/group_delay.c
@@ -31,9 +31,9 @@
 //  _h      : filter coefficients array [size: _n x 1]
 //  _n      : filter length
 //  _fc     : frequency at which delay is evaluated (-0.5 < _fc < 0.5)
-float fir_group_delay(float *      _h,
-                      unsigned int _n,
-                      float        _fc)
+float fir_group_delay(const float * _h,
+                      unsigned int  _n,
+                      float         _fc)
 {
     // validate input
     if (_n == 0) {
@@ -61,11 +61,11 @@ float fir_group_delay(float *      _h,
 //  _a      : filter coefficients array (denominator), [size: _na x 1]
 //  _na     : filter length (denominator)
 //  _fc     : frequency at which delay is evaluated (-0.5 < _fc < 0.5)
-float iir_group_delay(float *      _b,
-                      unsigned int _nb,
-                      float *      _a,
-                      unsigned int _na,
-                      float        _fc)
+float iir_group_delay(const float * _b,
+                      unsigned int  _nb,
+                      const float * _a,
+                      unsigned int  _na,
+                      float         _fc)
 {
     // validate input
     if (_nb == 0) {

--- a/src/filter/src/iirdecim.proto.c
+++ b/src/filter/src/iirdecim.proto.c
@@ -45,9 +45,9 @@ struct IIRDECIM(_s) {
 //  _a      : feed-forward coefficients [size: _na x 1]
 //  _na     : feed-forward coefficients length
 IIRDECIM() IIRDECIM(_create)(unsigned int _M,
-                             TC *         _b,
+                             const TC *   _b,
                              unsigned int _nb,
-                             TC *         _a,
+                             const TC *   _a,
                              unsigned int _na)
 {
     // validate input
@@ -152,7 +152,7 @@ int IIRDECIM(_reset)(IIRDECIM() _q)
 //  _y      :   output sample pointer
 //  _index  :   decimator output index [0,_M-1]
 int IIRDECIM(_execute)(IIRDECIM()   _q,
-                       TI *         _x,
+                       const TI *   _x,
                        TO *         _y)
 {
     TO v; // output value
@@ -174,7 +174,7 @@ int IIRDECIM(_execute)(IIRDECIM()   _q,
 //  _n      : number of _output_ samples
 //  _y      : output array [_sze: _n x 1]
 int IIRDECIM(_execute_block)(IIRDECIM()   _q,
-                             TI *         _x,
+                             const TI *   _x,
                              unsigned int _n,
                              TO *         _y)
 {

--- a/src/filter/src/iirdes.c
+++ b/src/filter/src/iirdes.c
@@ -56,10 +56,10 @@
 //  _n      :   number of elements in _z
 //  _tol    :   tolerance for finding complex pairs
 //  _p      :   resulting pairs, pure real values of _z at end
-int liquid_cplxpair(float complex * _z,
-                    unsigned int    _n,
-                    float           _tol,
-                    float complex * _p)
+int liquid_cplxpair(const float complex * _z,
+                    unsigned int          _n,
+                    float                 _tol,
+                    float complex *       _p)
 {
     // validate input
     if (_tol < 0)
@@ -227,15 +227,15 @@ float iirdes_freqprewarp(liquid_iirdes_bandtype _btype,
 // The filter order is characterized by the number of analog
 // poles.  The analog filter may have up to _npa zeros.
 // The number of digital zeros and poles is equal to _npa.
-int bilinear_zpkf(float complex * _za,
-                  unsigned int    _nza,
-                  float complex * _pa,
-                  unsigned int    _npa,
-                  float complex   _ka,
-                  float           _m,
-                  float complex * _zd,
-                  float complex * _pd,
-                  float complex * _kd)
+int bilinear_zpkf(const float complex * _za,
+                  unsigned int          _nza,
+                  const float complex * _pa,
+                  unsigned int          _npa,
+                  float complex         _ka,
+                  float                 _m,
+                  float complex *       _zd,
+                  float complex *       _pd,
+                  float complex *       _kd)
 {
     unsigned int i;
 
@@ -294,13 +294,13 @@ int bilinear_zpkf(float complex * _za,
 //  _m          : bilateral warping factor
 //  _bd         : output digital filter numerator, [size: _b_order+1]
 //  _ad         : output digital filter numerator, [size: _a_order+1]
-int bilinear_nd(float complex * _b,
-                unsigned int    _b_order,
-                float complex * _a,
-                unsigned int    _a_order,
-                float           _m,
-                float complex * _bd,
-                float complex * _ad)
+int bilinear_nd(const float complex * _b,
+                unsigned int          _b_order,
+                const float complex * _a,
+                unsigned int          _a_order,
+                float                 _m,
+                float complex *       _bd,
+                float complex *       _ad)
 {
     if (_b_order > _a_order)
         return liquid_error(LIQUID_EICONFIG,"bilinear_nd(), numerator order cannot be higher than denominator");
@@ -380,12 +380,12 @@ int bilinear_nd(float complex * _b,
 //  _k      :   digital gain
 //  _b      :   output numerator (length: _n+1)
 //  _a      :   output denominator (length: _n+1)
-int iirdes_dzpk2tff(float complex * _zd,
-                    float complex * _pd,
-                    unsigned int    _n,
-                    float complex   _k,
-                    float *         _b,
-                    float *         _a)
+int iirdes_dzpk2tff(const float complex * _zd,
+                    const float complex * _pd,
+                    unsigned int          _n,
+                    float complex         _k,
+                    float *               _b,
+                    float *               _a)
 {
     unsigned int i;
     float complex q[_n+1];
@@ -419,12 +419,12 @@ int iirdes_dzpk2tff(float complex * _zd,
 //  L is the number of sections in the cascade:
 //      r = _n % 2
 //      L = (_n - r) / 2;
-int iirdes_dzpk2sosf(float complex * _zd,
-                     float complex * _pd,
-                     unsigned int    _n,
-                     float complex   _kd,
-                     float *         _b,
-                     float *         _a)
+int iirdes_dzpk2sosf(const float complex * _zd,
+                     const float complex * _pd,
+                     unsigned int          _n,
+                     float complex         _kd,
+                     float *               _b,
+                     float *               _a)
 {
     int i;
     float tol=1e-6f; // tolerance for conjuate pair computation
@@ -534,11 +534,11 @@ int iirdes_dzpk2sosf(float complex * _zd,
 //  _n      :   low-pass filter order
 //  _zdt    :   digital zeros transformed [length: _n]
 //  _pdt    :   digital poles transformed [length: _n]
-int iirdes_dzpk_lp2hp(liquid_float_complex * _zd,
-                      liquid_float_complex * _pd,
-                      unsigned int           _n,
-                      liquid_float_complex * _zdt,
-                      liquid_float_complex * _pdt)
+int iirdes_dzpk_lp2hp(const liquid_float_complex * _zd,
+                      const liquid_float_complex * _pd,
+                      unsigned int                 _n,
+                      liquid_float_complex *       _zdt,
+                      liquid_float_complex *       _pdt)
 {
     unsigned int i;
     for (i=0; i<_n; i++) {
@@ -556,12 +556,12 @@ int iirdes_dzpk_lp2hp(liquid_float_complex * _zd,
 //  _f0     :   center frequency
 //  _zdt    :   digital zeros transformed [length: 2*_n]
 //  _pdt    :   digital poles transformed [length: 2*_n]
-int iirdes_dzpk_lp2bp(liquid_float_complex * _zd,
-                      liquid_float_complex * _pd,
-                      unsigned int           _n,
-                      float                  _f0,
-                      liquid_float_complex * _zdt,
-                      liquid_float_complex * _pdt)
+int iirdes_dzpk_lp2bp(const liquid_float_complex * _zd,
+                      const liquid_float_complex * _pd,
+                      unsigned int                 _n,
+                      float                        _f0,
+                      liquid_float_complex *       _zdt,
+                      liquid_float_complex *       _pdt)
 {
     float c0 = cosf(2*M_PI*_f0);
 
@@ -789,8 +789,8 @@ int liquid_iirdes(liquid_iirdes_filtertype _ftype,
 //  _b      :   feed-forward coefficients [size: _n x 1]
 //  _a      :   feed-back coefficients [size: _n x 1]
 //  _n      :   number of coefficients
-int iirdes_isstable(float * _b,
-                    float * _a,
+int iirdes_isstable(const float * _b,
+                    const float * _a,
                     unsigned int _n)
 {
     // validate input

--- a/src/filter/src/iirfilt.proto.c
+++ b/src/filter/src/iirfilt.proto.c
@@ -92,9 +92,9 @@ void IIRFILT(_init)(IIRFILT() _q)
 //  _nb     :   length of numerator
 //  _a      :   denominator, feed-back coefficients [size: _na x 1]
 //  _na     :   length of denominator
-IIRFILT() IIRFILT(_create)(TC *         _b,
+IIRFILT() IIRFILT(_create)(const TC *   _b,
                            unsigned int _nb,
-                           TC *         _a,
+                           const TC *   _a,
                            unsigned int _na)
 {
     // validate input
@@ -161,8 +161,8 @@ IIRFILT() IIRFILT(_create)(TC *         _b,
 //   r = n % 2
 //   L = (n-r)/2
 //   nsos = L+r
-IIRFILT() IIRFILT(_create_sos)(TC *         _B,
-                               TC *         _A,
+IIRFILT() IIRFILT(_create_sos)(const TC *   _B,
+                               const TC *   _A,
                                unsigned int _nsos)
 {
     // validate input
@@ -652,7 +652,7 @@ int IIRFILT(_execute)(IIRFILT() _q,
 //  _n      : number of input, output samples
 //  _y      : pointer to output array [size: _n x 1]
 int IIRFILT(_execute_block)(IIRFILT()    _q,
-                            TI *         _x,
+                            const TI *   _x,
                             unsigned int _n,
                             TO *         _y)
 {

--- a/src/filter/src/iirfiltsos.proto.c
+++ b/src/filter/src/iirfiltsos.proto.c
@@ -54,8 +54,8 @@ struct IIRFILTSOS(_s) {
 };
 
 // create iirfiltsos object
-IIRFILTSOS() IIRFILTSOS(_create)(TC * _b,
-                                 TC * _a)
+IIRFILTSOS() IIRFILTSOS(_create)(const TC * _b,
+                                 const TC * _a)
 {
     // create filter object
     IIRFILTSOS() q = (IIRFILTSOS()) malloc(sizeof(struct IIRFILTSOS(_s)));
@@ -76,8 +76,8 @@ IIRFILTSOS() IIRFILTSOS(_create)(TC * _b,
 //  _b      : feed-forward coefficients [size: _3 x 1]
 //  _a      : feed-back coefficients    [size: _3 x 1]
 int IIRFILTSOS(_set_coefficients)(IIRFILTSOS() _q,
-                                  TC *         _b,
-                                  TC *         _a)
+                                  const TC *   _b,
+                                  const TC *   _a)
 {
     // retain a0 coefficient for normalization
     TC a0 = _a[0];

--- a/src/filter/src/iirhilb.proto.c
+++ b/src/filter/src/iirhilb.proto.c
@@ -173,7 +173,7 @@ int IIRHILB(_r2c_execute)(IIRHILB()   _q,
 
 // Execute Hilbert transform (real to complex) on a block of samples
 int IIRHILB(_r2c_execute_block)(IIRHILB()    _q,
-                                T *          _x,
+                                const T *    _x,
                                 unsigned int _n,
                                 T complex *  _y)
 {
@@ -223,10 +223,10 @@ int IIRHILB(_c2r_execute)(IIRHILB() _q,
     return LIQUID_OK;
 }
 // Execute Hilbert transform (complex to real) on a block of samples
-int IIRHILB(_c2r_execute_block)(IIRHILB()    _q,
-                                T complex *  _x,
-                                unsigned int _n,
-                                T *          _y)
+int IIRHILB(_c2r_execute_block)(IIRHILB()         _q,
+                                const T complex * _x,
+                                unsigned int      _n,
+                                T *               _y)
 {
     unsigned int i;
     for (i=0; i<_n; i++)
@@ -239,7 +239,7 @@ int IIRHILB(_c2r_execute_block)(IIRHILB()    _q,
 //  _x      :   real-valued input array [size: 2 x 1]
 //  _y      :   complex-valued output sample
 int IIRHILB(_decim_execute)(IIRHILB()   _q,
-                            T *         _x,
+                            const T *   _x,
                             T complex * _y)
 {
     // mix down by Fs/4
@@ -271,7 +271,7 @@ int IIRHILB(_decim_execute)(IIRHILB()   _q,
 //  _n      :   number of *output* samples
 //  _y      :   complex-valued output array [size: _n x 1]
 int IIRHILB(_decim_execute_block)(IIRHILB()    _q,
-                                  T *          _x,
+                                  const T *    _x,
                                   unsigned int _n,
                                   T complex *  _y)
 {
@@ -318,10 +318,10 @@ int IIRHILB(_interp_execute)(IIRHILB() _q,
 //  _x      :   complex-valued input array [size: _n x 1]
 //  _n      :   number of *input* samples
 //  _y      :   real-valued output array [size: 2*_n x 1]
-int IIRHILB(_interp_execute_block)(IIRHILB()    _q,
-                                   T complex *  _x,
-                                   unsigned int _n,
-                                   T *          _y)
+int IIRHILB(_interp_execute_block)(IIRHILB()         _q,
+                                   const T complex * _x,
+                                   unsigned int      _n,
+                                   T *               _y)
 {
     unsigned int i;
 

--- a/src/filter/src/iirinterp.proto.c
+++ b/src/filter/src/iirinterp.proto.c
@@ -43,9 +43,9 @@ struct IIRINTERP(_s) {
 //  _a      : feed-forward coefficients [size: _na x 1]
 //  _na     : feed-forward coefficients length
 IIRINTERP() IIRINTERP(_create)(unsigned int _M,
-                               TC *         _b,
+                               const TC *   _b,
                                unsigned int _nb,
-                               TC *         _a,
+                               const TC *   _a,
                                unsigned int _na)
 {
     // validate input
@@ -169,7 +169,7 @@ int IIRINTERP(_execute)(IIRINTERP() _q,
 //  _n      : size of input array
 //  _y      : output sample array [size: _M*_n x 1]
 int IIRINTERP(_execute_block)(IIRINTERP()  _q,
-                              TI *         _x,
+                              const TI *   _x,
                               unsigned int _n,
                               TO *         _y)
 {

--- a/src/filter/src/lpc.c
+++ b/src/filter/src/lpc.c
@@ -40,7 +40,7 @@
 //  _p      :   prediction filter order
 //  _a      :   prediction filter [size: _p+1 x 1]
 //  _e      :   prediction error variance [size: _p+1 x 1]
-void liquid_lpc(float * _x,
+void liquid_lpc(const float * _x,
                 unsigned int _n,
                 unsigned int _p,
                 float * _a,
@@ -79,7 +79,7 @@ void liquid_lpc(float * _x,
 //
 // NOTES:
 //  By definition _a[0] = 1.0
-void liquid_levinson(float * _r,
+void liquid_levinson(const float * _r,
                      unsigned int _p,
                      float * _a,
                      float * _e)

--- a/src/filter/src/msresamp.proto.c
+++ b/src/filter/src/msresamp.proto.c
@@ -39,14 +39,14 @@
 
 // execute multi-stage interpolation
 int MSRESAMP(_interp_execute)(MSRESAMP()    _q,
-                             TI *           _x,
+                             const TI *     _x,
                              unsigned int   _nx,
                              TO *           _y,
                              unsigned int * _num_written);
 
 // execute multi-stage decimation
 int MSRESAMP(_decim_execute)(MSRESAMP()     _q,
-                             TI *           _x,
+                             const TI *     _x,
                              unsigned int   _nx,
                              TO *           _y,
                              unsigned int * _num_written);
@@ -312,7 +312,7 @@ unsigned int MSRESAMP(_get_num_output)(MSRESAMP()   _q,
 //  _y      :   output sample array
 //  _ny     :   number of samples written to _y
 int MSRESAMP(_execute)(MSRESAMP()     _q,
-                       TI *           _x,
+                       const TI *     _x,
                        unsigned int   _nx,
                        TO *           _y,
                        unsigned int * _ny)
@@ -337,7 +337,7 @@ int MSRESAMP(_execute)(MSRESAMP()     _q,
 //  _y      :   output sample array
 //  _nw     :   number of samples written to _y
 int MSRESAMP(_interp_execute)(MSRESAMP()     _q,
-                              TI *           _x,
+                              const TI *     _x,
                               unsigned int   _nx,
                               TO *           _y,
                               unsigned int * _ny)
@@ -373,7 +373,7 @@ int MSRESAMP(_interp_execute)(MSRESAMP()     _q,
 //  _y      :   output sample array
 //  _nw     :   number of samples written to _y
 int MSRESAMP(_decim_execute)(MSRESAMP()     _q,
-                             TI *           _x,
+                             const TI *     _x,
                              unsigned int   _nx,
                              TO *           _y,
                              unsigned int * _ny)

--- a/src/filter/src/ordfilt.proto.c
+++ b/src/filter/src/ordfilt.proto.c
@@ -167,7 +167,7 @@ int ORDFILT(_push)(ORDFILT() _q,
 //  _x      : array of input samples, [size: _n x 1]
 //  _n      : number of input elements
 int ORDFILT(_write)(ORDFILT()    _q,
-                    TI *         _x,
+                    const TI *   _x,
                     unsigned int _n)
 {
 #if LIQUID_ORDFILT_USE_WINDOW
@@ -220,7 +220,7 @@ int ORDFILT(_execute_one)(ORDFILT() _q,
 //  _n      : number of input, output samples
 //  _y      : pointer to output array [size: _n x 1]
 int ORDFILT(_execute_block)(ORDFILT()    _q,
-                            TI *         _x,
+                            const TI *   _x,
                             unsigned int _n,
                             TO *         _y)
 {

--- a/src/filter/src/resamp.fixed.proto.c
+++ b/src/filter/src/resamp.fixed.proto.c
@@ -312,7 +312,7 @@ int RESAMP(_execute)(RESAMP()       _q,
 //  _y              :   output sample array (pointer)
 //  _ny             :   number of samples written to _y
 int RESAMP(_execute_block)(RESAMP()       _q,
-                           TI *           _x,
+                           const TI *     _x,
                            unsigned int   _nx,
                            TO *           _y,
                            unsigned int * _ny)

--- a/src/filter/src/resamp.proto.c
+++ b/src/filter/src/resamp.proto.c
@@ -382,7 +382,7 @@ int RESAMP(_execute)(RESAMP()       _q,
 //  _y              :   output sample array (pointer)
 //  _ny             :   number of samples written to _y
 int RESAMP(_execute_block)(RESAMP()       _q,
-                           TI *           _x,
+                           const TI *     _x,
                            unsigned int   _nx,
                            TO *           _y,
                            unsigned int * _ny)

--- a/src/filter/src/rresamp.proto.c
+++ b/src/filter/src/rresamp.proto.c
@@ -40,9 +40,9 @@ struct RRESAMP(_s) {
 
 // internal: execute rational-rate resampler on a primitive-length block of
 // input samples and store the resulting samples in the output array.
-int RRESAMP(_execute_primitive)(RRESAMP() _q,
-                                TI *      _x,
-                                TO *      _y);
+int RRESAMP(_execute_primitive)(RRESAMP()  _q,
+                                const TI * _x,
+                                TO *       _y);
 
 // Create rational-rate resampler object from external coefficients
 //  _interp : interpolation factor
@@ -52,7 +52,7 @@ int RRESAMP(_execute_primitive)(RRESAMP() _q,
 RRESAMP() RRESAMP(_create)(unsigned int _interp,
                            unsigned int _decim,
                            unsigned int _m,
-                           TC *         _h)
+                           const TC *   _h)
 {
     // validate input
     if (_interp == 0)
@@ -286,8 +286,8 @@ unsigned int RRESAMP(_get_decim)(RRESAMP() _q)
 // internal state of the resampler.
 //  _q      : resamp object
 //  _buf    : input sample array, [size: Q x 1]
-int RRESAMP(_write)(RRESAMP() _q,
-                    TI *      _buf)
+int RRESAMP(_write)(RRESAMP()  _q,
+                    const TI * _buf)
 {
     return FIRPFB(_write)(_q->pfb, _buf, _q->Q);
 }
@@ -297,9 +297,9 @@ int RRESAMP(_write)(RRESAMP() _q,
 //  _q  : resamp object
 //  _x  : input sample array, [size: Q x 1]
 //  _y  : output sample array [size: P x 1]
-int RRESAMP(_execute)(RRESAMP() _q,
-                      TI *      _x,
-                      TO *      _y)
+int RRESAMP(_execute)(RRESAMP()  _q,
+                      const TI * _x,
+                      TO *       _y)
 {
     // run in blocks
     unsigned int i;
@@ -319,10 +319,10 @@ int RRESAMP(_execute)(RRESAMP() _q,
 //  _x  : input sample array, [size: Q*n x 1]
 //  _n  : block size
 //  _y  : output sample array [size: P*n x 1]
-int RRESAMP(_execute_block)(RRESAMP()      _q,
-                            TI *           _x,
-                            unsigned int   _n,
-                            TO *           _y)
+int RRESAMP(_execute_block)(RRESAMP()    _q,
+                            const TI *   _x,
+                            unsigned int _n,
+                            TO *         _y)
 {
     unsigned int i;
     for (i=0; i<_n; i++) {
@@ -334,9 +334,9 @@ int RRESAMP(_execute_block)(RRESAMP()      _q,
 }
 
 // internal
-int RRESAMP(_execute_primitive)(RRESAMP() _q,
-                                TI *      _x,
-                                TO *      _y)
+int RRESAMP(_execute_primitive)(RRESAMP()  _q,
+                                const TI * _x,
+                                TO *       _y)
 {
     unsigned int index = 0; // filterbank index
     unsigned int i, n=0;

--- a/src/filter/src/symsync.proto.c
+++ b/src/filter/src/symsync.proto.c
@@ -99,7 +99,7 @@ struct SYMSYNC(_s) {
 //  _h_len  : length of matched filter
 SYMSYNC() SYMSYNC(_create)(unsigned int _k,
                            unsigned int _M,
-                           TC *         _h,
+                           const TC *   _h,
                            unsigned int _h_len)
 {
     // validate input
@@ -396,7 +396,7 @@ float SYMSYNC(_get_tau)(SYMSYNC() _q)
 //  _y      : output data array
 //  _ny     : number of samples written to output buffer
 int SYMSYNC(_execute)(SYMSYNC()      _q,
-                      TI *           _x,
+                      const TI *     _x,
                       unsigned int   _nx,
                       TO *           _y,
                       unsigned int * _ny)

--- a/src/framing/bench/bpacketsync_benchmark.c
+++ b/src/framing/bench/bpacketsync_benchmark.c
@@ -28,11 +28,11 @@
 #include "liquid.internal.h"
 
 // callback function
-static int bpacketsync_benchmark_callback(unsigned char *  _payload,
-                                          int              _payload_valid,
-                                          unsigned int     _payload_len,
-                                          framesyncstats_s _stats,
-                                          void *           _userdata)
+static int bpacketsync_benchmark_callback(const unsigned char *  _payload,
+                                          int                    _payload_valid,
+                                          unsigned int           _payload_len,
+                                          framesyncstats_s       _stats,
+                                          void *                 _userdata)
 {
     if (!_payload_valid)
         return 0;

--- a/src/framing/bench/framesync64_benchmark.c
+++ b/src/framing/bench/framesync64_benchmark.c
@@ -32,13 +32,13 @@ typedef struct {
     unsigned int num_frames_valid;      // number of valid payloads
 } framedata;
 
-static int callback(unsigned char *  _header,
-                    int              _header_valid,
-                    unsigned char *  _payload,
-                    unsigned int     _payload_len,
-                    int              _payload_valid,
-                    framesyncstats_s _stats,
-                    void *           _userdata)
+static int callback(const unsigned char *  _header,
+                    int                    _header_valid,
+                    const unsigned char *  _payload,
+                    unsigned int           _payload_len,
+                    int                    _payload_valid,
+                    framesyncstats_s       _stats,
+                    void *                 _userdata)
 {
     framedata * fd = (framedata*) _userdata;
     fd->num_frames_detected += 1;

--- a/src/framing/src/bpacketgen.c
+++ b/src/framing/src/bpacketgen.c
@@ -216,9 +216,9 @@ unsigned int bpacketgen_get_packet_len(bpacketgen _q)
 }
 
 // encode packet
-void bpacketgen_encode(bpacketgen _q,
-                       unsigned char * _msg_dec,
-                       unsigned char * _packet)
+void bpacketgen_encode(bpacketgen            _q,
+                       const unsigned char * _msg_dec,
+                       unsigned char *       _packet)
 {
     // output byte index counter
     unsigned int n=0;

--- a/src/framing/src/bpresync.proto.c
+++ b/src/framing/src/bpresync.proto.c
@@ -62,7 +62,7 @@ int BPRESYNC(_correlatex)(BPRESYNC()      _q,
 //  _n          :   baseband sequence length
 //  _dphi_max   :   maximum absolute frequency deviation
 //  _m          :   number of correlators
-BPRESYNC() BPRESYNC(_create)(TC *         _v,
+BPRESYNC() BPRESYNC(_create)(const TC *   _v,
                              unsigned int _n,
                              float        _dphi_max,
                              unsigned int _m)

--- a/src/framing/src/bsync.proto.c
+++ b/src/framing/src/bsync.proto.c
@@ -46,7 +46,7 @@ struct BSYNC(_s) {
     TO rxy;             // cross correlation
 };
 
-BSYNC() BSYNC(_create)(unsigned int _n, TC * _v)
+BSYNC() BSYNC(_create)(unsigned int _n, const TC * _v)
 {
     BSYNC() fs = (BSYNC()) malloc(sizeof(struct BSYNC(_s)));
     fs->n = _n;

--- a/src/framing/src/detector_cccf.c
+++ b/src/framing/src/detector_cccf.c
@@ -106,10 +106,10 @@ struct detector_cccf_s {
 //  _n          :   sequence length
 //  _threshold  :   detection threshold (default: 0.7)
 //  _dphi_max   :   maximum carrier offset
-detector_cccf detector_cccf_create(float complex * _s,
-                                   unsigned int    _n,
-                                   float           _threshold,
-                                   float           _dphi_max)
+detector_cccf detector_cccf_create(const float complex * _s,
+                                   unsigned int          _n,
+                                   float                 _threshold,
+                                   float                 _dphi_max)
 {
     // validate input
     if (_n == 0)

--- a/src/framing/src/dsssframe64sync.c
+++ b/src/framing/src/dsssframe64sync.c
@@ -226,9 +226,9 @@ int dsssframe64sync_set_context(dsssframe64sync _q,
 //  _q       : frame synchronizer object
 //  _buf     : input sample array, shape: (_buf_len,)
 //  _buf_len : number of input samples
-int dsssframe64sync_execute(dsssframe64sync _q,
-                            float complex * _buf,
-                            unsigned int    _buf_len)
+int dsssframe64sync_execute(dsssframe64sync       _q,
+                            const float complex * _buf,
+                            unsigned int          _buf_len)
 {
     // run detector/synchronizer, invoking internal callback as needed
     return qdsync_cccf_execute(_q->detector, _buf, _buf_len);
@@ -366,4 +366,3 @@ int dsssframe64sync_decode(dsssframe64sync _q)
     dsssframe64sync_reset(_q);
     return rc;
 }
-

--- a/src/framing/src/dsssframesync.c
+++ b/src/framing/src/dsssframesync.c
@@ -264,7 +264,7 @@ int dsssframesync_set_header_props(dsssframesync _q, dsssframegenprops_s * _prop
     return dsssframesync_set_header_len(_q, _q->header_user_len);
 }
 
-int dsssframesync_execute(dsssframesync _q, float complex * _x, unsigned int _n)
+int dsssframesync_execute(dsssframesync _q, const float complex * _x, unsigned int _n)
 {
     unsigned int i;
     for (i = 0; i < _n; i++) {

--- a/src/framing/src/framegen64.c
+++ b/src/framing/src/framegen64.c
@@ -145,10 +145,10 @@ int framegen64_print(framegen64 _q)
 //  _header     :   8-byte header data, NULL for random
 //  _payload    :   64-byte payload data, NULL for random
 //  _frame      :   output frame samples [size: LIQUID_FRAME64_LEN x 1]
-int framegen64_execute(framegen64      _q,
-                       unsigned char * _header,
-                       unsigned char * _payload,
-                       float complex * _frame)
+int framegen64_execute(framegen64             _q,
+                       const unsigned char *  _header,
+                       const unsigned char *  _payload,
+                       liquid_float_complex * _frame)
 {
     unsigned int i;
 

--- a/src/framing/src/fskframegen.c
+++ b/src/framing/src/fskframegen.c
@@ -34,7 +34,7 @@
 #define DEBUG_FSKFRAMEGEN    0
 
 // fskframegen
-int fskframegen_encode_header    (fskframegen _q, unsigned char * _header);
+int fskframegen_encode_header    (fskframegen _q, const unsigned char * _header);
 int fskframegen_generate_symbol  (fskframegen _q);
 int fskframegen_generate_zeros   (fskframegen _q);
 int fskframegen_generate_preamble(fskframegen _q);
@@ -282,13 +282,13 @@ int fskframegen_print(fskframegen _q)
 //  _check          :   data validity check
 //  _fec0           :   inner forward error correction
 //  _fec1           :   outer forward error correction
-int fskframegen_assemble(fskframegen     _q,
-                         unsigned char * _header,
-                         unsigned char * _payload,
-                         unsigned int    _payload_len,
-                         crc_scheme      _check,
-                         fec_scheme      _fec0,
-                         fec_scheme      _fec1)
+int fskframegen_assemble(fskframegen           _q,
+                         const unsigned char * _header,
+                         const unsigned char * _payload,
+                         unsigned int          _payload_len,
+                         crc_scheme            _check,
+                         fec_scheme            _fec0,
+                         fec_scheme            _fec1)
 {
 #if 1
     liquid_error(LIQUID_ENOIMP,"fskframegen_assemble(), base functionality not implemented; ignoring input parameters for now");
@@ -376,8 +376,8 @@ int fskframegen_write_samples(fskframegen     _q,
 // internal methods
 //
 
-int fskframegen_encode_header(fskframegen     _q,
-                               unsigned char * _header)
+int fskframegen_encode_header(fskframegen            _q,
+                               const unsigned char * _header)
 {
     // first 8 bytes user data
     memmove(_q->header_dec, _header, 8);

--- a/src/framing/src/ofdmflexframesync.c
+++ b/src/framing/src/ofdmflexframesync.c
@@ -39,10 +39,10 @@
 //
 
 // internal callback
-int ofdmflexframesync_internal_callback(float complex * _X,
-                                        unsigned char * _p,
-                                        unsigned int    _M,
-                                        void * _userdata);
+int ofdmflexframesync_internal_callback(float complex *       _X,
+                                        const unsigned char * _p,
+                                        unsigned int          _M,
+                                        void *                _userdata);
 
 // receive header data
 int ofdmflexframesync_rxheader(ofdmflexframesync _q,
@@ -441,10 +441,10 @@ int ofdmflexframesync_debug_print(ofdmflexframesync _q,
 //  _p          :   subcarrier allocation
 //  _M          :   number of subcarriers
 //  _userdata   :   user-defined data structure
-int ofdmflexframesync_internal_callback(float complex * _X,
-                                        unsigned char * _p,
-                                        unsigned int    _M,
-                                        void *          _userdata)
+int ofdmflexframesync_internal_callback(float complex *       _X,
+                                        const unsigned char * _p,
+                                        unsigned int          _M,
+                                        void *                _userdata)
 {
 #if DEBUG_OFDMFLEXFRAMESYNC
     printf("******* ofdmflexframesync callback invoked!\n");

--- a/src/framing/src/presync.proto.c
+++ b/src/framing/src/presync.proto.c
@@ -62,7 +62,7 @@ int PRESYNC(_correlate)(PRESYNC()       _q,
 /*  _n          :   baseband sequence length                */
 /*  _dphi_max   :   maximum absolute frequency deviation    */
 /*  _m          :   number of correlators                   */
-PRESYNC() PRESYNC(_create)(TC *         _v,
+PRESYNC() PRESYNC(_create)(const TC *   _v,
                            unsigned int _n,
                            float        _dphi_max,
                            unsigned int _m)

--- a/src/framing/src/qdetector.proto.c
+++ b/src/framing/src/qdetector.proto.c
@@ -81,7 +81,7 @@ struct QDETECTOR(_s) {
 // create detector with generic sequence
 //  _s      :   sample sequence
 //  _s_len  :   length of sample sequence
-QDETECTOR() QDETECTOR(_create)(TI *         _s,
+QDETECTOR() QDETECTOR(_create)(const TI *   _s,
                                unsigned int _s_len)
 {
     // validate input
@@ -140,7 +140,7 @@ QDETECTOR() QDETECTOR(_create)(TI *         _s,
 //  _k              :   samples/symbol
 //  _m              :   filter delay
 //  _beta           :   excess bandwidth factor
-QDETECTOR() QDETECTOR(_create_linear)(TI *         _sequence,
+QDETECTOR() QDETECTOR(_create_linear)(const TI *   _sequence,
                                       unsigned int _sequence_len,
                                       int          _ftype,
                                       unsigned int _k,
@@ -182,11 +182,11 @@ QDETECTOR() QDETECTOR(_create_linear)(TI *         _sequence,
 //  _k              :   samples/symbol
 //  _m              :   filter delay
 //  _beta           :   excess bandwidth factor
-QDETECTOR() QDETECTOR(_create_gmsk)(unsigned char * _sequence,
-                                    unsigned int    _sequence_len,
-                                    unsigned int    _k,
-                                    unsigned int    _m,
-                                    float           _beta)
+QDETECTOR() QDETECTOR(_create_gmsk)(const unsigned char * _sequence,
+                                    unsigned int          _sequence_len,
+                                    unsigned int          _k,
+                                    unsigned int          _m,
+                                    float                 _beta)
 {
     // validate input
     if (_sequence_len == 0)
@@ -226,14 +226,14 @@ QDETECTOR() QDETECTOR(_create_gmsk)(unsigned char * _sequence,
 //  _m              :   filter delay
 //  _beta           :   filter bandwidth parameter, _beta > 0
 //  _type           :   filter type (e.g. LIQUID_CPFSK_SQUARE)
-QDETECTOR() QDETECTOR(_create_cpfsk)(unsigned char * _sequence,
-                                     unsigned int    _sequence_len,
-                                     unsigned int    _bps,
-                                     float           _h,
-                                     unsigned int    _k,
-                                     unsigned int    _m,
-                                     float           _beta,
-                                     int             _type)
+QDETECTOR() QDETECTOR(_create_cpfsk)(const unsigned char * _sequence,
+                                     unsigned int          _sequence_len,
+                                     unsigned int          _bps,
+                                     float                 _h,
+                                     unsigned int          _k,
+                                     unsigned int          _m,
+                                     float                 _beta,
+                                     int                   _type)
 {
     // validate input
     if (_sequence_len == 0)

--- a/src/framing/src/qdsync.proto.c
+++ b/src/framing/src/qdsync.proto.c
@@ -78,7 +78,7 @@ struct QDSYNC(_s) {
 };
 
 // create detector with generic sequence
-QDSYNC() QDSYNC(_create_linear)(TI *              _seq,
+QDSYNC() QDSYNC(_create_linear)(const TI *        _seq,
                                 unsigned int      _seq_len,
                                 int               _ftype,
                                 unsigned int      _k,
@@ -268,7 +268,7 @@ int QDSYNC(_set_buf_len)(QDSYNC() _q, unsigned int _buf_len)
 
 // execute synchronizer on a block of samples
 int QDSYNC(_execute)(QDSYNC()     _q,
-                     TI *         _buf,
+                     const TI *   _buf,
                      unsigned int _buf_len)
 {
     unsigned int i;

--- a/src/framing/src/qpilotgen.c
+++ b/src/framing/src/qpilotgen.c
@@ -158,9 +158,9 @@ unsigned int qpilotgen_get_frame_len(qpilotgen _q)
 // encode packet into modulated frame samples
 // TODO: include method with just symbol indices? would be useful for
 //       non-linear modulation types
-int qpilotgen_execute(qpilotgen       _q,
-                      float complex * _payload,
-                      float complex * _frame)
+int qpilotgen_execute(qpilotgen                    _q,
+                      const liquid_float_complex * _payload,
+                      liquid_float_complex *       _frame)
 {
     unsigned int i;
     unsigned int n = 0;

--- a/src/framing/tests/bpacketsync_autotest.c
+++ b/src/framing/tests/bpacketsync_autotest.c
@@ -25,11 +25,11 @@
 #include "autotest/autotest.h"
 #include "liquid.h"
 
-static int bpacketsync_autotest_callback(unsigned char *  _payload,
-                                         int              _payload_valid,
-                                         unsigned int     _payload_len,
-                                         framesyncstats_s _stats,
-                                         void *           _userdata)
+static int bpacketsync_autotest_callback(const unsigned char *  _payload,
+                                         int                    _payload_valid,
+                                         unsigned int           _payload_len,
+                                         framesyncstats_s       _stats,
+                                         void *                 _userdata)
 {
     if (!_payload_valid)
         return 0;

--- a/src/framing/tests/framesync64_autotest.c
+++ b/src/framing/tests/framesync64_autotest.c
@@ -168,13 +168,13 @@ void autotest_framesync64_config()
 }
 
 static int callback_framesync64_autotest_debug(
-    unsigned char *  _header,
-    int              _header_valid,
-    unsigned char *  _payload,
-    unsigned int     _payload_len,
-    int              _payload_valid,
-    framesyncstats_s _stats,
-    void *           _userdata)
+    const unsigned char *  _header,
+    int                    _header_valid,
+    const unsigned char *  _payload,
+    unsigned int           _payload_len,
+    int                    _payload_valid,
+    framesyncstats_s       _stats,
+    void *                 _userdata)
 {
     // return custom code based on user context
     return *((int*)_userdata);
@@ -255,13 +255,13 @@ void autotest_framesync64_debug_rand() { testbench_framesync64_debug(-3); }
 
 
 static int callback_framesync64_autotest_estimation(
-    unsigned char *  _header,
-    int              _header_valid,
-    unsigned char *  _payload,
-    unsigned int     _payload_len,
-    int              _payload_valid,
-    framesyncstats_s _stats,
-    void *           _userdata)
+    const unsigned char *  _header,
+    int                    _header_valid,
+    const unsigned char *  _payload,
+    unsigned int           _payload_len,
+    int                    _payload_valid,
+    framesyncstats_s       _stats,
+    void *                 _userdata)
 {
     //printf("callback invoked, payload valid: %s\n", _payload_valid ? "yes" : "no");
     memmove(_userdata, &_stats, sizeof(framesyncstats_s));

--- a/src/math/src/poly.c
+++ b/src/math/src/poly.c
@@ -48,7 +48,7 @@
 //  _p      :   polynomial array, ascending powers [size: _k x 1]
 //  _k      :   polynomials length (poly order = _k - 1)
 //  _roots  :   resulting complex roots [size: _k-1 x 1]
-int poly_findroots(double *         _p,
+int poly_findroots(const double *   _p,
                    unsigned int     _k,
                    double complex * _roots)
 {

--- a/src/math/src/poly.common.proto.c
+++ b/src/math/src/poly.common.proto.c
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <math.h>
 
-T POLY(_val)(T * _p, unsigned int _k, T _x)
+T POLY(_val)(const T * _p, unsigned int _k, T _x)
 {
     unsigned int i;
     T xk = 1;
@@ -43,8 +43,8 @@ T POLY(_val)(T * _p, unsigned int _k, T _x)
     return y;
 }
 
-int POLY(_fit)(T *          _x,
-               T *          _y,
+int POLY(_fit)(const T *    _x,
+               const T *    _y,
                unsigned int _n,
                T *          _p,
                unsigned int _k)

--- a/src/math/src/poly.expand.proto.c
+++ b/src/math/src/poly.expand.proto.c
@@ -147,7 +147,7 @@ int POLY(_expandbinomial)(T *          _a,
 //  _r      : roots of polynomial [size: _n x 1]
 //  _n      : number of roots in polynomial
 //  _p      : polynomial coefficients [size: _n+1 x 1]
-int POLY(_expandroots)(T *          _r,
+int POLY(_expandroots)(const T *    _r,
                        unsigned int _n,
                        T *          _p)
 {
@@ -183,8 +183,8 @@ int POLY(_expandroots)(T *          _r,
 //  _b      : multiplicant of polynomial roots [size: _n x 1]
 //  _n      : number of roots in polynomial
 //  _p      : polynomial coefficients [size: _n+1 x 1]
-int POLY(_expandroots2)(T *          _a,
-                        T *          _b,
+int POLY(_expandroots2)(const T *    _a,
+                        const T *    _b,
                         unsigned int _n,
                         T *          _p)
 {
@@ -221,9 +221,9 @@ int POLY(_expandroots2)(T *          _a,
 //  _b          :   2nd polynomial coefficients (length is _order_b+1)
 //  _order_b    :   2nd polynomial order
 //  _c          :   output polynomial coefficients (length is _order_a + _order_b + 1)
-int POLY(_mul)(T *          _a,
+int POLY(_mul)(const T *    _a,
                unsigned int _order_a,
-               T *          _b,
+               const T *    _b,
                unsigned int _order_b,
                T *          _c)
 {

--- a/src/math/src/poly.findroots.c
+++ b/src/math/src/poly.findroots.c
@@ -38,7 +38,7 @@
 //  _p      :   polynomial array, ascending powers [size: _k x 1]
 //  _k      :   polynomials length (poly order = _k - 1)
 //  _roots  :   resulting complex roots [size: _k-1 x 1]
-int liquid_poly_findroots_durandkerner(double *         _p,
+int liquid_poly_findroots_durandkerner(const double *   _p,
                                        unsigned int     _k,
                                        double complex * _roots)
 {
@@ -120,7 +120,7 @@ int liquid_poly_findroots_durandkerner(double *         _p,
 //  _p      :   polynomial array, ascending powers [size: _k x 1]
 //  _k      :   polynomials length (poly order = _k - 1)
 //  _roots  :   resulting complex roots [size: _k-1 x 1]
-int liquid_poly_findroots_bairstow(double *         _p,
+int liquid_poly_findroots_bairstow(const double *   _p,
                                    unsigned int     _k,
                                    double complex * _roots)
 {

--- a/src/math/src/poly.lagrange.proto.c
+++ b/src/math/src/poly.lagrange.proto.c
@@ -28,8 +28,8 @@
 #include <string.h>
 
 // Lagrange polynomial exact fit (order _n-1)
-int POLY(_fit_lagrange)(T *          _x,
-                        T *          _y,
+int POLY(_fit_lagrange)(const T *    _x,
+                        const T *    _y,
                         unsigned int _n,
                         T *          _p)
 {
@@ -80,8 +80,8 @@ int POLY(_fit_lagrange)(T *          _x,
 }
 
 // Lagrange polynomial interpolation
-T POLY(_interp_lagrange)(T * _x,
-                         T * _y,
+T POLY(_interp_lagrange)(const T * _x,
+                         const T * _y,
                          unsigned int _n,
                          T   _x0)
 {
@@ -101,7 +101,7 @@ T POLY(_interp_lagrange)(T * _x,
     return y0;
 }
 // Lagrange polynomial fit (barycentric form)
-int POLY(_fit_lagrange_barycentric)(T *         _x,
+int POLY(_fit_lagrange_barycentric)(const T *   _x,
                                    unsigned int _n,
                                    T *          _w)
 {
@@ -126,9 +126,9 @@ int POLY(_fit_lagrange_barycentric)(T *         _x,
 }
 
 // Lagrange polynomial interpolation (barycentric form)
-T POLY(_val_lagrange_barycentric)(T *          _x,
-                                  T *          _y,
-                                  T *          _w,
+T POLY(_val_lagrange_barycentric)(const T *    _x,
+                                  const T *    _y,
+                                  const T *    _w,
                                   T            _x0,
                                   unsigned int _n)
 {

--- a/src/math/src/polyc.c
+++ b/src/math/src/polyc.c
@@ -48,9 +48,9 @@
 //  _p      :   polynomial array, ascending powers [size: _k x 1]
 //  _k      :   polynomials length (poly order = _k - 1)
 //  _roots  :   resulting complex roots [size: _k-1 x 1]
-int polyc_findroots(double complex * _p,
-                    unsigned int     _k,
-                    double complex * _roots)
+int polyc_findroots(const double complex * _p,
+                    unsigned int           _k,
+                    double complex *       _roots)
 {
     return liquid_error(LIQUID_ENOIMP,"polyc_findroots(), complex root-finding not yet supported");
 }

--- a/src/math/src/polycf.c
+++ b/src/math/src/polycf.c
@@ -48,9 +48,9 @@
 //  _p      :   polynomial array, ascending powers [size: _k x 1]
 //  _k      :   polynomials length (poly order = _k - 1)
 //  _roots  :   resulting complex roots [size: _k-1 x 1]
-int polycf_findroots(float complex * _p,
-                     unsigned int    _k,
-                     float complex * _roots)
+int polycf_findroots(const float complex * _p,
+                     unsigned int          _k,
+                     float complex *       _roots)
 {
     return liquid_error(LIQUID_ENOIMP,"polycf_findroots(), complex root-finding not yet supported");
 }

--- a/src/math/src/polyf.c
+++ b/src/math/src/polyf.c
@@ -48,7 +48,7 @@
 //  _p      :   polynomial array, ascending powers [size: _k x 1]
 //  _k      :   polynomials length (poly order = _k - 1)
 //  _roots  :   resulting complex roots [size: _k-1 x 1]
-int polyf_findroots(float *         _p,
+int polyf_findroots(const float *   _p,
                     unsigned int    _k,
                     float complex * _roots)
 {

--- a/src/matrix/src/matrix.base.proto.c
+++ b/src/matrix/src/matrix.base.proto.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int MATRIX(_print)(T *          _X,
+int MATRIX(_print)(const T *    _X,
                    unsigned int _R,
                    unsigned int _C)
 {

--- a/src/matrix/src/matrix.cgsolve.proto.c
+++ b/src/matrix/src/matrix.cgsolve.proto.c
@@ -42,9 +42,9 @@
 //  _b      :   equality [size: _n x 1]
 //  _x      :   solution estimate [size: _n x 1]
 //  _opts   :   options (ignored for now)
-int MATRIX(_cgsolve)(T *          _A,
+int MATRIX(_cgsolve)(const T *    _A,
                      unsigned int _n,
-                     T *          _b,
+                     const T *    _b,
                      T *          _x,
                      void *       _opts)
 {

--- a/src/matrix/src/matrix.chol.proto.c
+++ b/src/matrix/src/matrix.chol.proto.c
@@ -34,7 +34,7 @@
 //  _a      :   input square matrix [size: _n x _n]
 //  _n      :   input matrix dimension
 //  _l      :   output lower-triangular matrix
-int MATRIX(_chol)(T *          _a,
+int MATRIX(_chol)(const T *    _a,
                   unsigned int _n,
                   T *          _l)
 {

--- a/src/matrix/src/matrix.gramschmidt.proto.c
+++ b/src/matrix/src/matrix.gramschmidt.proto.c
@@ -52,7 +52,7 @@ int MATRIX(_proj)(T *          _u,
 }
 
 // Orthnormalization using the Gram-Schmidt algorithm
-int MATRIX(_gramschmidt)(T *          _x,
+int MATRIX(_gramschmidt)(const T *    _x,
                          unsigned int _rx,
                          unsigned int _cx,
                          T *          _v)

--- a/src/matrix/src/matrix.linsolve.proto.c
+++ b/src/matrix/src/matrix.linsolve.proto.c
@@ -34,9 +34,9 @@
 //  _b      :   equality vector [size: _n x 1]
 //  _x      :   solution vector [size: _n x 1]
 //  _opts   :   options (ignored for now)
-int MATRIX(_linsolve)(T *          _A,
+int MATRIX(_linsolve)(const T *    _A,
                       unsigned int _n,
-                      T *          _b,
+                      const T *    _b,
                       T *          _x,
                       void *       _opts)
 {

--- a/src/matrix/src/matrix.ludecomp.proto.c
+++ b/src/matrix/src/matrix.ludecomp.proto.c
@@ -27,7 +27,7 @@
 #include "liquid.internal.h"
 
 // L/U/P decomposition, Crout's method
-int MATRIX(_ludecomp_crout)(T *          _x,
+int MATRIX(_ludecomp_crout)(const T *    _x,
                             unsigned int _rx,
                             unsigned int _cx,
                             T *          _l,
@@ -82,7 +82,7 @@ int MATRIX(_ludecomp_crout)(T *          _x,
 }
 
 // L/U/P decomposition, Doolittle's method
-int MATRIX(_ludecomp_doolittle)(T *          _x,
+int MATRIX(_ludecomp_doolittle)(const T *    _x,
                                 unsigned int _rx,
                                 unsigned int _cx,
                                 T *          _l,

--- a/src/matrix/src/matrix.math.proto.c
+++ b/src/matrix/src/matrix.math.proto.c
@@ -34,8 +34,8 @@
 //  _Z      :   output matrix [size: _R x _C]
 //  _R      :   number of rows
 //  _C      :   number of columns
-int MATRIX(_add)(T *          _X,
-                 T *          _Y,
+int MATRIX(_add)(const T *    _X,
+                 const T *    _Y,
                  T *          _Z,
                  unsigned int _R,
                  unsigned int _C)
@@ -52,8 +52,8 @@ int MATRIX(_add)(T *          _X,
 //  _Z      :   output matrix [size: _R x _C]
 //  _R      :   number of rows
 //  _C      :   number of columns
-int MATRIX(_sub)(T *          _X,
-                 T *          _Y,
+int MATRIX(_sub)(const T *    _X,
+                 const T *    _Y,
                  T *          _Z,
                  unsigned int _R,
                  unsigned int _C)
@@ -70,8 +70,8 @@ int MATRIX(_sub)(T *          _X,
 //  _Z      :   output matrix [size: _R x _C]
 //  _R      :   number of rows
 //  _C      :   number of columns
-int MATRIX(_pmul)(T *          _X,
-                  T *          _Y,
+int MATRIX(_pmul)(const T *    _X,
+                  const T *    _Y,
                   T *          _Z,
                   unsigned int _R,
                   unsigned int _C)
@@ -88,8 +88,8 @@ int MATRIX(_pmul)(T *          _X,
 //  _Z      :   output matrix [size: _R x _C]
 //  _R      :   number of rows
 //  _C      :   number of columns
-int MATRIX(_pdiv)(T *          _X,
-                  T *          _Y,
+int MATRIX(_pdiv)(const T *    _X,
+                  const T *    _Y,
                   T *          _Z,
                   unsigned int _R,
                   unsigned int _C)
@@ -102,8 +102,8 @@ int MATRIX(_pdiv)(T *          _X,
 
 
 // multiply two matrices together
-int MATRIX(_mul)(T * _X, unsigned int _XR, unsigned int _XC,
-                 T * _Y, unsigned int _YR, unsigned int _YC,
+int MATRIX(_mul)(const T * _X, unsigned int _XR, unsigned int _XC,
+                 const T * _Y, unsigned int _YR, unsigned int _YC,
                  T * _Z, unsigned int _ZR, unsigned int _ZC)
 {
     // ensure lengths are valid
@@ -132,8 +132,8 @@ int MATRIX(_mul)(T * _X, unsigned int _XR, unsigned int _XC,
 
 // augment matrices x and y:
 //  z = [x | y]
-int MATRIX(_aug)(T * _x, unsigned int _rx, unsigned int _cx,
-                 T * _y, unsigned int _ry, unsigned int _cy,
+int MATRIX(_aug)(const T * _x, unsigned int _rx, unsigned int _cx,
+                 const T * _y, unsigned int _ry, unsigned int _cy,
                  T * _z, unsigned int _rz, unsigned int _cz)
 {
     // ensure lengths are valid
@@ -153,8 +153,8 @@ int MATRIX(_aug)(T * _x, unsigned int _rx, unsigned int _cx,
 }
 
 // solve set of linear equations
-int MATRIX(_div)(T *          _X,
-                 T *          _Y,
+int MATRIX(_div)(const T *    _X,
+                 const T *    _Y,
                  T *          _Z,
                  unsigned int _n)
 {
@@ -171,7 +171,7 @@ int MATRIX(_div)(T *          _X,
 }
 
 // matrix determinant (2 x 2)
-T MATRIX(_det2x2)(T *          _X,
+T MATRIX(_det2x2)(const T *    _X,
                   unsigned int _r,
                   unsigned int _c)
 {
@@ -183,7 +183,7 @@ T MATRIX(_det2x2)(T *          _X,
 }
 
 // matrix determinant (n x n)
-T MATRIX(_det)(T *          _X,
+T MATRIX(_det)(const T *    _X,
                unsigned int _r,
                unsigned int _c)
 {
@@ -242,7 +242,7 @@ int MATRIX(_hermitian)(T *          _X,
 }
 
 // compute x*x' on m x n matrix, result: m x m
-int MATRIX(_mul_transpose)(T *          _x,
+int MATRIX(_mul_transpose)(const T *    _x,
                            unsigned int _m,
                            unsigned int _n,
                            T *          _xxT)
@@ -276,7 +276,7 @@ int MATRIX(_mul_transpose)(T *          _x,
 
 
 // compute x'*x on m x n matrix, result: n x n
-int MATRIX(_transpose_mul)(T *          _x,
+int MATRIX(_transpose_mul)(const T *    _x,
                            unsigned int _m,
                            unsigned int _n,
                            T *          _xTx)
@@ -310,7 +310,7 @@ int MATRIX(_transpose_mul)(T *          _x,
 
 
 // compute x*x.' on m x n matrix, result: m x m
-int MATRIX(_mul_hermitian)(T *          _x,
+int MATRIX(_mul_hermitian)(const T *    _x,
                            unsigned int _m,
                            unsigned int _n,
                            T *          _xxH)
@@ -343,7 +343,7 @@ int MATRIX(_mul_hermitian)(T *          _x,
 
 
 // compute x.'*x on m x n matrix, result: n x n
-int MATRIX(_hermitian_mul)(T *          _x,
+int MATRIX(_hermitian_mul)(const T *    _x,
                            unsigned int _m,
                            unsigned int _n,
                            T *          _xHx)

--- a/src/matrix/src/matrix.qrdecomp.proto.c
+++ b/src/matrix/src/matrix.qrdecomp.proto.c
@@ -30,7 +30,7 @@
 #define DEBUG_MATRIX_QRDECOMP 1
 
 // Q/R decomposition using the Gram-Schmidt algorithm
-int MATRIX(_qrdecomp_gramschmidt)(T *          _x,
+int MATRIX(_qrdecomp_gramschmidt)(const T *    _x,
                                   unsigned int _m,
                                   unsigned int _n,
                                   T *          _q,

--- a/src/matrix/src/smatrix.proto.c
+++ b/src/matrix/src/smatrix.proto.c
@@ -112,7 +112,7 @@ SMATRIX() SMATRIX(_create)(unsigned int _m,
 }
 
 // create _m x _n matrix, initialized on array
-SMATRIX() SMATRIX(_create_array)(T *          _v,
+SMATRIX() SMATRIX(_create_array)(const T *    _v,
                                  unsigned int _m,
                                  unsigned int _n)
 {
@@ -548,8 +548,8 @@ int SMATRIX(_mul)(SMATRIX() _a,
 //  _q  :   sparse matrix
 //  _x  :   input vector [size: _n x 1]
 //  _y  :   output vector [size: _m x 1]
-int SMATRIX(_vmul)(SMATRIX() _q,
-                   T *       _x,
+int SMATRIX(_vmul)(SMATRIX()  _q,
+                   const T * _x,
                    T *       _y)
 {
     unsigned int i;

--- a/src/matrix/src/smatrixb.c
+++ b/src/matrix/src/smatrixb.c
@@ -57,7 +57,7 @@
 //  _x  :   input vector  [size:  mx  x  nx ]
 //  _y  :   output vector [size:  my  x  ny ]
 int smatrixb_mulf(smatrixb     _A,
-                  float *      _x,
+                  const float * _x,
                   unsigned int _mx,
                   unsigned int _nx,
                   float *      _y,
@@ -93,9 +93,9 @@ int smatrixb_mulf(smatrixb     _A,
 //  _q  :   sparse matrix
 //  _x  :   input vector [size: _N x 1]
 //  _y  :   output vector [size: _M x 1]
-int smatrixb_vmulf(smatrixb _q,
-                   float *  _x,
-                   float *  _y)
+int smatrixb_vmulf(smatrixb     _q,
+                   const float * _x,
+                   float *      _y)
 {
     unsigned int i;
     unsigned int j;

--- a/src/modem/src/ampmodem.c
+++ b/src/modem/src/ampmodem.c
@@ -218,7 +218,7 @@ int ampmodem_modulate(ampmodem        _q,
 //  _n      :   number of input, output samples
 //  _s      :   complex baseband signal s(t) [size: _n x 1]
 int ampmodem_modulate_block(ampmodem        _q,
-                            float *         _m,
+                            const float *   _m,
                             unsigned int    _n,
                             float complex * _s)
 {
@@ -243,10 +243,10 @@ int ampmodem_demodulate(ampmodem      _q,
 //  _y      :   received signal r(t) [size: _n x 1]
 //  _n      :   number of input, output samples
 //  _x      :   message signal m(t), [size: _n x 1]
-int ampmodem_demodulate_block(ampmodem        _q,
-                              float complex * _y,
-                              unsigned int    _n,
-                              float *         _x)
+int ampmodem_demodulate_block(ampmodem              _q,
+                              const float complex * _y,
+                              unsigned int          _n,
+                              float *               _x)
 {
     unsigned int i;
     int rc;

--- a/src/modem/src/cpfskdem.proto.c
+++ b/src/modem/src/cpfskdem.proto.c
@@ -37,10 +37,10 @@ int CPFSKDEM(_init_coherent)(CPFSKDEM() _q);
 int CPFSKDEM(_init_noncoherent)(CPFSKDEM() _q);
 
 // demodulate array of samples (coherent)
-unsigned int CPFSKDEM(_demodulate_coherent)(CPFSKDEM() _q, TC * _y);
+unsigned int CPFSKDEM(_demodulate_coherent)(CPFSKDEM() _q, const TC * _y);
 
 // demodulate array of samples (non-coherent)
-unsigned int CPFSKDEM(_demodulate_noncoherent)(CPFSKDEM() _q, TC * _y);
+unsigned int CPFSKDEM(_demodulate_noncoherent)(CPFSKDEM() _q, const TC * _y);
 
 // cpfskdem
 struct CPFSKDEM(_s) {
@@ -67,7 +67,7 @@ struct CPFSKDEM(_s) {
                        unsigned int * _s,
                        unsigned int * _nw);
 #else
-    unsigned int (*demodulate)(CPFSKDEM() _q, TC * _y);
+    unsigned int (*demodulate)(CPFSKDEM() _q, const TC * _y);
 #endif
 
     // common data structure shared between coherent and non-coherent
@@ -458,14 +458,14 @@ int CPFSKDEM(_demodulate_noncoherent)(CPFSKDEM()        _q,
 //  _q      :   continuous-phase frequency demodulator object
 //  _y      :   input sample array [size: _k x 1]
 unsigned int CPFSKDEM(_demodulate)(CPFSKDEM() _q,
-                                   TC *       _y)
+                                   const TC * _y)
 {
     return _q->demodulate(_q, _y);
 }
 
 // demodulate array of samples (coherent)
 unsigned int CPFSKDEM(_demodulate_coherent)(CPFSKDEM() _q,
-                                            TC *       _y)
+                                            const TC * _y)
 {
     liquid_error(LIQUID_EINT,"cpfskdem_demodulate_coherent(), coherent mode not supported");
     return 0;
@@ -473,7 +473,7 @@ unsigned int CPFSKDEM(_demodulate_coherent)(CPFSKDEM() _q,
 
 // demodulate array of samples (non-coherent)
 unsigned int CPFSKDEM(_demodulate_noncoherent)(CPFSKDEM() _q,
-                                               TC *       _y)
+                                               const TC * _y)
 {
     unsigned int i;
     unsigned int sym_out = 0;

--- a/src/modem/src/freqdem.proto.c
+++ b/src/modem/src/freqdem.proto.c
@@ -108,7 +108,7 @@ int FREQDEM(_demodulate)(FREQDEM() _q,
 //  _n      :   number of input, output samples
 //  _m      :   message signal m(t), [size: _n x 1]
 int FREQDEM(_demodulate_block)(FREQDEM()    _q,
-                               TC *         _r,
+                               const TC *   _r,
                                unsigned int _n,
                                T *          _m)
 {

--- a/src/modem/src/freqmod.proto.c
+++ b/src/modem/src/freqmod.proto.c
@@ -130,7 +130,7 @@ int FREQMOD(_modulate)(FREQMOD()   _q,
 //  _n      :   number of input, output samples
 //  _s      :   complex baseband signal s(t) [size: _n x 1]
 int FREQMOD(_modulate_block)(FREQMOD()    _q,
-                             T *          _m,
+                             const T *    _m,
                              unsigned int _n,
                              TC *         _s)
 {

--- a/src/modem/src/fskdem.c
+++ b/src/modem/src/fskdem.c
@@ -212,8 +212,8 @@ int fskdem_reset(fskdem _q)
 // demodulate symbol, assuming perfect symbol timing
 //  _q      :   fskdem object
 //  _y      :   input sample array [size: _k x 1]
-unsigned int fskdem_demodulate(fskdem          _q,
-                               float complex * _y)
+unsigned int fskdem_demodulate(fskdem                _q,
+                               const float complex * _y)
 {
     // copy input to internal time buffer
     memmove(_q->buf_time, _y, _q->k*sizeof(float complex));

--- a/src/modem/src/modem.shim.c
+++ b/src/modem/src/modem.shim.c
@@ -30,7 +30,7 @@
 modem modem_create(modulation_scheme _scheme)
     { return modemcf_create(_scheme); }
 
-modem modem_create_arbitrary(float complex * _table, unsigned int _M)
+modem modem_create_arbitrary(const float complex * _table, unsigned int _M)
     { return modemcf_create_arbitrary(_table, _M); }
 
 modem modem_recreate(modem _q, modulation_scheme _scheme)

--- a/src/modem/src/modem_arb.proto.c
+++ b/src/modem/src/modem_arb.proto.c
@@ -25,8 +25,8 @@
 //
 
 // create arbitrary digital modem object
-MODEM() MODEM(_create_arbitrary)(float complex * _table,
-                                 unsigned int    _M)
+MODEM() MODEM(_create_arbitrary)(const float complex * _table,
+                                 unsigned int          _M)
 {
     // strip out bits/symbol
     unsigned int m = liquid_nextpow2(_M);
@@ -185,9 +185,9 @@ MODEM() MODEM(_create_arb64vt)()
 //  _mod        :   modem object
 //  _symbol_map :   arbitrary modem symbol map
 //  _len        :   number of symbols in the map
-int MODEM(_arb_init)(MODEM()         _q,
-                     float complex * _symbol_map,
-                     unsigned int    _len)
+int MODEM(_arb_init)(MODEM()               _q,
+                     const float complex * _symbol_map,
+                     unsigned int          _len)
 {
 #ifdef LIQUID_VALIDATE_INPUT
     if (_q->scheme != LIQUID_MODEM_ARB)

--- a/src/modem/src/modem_utilities.c
+++ b/src/modem/src/modem_utilities.c
@@ -273,7 +273,7 @@ unsigned int gray_decode(unsigned int symbol_in)
 //  _soft_bits  :   soft input bits [size: _bps x 1]
 //  _bps        :   bits per symbol
 //  _sym_out    :   output symbol, value in [0,2^_bps)
-int liquid_pack_soft_bits(unsigned char * _soft_bits,
+int liquid_pack_soft_bits(const unsigned char * _soft_bits,
                           unsigned int _bps,
                           unsigned int * _sym_out)
 {

--- a/src/multichannel/src/firpfbch.proto.c
+++ b/src/multichannel/src/firpfbch.proto.c
@@ -69,7 +69,7 @@ int FIRPFBCH(_analyzer_run)(FIRPFBCH()   _q,
 FIRPFBCH() FIRPFBCH(_create)(int          _type,
                              unsigned int _M,
                              unsigned int _p,
-                             TC *         _h)
+                             const TC *   _h)
 {
     // validate input
     if (_type != LIQUID_ANALYZER && _type != LIQUID_SYNTHESIZER)
@@ -278,7 +278,7 @@ int FIRPFBCH(_print)(FIRPFBCH() _q)
 //  _x      :   channelized input, [size: num_channels x 1]
 //  _y      :   output time series, [size: num_channels x 1]
 int FIRPFBCH(_synthesizer_execute)(FIRPFBCH() _q,
-                                   TI *       _x,
+                                   const TI * _x,
                                    TO *       _y)
 {
     unsigned int i;
@@ -311,7 +311,7 @@ int FIRPFBCH(_synthesizer_execute)(FIRPFBCH() _q,
 //  _x      :   input time series, [size: num_channels x 1]
 //  _y      :   channelized output, [size: num_channels x 1]
 int FIRPFBCH(_analyzer_execute)(FIRPFBCH() _q,
-                                TI *       _x,
+                                const TI * _x,
                                 TO *       _y)
 {
     unsigned int i;

--- a/src/multichannel/src/firpfbch2.proto.c
+++ b/src/multichannel/src/firpfbch2.proto.c
@@ -68,7 +68,7 @@ struct FIRPFBCH2(_s) {
 FIRPFBCH2() FIRPFBCH2(_create)(int          _type,
                                unsigned int _M,
                                unsigned int _m,
-                               TC *         _h)
+                               const TC *   _h)
 {
     // validate input
     if (_type != LIQUID_ANALYZER && _type != LIQUID_SYNTHESIZER)
@@ -283,7 +283,7 @@ unsigned int FIRPFBCH2(_get_m)(FIRPFBCH2() _q)
 //  _x      :   channelizer input,  [size: M/2 x 1]
 //  _y      :   channelizer output, [size: M   x 1]
 int FIRPFBCH2(_execute_analyzer)(FIRPFBCH2() _q,
-                                 TI *        _x,
+                                 const TI *  _x,
                                  TO *        _y)
 {
     unsigned int i;
@@ -324,7 +324,7 @@ int FIRPFBCH2(_execute_analyzer)(FIRPFBCH2() _q,
 //  _x      :   channelizer input,  [size: M   x 1]
 //  _y      :   channelizer output, [size: M/2 x 1]
 int FIRPFBCH2(_execute_synthesizer)(FIRPFBCH2() _q,
-                                    TI *        _x,
+                                    const TI *  _x,
                                     TO *        _y)
 {
     unsigned int i;
@@ -380,7 +380,7 @@ int FIRPFBCH2(_execute_synthesizer)(FIRPFBCH2() _q,
 //  _x      :   channelizer input
 //  _y      :   channelizer output
 int FIRPFBCH2(_execute)(FIRPFBCH2() _q,
-                        TI *        _x,
+                        const TI *  _x,
                         TO *        _y)
 {
     switch (_q->type) {

--- a/src/multichannel/src/firpfbchr.proto.c
+++ b/src/multichannel/src/firpfbchr.proto.c
@@ -62,7 +62,7 @@ struct FIRPFBCHR(_s) {
 FIRPFBCHR() FIRPFBCHR(_create)(unsigned int _chans,
                                unsigned int _decim,
                                unsigned int _m,
-                               TC *         _h)
+                               const TC *   _h)
 {
     // validate input
     if (_chans < 2)
@@ -250,7 +250,7 @@ unsigned int FIRPFBCHR(_get_m)(FIRPFBCHR() _q)
 //  _q      : channelizer object
 //  _x      : channelizer input, [size: decim x 1]
 int FIRPFBCHR(_push)(FIRPFBCHR() _q,
-                     TI *        _x)
+                     const TI *  _x)
 {
     // load buffers in blocks of P in the reverse direction
     unsigned int i;

--- a/src/multichannel/src/ofdmframe.common.c
+++ b/src/multichannel/src/ofdmframe.common.c
@@ -269,11 +269,11 @@ int ofdmframe_init_sctype_range(unsigned int    _M,
 //  _M_null     :   output number of null subcarriers
 //  _M_pilot    :   output number of pilot subcarriers
 //  _M_data     :   output number of data subcarriers
-int ofdmframe_validate_sctype(unsigned char * _p,
-                              unsigned int    _M,
-                              unsigned int *  _M_null,
-                              unsigned int *  _M_pilot,
-                              unsigned int *  _M_data)
+int ofdmframe_validate_sctype(const unsigned char * _p,
+                              unsigned int          _M,
+                              unsigned int *        _M_null,
+                              unsigned int *        _M_pilot,
+                              unsigned int *        _M_data)
 {
     // clear counters
     unsigned int M_null  = 0;
@@ -314,8 +314,8 @@ int ofdmframe_validate_sctype(unsigned char * _p,
 // key: '.' (null), 'P' (pilot), '+' (data)
 // .+++P+++++++P.........P+++++++P+++
 //
-int ofdmframe_print_sctype(unsigned char * _p,
-                           unsigned int    _M)
+int ofdmframe_print_sctype(const unsigned char * _p,
+                           unsigned int          _M)
 {
     unsigned int i;
 

--- a/src/multichannel/src/ofdmframegen.c
+++ b/src/multichannel/src/ofdmframegen.c
@@ -82,10 +82,10 @@ struct ofdmframegen_s {
 //  _cp_len     :   cyclic prefix length
 //  _taper_len  :   taper length (OFDM symbol overlap)
 //  _p          :   subcarrier allocation (null, pilot, data), [size: _M x 1]
-ofdmframegen ofdmframegen_create(unsigned int    _M,
-                                 unsigned int    _cp_len,
-                                 unsigned int    _taper_len,
-                                 unsigned char * _p)
+ofdmframegen ofdmframegen_create(unsigned int          _M,
+                                 unsigned int          _cp_len,
+                                 unsigned int          _taper_len,
+                                 const unsigned char * _p)
 {
     // validate input
     if (_M < 8)
@@ -266,9 +266,9 @@ int ofdmframegen_write_S1(ofdmframegen _q,
 //  _q      :   framing generator object
 //  _x      :   input symbols, [size: _M x 1]
 //  _y      :   output samples, [size: _M x 1]
-int ofdmframegen_writesymbol(ofdmframegen    _q,
-                             float complex * _x,
-                             float complex * _y)
+int ofdmframegen_writesymbol(ofdmframegen          _q,
+                             const float complex * _x,
+                             float complex *       _y)
 {
     // move frequency data to internal buffer
     unsigned int i;

--- a/src/multichannel/src/ofdmframesync.c
+++ b/src/multichannel/src/ofdmframesync.c
@@ -180,7 +180,7 @@ struct ofdmframesync_s {
 ofdmframesync ofdmframesync_create(unsigned int           _M,
                                    unsigned int           _cp_len,
                                    unsigned int           _taper_len,
-                                   unsigned char *        _p,
+                                   const unsigned char *  _p,
                                    ofdmframesync_callback _callback,
                                    void *                 _userdata)
 {
@@ -394,9 +394,9 @@ int ofdmframesync_is_frame_open(ofdmframesync _q)
     return (_q->state == OFDMFRAMESYNC_STATE_SEEKPLCP) ? 0 : 1;
 }
 
-int ofdmframesync_execute(ofdmframesync   _q,
-                          float complex * _x,
-                          unsigned int    _n)
+int ofdmframesync_execute(ofdmframesync         _q,
+                          const float complex * _x,
+                          unsigned int          _n)
 {
     unsigned int i;
     float complex x;

--- a/src/multichannel/tests/ofdmframe_autotest.c
+++ b/src/multichannel/tests/ofdmframe_autotest.c
@@ -36,9 +36,9 @@
 //  _p          :   subcarrier allocation
 //  _M          :   number of subcarriers
 //  _userdata   :   user-defined data structure
-int ofdmframesync_autotest_callback(float complex * _X,
-                                    unsigned char * _p,
-                                    unsigned int    _M,
+int ofdmframesync_autotest_callback(float complex *       _X,
+                                    const unsigned char * _p,
+                                    unsigned int          _M,
                                     void * _userdata)
 {
     if (liquid_autotest_verbose)

--- a/src/nco/src/nco.proto.c
+++ b/src/nco/src/nco.proto.c
@@ -616,7 +616,7 @@ int NCO(_mix_down)(NCO() _q,
 //  _y      :   output sample [size: _n x 1]
 //  _n      :   number of input, output samples
 int NCO(_mix_block_up)(NCO()        _q,
-                       TC *         _x,
+                       const TC *   _x,
                        TC *         _y,
                        unsigned int _n)
 {
@@ -655,7 +655,7 @@ int NCO(_mix_block_up)(NCO()        _q,
 //  _y      :   output sample [size: _n x 1]
 //  _n      :   number of input, output samples
 int NCO(_mix_block_down)(NCO()        _q,
-                         TC *         _x,
+                         const TC *   _x,
                          TC *         _y,
                          unsigned int _n)
 {

--- a/src/nco/src/synth.proto.c
+++ b/src/nco/src/synth.proto.c
@@ -202,7 +202,7 @@ void SYNTH(_mix_down)(SYNTH() _q, TC _x, TC * _y)
     *_y = _x * conjf(_q->current);
 }
 
-void SYNTH(_mix_block_up)(SYNTH() _q, TC * _x, TC * _y, unsigned int _n)
+void SYNTH(_mix_block_up)(SYNTH() _q, const TC * _x, TC * _y, unsigned int _n)
 {
     unsigned int i;
     for (i = 0; i < _n; i++) {
@@ -214,7 +214,7 @@ void SYNTH(_mix_block_up)(SYNTH() _q, TC * _x, TC * _y, unsigned int _n)
     }
 }
 
-void SYNTH(_mix_block_down)(SYNTH() _q, TC * _x, TC * _y, unsigned int _n)
+void SYNTH(_mix_block_down)(SYNTH() _q, const TC * _x, TC * _y, unsigned int _n)
 {
     unsigned int i;
     for (i = 0; i < _n; i++) {
@@ -236,7 +236,7 @@ void SYNTH(_spread)(SYNTH() _q, TC _x, TC * _y)
     }
 }
 
-void SYNTH(_despread)(SYNTH() _q, TC * _x, TC * _y)
+void SYNTH(_despread)(SYNTH() _q, const TC * _x, TC * _y)
 {
     TC despread = 0;
     T  sum      = 0;
@@ -253,7 +253,7 @@ void SYNTH(_despread)(SYNTH() _q, TC * _x, TC * _y)
     *_y = despread / sum;
 }
 
-void SYNTH(_despread_triple)(SYNTH() _q, TC * _x, TC * _early, TC * _punctual, TC * _late)
+void SYNTH(_despread_triple)(SYNTH() _q, const TC * _x, TC * _early, TC * _punctual, TC * _late)
 {
     TC despread_early    = 0;
     TC despread_punctual = 0;

--- a/src/optim/src/chromosome.c
+++ b/src/optim/src/chromosome.c
@@ -34,8 +34,8 @@
 // create chromosome with varying bits/trait
 //  _bits_per_trait     :   array of bits/trait [size: _num_traits x 1]
 //  _num_traits         :   number of traits in this chromosome
-chromosome chromosome_create(unsigned int * _bits_per_trait,
-                             unsigned int   _num_traits)
+chromosome chromosome_create(const unsigned int * _bits_per_trait,
+                             unsigned int         _num_traits)
 {
     // validate input
     unsigned int i;
@@ -171,8 +171,8 @@ int chromosome_reset(chromosome _q)
 }
 
 // initialize chromosome on integer values
-int chromosome_init(chromosome     _c,
-                    unsigned int * _v)
+int chromosome_init(chromosome           _c,
+                    const unsigned int * _v)
 {
     unsigned int i;
     for (i=0; i<_c->num_traits; i++) {
@@ -186,8 +186,8 @@ int chromosome_init(chromosome     _c,
 }
 
 // initialize chromosome on floating-point values
-int chromosome_initf(chromosome _c,
-                     float *    _v)
+int chromosome_initf(chromosome    _c,
+                     const float * _v)
 {
     unsigned int i;
     for (i=0; i<_c->num_traits; i++) {

--- a/src/optim/src/utilities.c
+++ b/src/optim/src/utilities.c
@@ -29,9 +29,9 @@
 #include "liquid.internal.h"
 
 // n-dimensional Rosenbrock utility function, minimum at _v = {1,1,1...}
-float liquid_rosenbrock(void *       _userdata,
-                        float *      _v,
-                        unsigned int _n)
+float liquid_rosenbrock(void *        _userdata,
+                        const float * _v,
+                        unsigned int  _n)
 {
     if (_n == 0) {
         liquid_error(LIQUID_EICONFIG,"liquid_rosenbrock(), input vector length cannot be zero");
@@ -52,9 +52,9 @@ float liquid_rosenbrock(void *       _userdata,
 //  _userdata   :   user-defined data structure (convenience)
 //  _v          :   input vector [size: _n x 1]
 //  _n          :   input vector size
-float liquid_invgauss(void *       _userdata,
-                      float *      _v,
-                      unsigned int _n)
+float liquid_invgauss(void *        _userdata,
+                      const float * _v,
+                      unsigned int  _n)
 {
     if (_n == 0) {
         liquid_error(LIQUID_EICONFIG,"liquid_invgauss(), input vector length cannot be zero");
@@ -78,9 +78,9 @@ float liquid_invgauss(void *       _userdata,
 //  _userdata   :   user-defined data structure (convenience)
 //  _v          :   input vector [size: _n x 1]
 //  _n          :   input vector size
-float liquid_multimodal(void *       _userdata,
-                        float *      _v,
-                        unsigned int _n)
+float liquid_multimodal(void *        _userdata,
+                        const float * _v,
+                        unsigned int  _n)
 {
     if (_n == 0) {
         liquid_error(LIQUID_EICONFIG,"liquid_multimodal(), input vector length cannot be zero");
@@ -105,9 +105,9 @@ float liquid_multimodal(void *       _userdata,
 //  _userdata   :   user-defined data structure (convenience)
 //  _v          :   input vector [size: _n x 1]
 //  _n          :   input vector size
-float liquid_spiral(void *       _userdata,
-                    float *      _v,
-                    unsigned int _n)
+float liquid_spiral(void *        _userdata,
+                    const float * _v,
+                    unsigned int  _n)
 {
     if (_n == 0) {
         liquid_error(LIQUID_EICONFIG,"liquid_rosenbrock(), input vector length cannot be zero");

--- a/src/optim/tests/gradsearch_autotest.c
+++ b/src/optim/tests/gradsearch_autotest.c
@@ -90,9 +90,9 @@ void autotest_gradsearch_rosenbrock()
 //
 
 // test utility function
-float utility_max_autotest(void *       _userdata,
-                           float *      _v,
-                           unsigned int _n)
+float utility_max_autotest(void *        _userdata,
+                           const float * _v,
+                           unsigned int  _n)
 {
     if (_n == 0) {
         liquid_error(LIQUID_EICONFIG,"liquid_invgauss(), input vector length cannot be zero");

--- a/src/sequence/src/bsequence.c
+++ b/src/sequence/src/bsequence.c
@@ -93,8 +93,8 @@ int bsequence_reset(bsequence _bs)
 }
 
 // initialize sequence on external array
-int bsequence_init(bsequence       _bs,
-                   unsigned char * _v)
+int bsequence_init(bsequence             _bs,
+                   const unsigned char * _v)
 {
     // push single bit at a time
     unsigned int i;

--- a/src/utility/src/byte_utilities.c
+++ b/src/utility/src/byte_utilities.c
@@ -98,8 +98,8 @@ unsigned int count_bit_errors(unsigned int _s1,
 //  _msg0   :   original message [size: _n x 1]
 //  _msg1   :   copy of original message [size: _n x 1]
 //  _n      :   message size
-unsigned int count_bit_errors_array(unsigned char * _msg0,
-                                    unsigned char * _msg1,
+unsigned int count_bit_errors_array(const unsigned char * _msg0,
+                                    const unsigned char * _msg1,
                                     unsigned int _n)
 {
     unsigned int num_bit_errors = 0;

--- a/src/utility/src/memory.c
+++ b/src/utility/src/memory.c
@@ -28,7 +28,7 @@
 //  _orig   : pointer to original memory array
 //  _num    : number of original elements
 //  _size   : size of each element
-void * liquid_malloc_copy(void *       _orig,
+void * liquid_malloc_copy(const void * _orig,
                           unsigned int _num,
                           unsigned int _size)
 {

--- a/src/utility/src/pack_bytes.c
+++ b/src/utility/src/pack_bytes.c
@@ -111,11 +111,11 @@ int liquid_pack_array(unsigned char * _src,
 //  _k          :   bit index to write in _src
 //  _b          :   number of bits in output symbol
 //  _sym_out    :   output symbol
-int liquid_unpack_array(unsigned char * _src,
-                        unsigned int    _n,
-                        unsigned int    _k,
-                        unsigned int    _b,
-                        unsigned char * _sym_out)
+int liquid_unpack_array(const unsigned char * _src,
+                        unsigned int          _n,
+                        unsigned int          _k,
+                        unsigned int          _b,
+                        unsigned char *       _sym_out)
 {
     // validate input
     if (_k >= 8*_n)
@@ -179,11 +179,11 @@ int liquid_unpack_array(unsigned char * _src,
 //  _sym_out            :   output symbols
 //  _sym_out_len        :   number of bytes allocated to output symbols array
 //  _num_written        :   number of output symbols actually written
-int liquid_pack_bytes(unsigned char * _sym_in,
-                      unsigned int    _sym_in_len,
-                      unsigned char * _sym_out,
-                      unsigned int    _sym_out_len,
-                      unsigned int *  _num_written)
+int liquid_pack_bytes(const unsigned char * _sym_in,
+                      unsigned int          _sym_in_len,
+                      unsigned char *       _sym_out,
+                      unsigned int          _sym_out_len,
+                      unsigned int *        _num_written)
 {
     div_t d = div(_sym_in_len,8);
     unsigned int req__sym_out_len = d.quot;
@@ -221,11 +221,11 @@ int liquid_pack_bytes(unsigned char * _sym_in,
 //  _sym_out            :   output symbols array
 //  _sym_out_len        :   number of bytes allocated to output symbols array
 //  _num_written        :   number of output symbols actually written
-int liquid_unpack_bytes(unsigned char * _sym_in,
-                        unsigned int    _sym_in_len,
-                        unsigned char * _sym_out,
-                        unsigned int    _sym_out_len,
-                        unsigned int *  _num_written)
+int liquid_unpack_bytes(const unsigned char * _sym_in,
+                        unsigned int          _sym_in_len,
+                        unsigned char *       _sym_out,
+                        unsigned int          _sym_out_len,
+                        unsigned int *        _num_written)
 {
     if ( _sym_out_len < 8*_sym_in_len )
         return liquid_error(LIQUID_EIMEM,"unpack_bytes(), output too short");
@@ -261,13 +261,13 @@ int liquid_unpack_bytes(unsigned char * _sym_in,
 //  _sym_out_bps        :   number of bits per output symbol
 //  _sym_out_len        :   number of bytes allocated to output symbols array
 //  _num_written        :   number of output symbols actually written
-int liquid_repack_bytes(unsigned char * _sym_in,
-                        unsigned int    _sym_in_bps,
-                        unsigned int    _sym_in_len,
-                        unsigned char * _sym_out,
-                        unsigned int    _sym_out_bps,
-                        unsigned int    _sym_out_len,
-                        unsigned int *  _num_written)
+int liquid_repack_bytes(const unsigned char * _sym_in,
+                        unsigned int          _sym_in_bps,
+                        unsigned int          _sym_in_len,
+                        unsigned char *       _sym_out,
+                        unsigned int          _sym_out_bps,
+                        unsigned int          _sym_out_len,
+                        unsigned int *        _num_written)
 {
     // compute number of output symbols and determine if output array
     // is sufficiently sized

--- a/src/vector/src/vector_add.proto.c
+++ b/src/vector/src/vector_add.proto.c
@@ -33,8 +33,8 @@
 //  _y      :   second array [size: _n x 1]
 //  _n      :   array lengths
 //  _z      :   output array pointer [size: _n x 1]
-void VECTOR(_add)(T *          _x,
-                  T *          _y,
+void VECTOR(_add)(const T *    _x,
+                  const T *    _y,
                   unsigned int _n,
                   T *          _z)
 {
@@ -60,7 +60,7 @@ void VECTOR(_add)(T *          _x,
 //  _n      :   array length
 //  _v      :   scalar
 //  _y      :   output array pointer [size: _n x 1]
-void VECTOR(_addscalar)(T *          _x,
+void VECTOR(_addscalar)(const T *    _x,
                         unsigned int _n,
                         T            _v,
                         T *          _y)

--- a/src/vector/src/vector_mul.proto.c
+++ b/src/vector/src/vector_mul.proto.c
@@ -33,8 +33,8 @@
 //  _y      :   second array [size: _n x 1]
 //  _n      :   array lengths
 //  _z      :   output array pointer [size: _n x 1]
-void VECTOR(_mul)(T *          _x,
-                  T *          _y,
+void VECTOR(_mul)(const T *    _x,
+                  const T *    _y,
                   unsigned int _n,
                   T *          _z)
 {
@@ -60,7 +60,7 @@ void VECTOR(_mul)(T *          _x,
 //  _n      :   array length
 //  _v      :   scalar
 //  _y      :   output array pointer [size: _n x 1]
-void VECTOR(_mulscalar)(T *          _x,
+void VECTOR(_mulscalar)(const T *    _x,
                         unsigned int _n,
                         T            _v,
                         T *          _y)

--- a/src/vector/src/vector_norm.proto.c
+++ b/src/vector/src/vector_norm.proto.c
@@ -32,7 +32,7 @@
 // compute l2-norm on vector
 //  _x      :   input array [size: _n x 1]
 //  _n      :   array length
-TP VECTOR(_norm)(T *          _x,
+TP VECTOR(_norm)(const T *    _x,
                  unsigned int _n)
 {
     // t = 4*(floor(_n/4))
@@ -65,7 +65,7 @@ TP VECTOR(_norm)(T *          _x,
 //  _x      :   input array [size: _n x 1]
 //  _n      :   array length
 //  _y      :   output array [size: _n x 1]
-void VECTOR(_normalize)(T *          _x,
+void VECTOR(_normalize)(const T *    _x,
                         unsigned int _n,
                         T *          _y)
 {

--- a/src/vector/src/vector_trig.proto.c
+++ b/src/vector/src/vector_trig.proto.c
@@ -34,7 +34,7 @@
 //  _theta  :   input primitive array [size: _n x 1]
 //  _n      :   array length
 //  _x      :   output array pointer [size: _n x 1]
-void VECTOR(_cexpj)(TP *         _theta,
+void VECTOR(_cexpj)(const TP *   _theta,
                     unsigned int _n,
                     T *          _x)
 {
@@ -71,7 +71,7 @@ void VECTOR(_cexpj)(TP *         _theta,
 //  _x      :   input array [size: _n x 1]
 //  _n      :   array length
 //  _theta  :   output primitive array [size: _n x 1]
-void VECTOR(_carg)(T *          _x,
+void VECTOR(_carg)(const T *    _x,
                    unsigned int _n,
                    TP *         _theta)
 {
@@ -108,7 +108,7 @@ void VECTOR(_carg)(T *          _x,
 //  _x      :   input array [size: _n x 1]
 //  _n      :   array length
 //  _y      :   output primitive array pointer [size: _n x 1]
-void VECTOR(_abs)(T *          _x,
+void VECTOR(_abs)(const T *    _x,
                   unsigned int _n,
                   TP *         _y)
 {

--- a/src/vector/src/vector_trig.proto.c
+++ b/src/vector/src/vector_trig.proto.c
@@ -124,10 +124,10 @@ void VECTOR(_abs)(T *          _x,
         _y[i+2] = cabsf(_x[i+2]);
         _y[i+3] = cabsf(_x[i+3]);
 #else
-        _x[i  ] = fabsf(_x[i  ]);
-        _x[i+1] = fabsf(_x[i+1]);
-        _x[i+2] = fabsf(_x[i+2]);
-        _x[i+3] = fabsf(_x[i+3]);
+        _y[i  ] = fabsf(_x[i  ]);
+        _y[i+1] = fabsf(_x[i+1]);
+        _y[i+2] = fabsf(_x[i+2]);
+        _y[i+3] = fabsf(_x[i+3]);
 #endif
     }
 
@@ -136,7 +136,7 @@ void VECTOR(_abs)(T *          _x,
 #if T_COMPLEX
         _y[i] = cabsf(_x[i]);
 #else
-        _x[i] = fabsf(_x[i]);
+        _y[i] = fabsf(_x[i]);
 #endif
     }
 }

--- a/src/vector/src/vectorf_mul.avx.c
+++ b/src/vector/src/vectorf_mul.avx.c
@@ -27,8 +27,8 @@
 #include <stdio.h>
 #include <immintrin.h>
 
-void liquid_vectorf_mul(float *      _v0,
-                        float *      _v1,
+void liquid_vectorf_mul(const float * _v0,
+                        const float * _v1,
                         unsigned int _n,
                         float *      _y)
 {
@@ -60,7 +60,7 @@ void liquid_vectorf_mul(float *      _v0,
 }
 
 // basic vector scalar multiplication, unrolling loop
-void liquid_vectorf_mulscalar(float *      _v,
+void liquid_vectorf_mulscalar(const float * _v,
                               unsigned int _n,
                               float        _s,
                               float *      _y)


### PR DESCRIPTION
As mentioned in the discussion tab, I have spent some time adding const qualifiers to a large portion of the public API to try and cut down on the const_cast in C++ projects that consume this library. I took the following approach:

- Break public API into modules
- For each module:
  - Add const qualifiers to initialization parameters in public API (coefficient arrays)
  - Add const qualifiers to input parameters in public API (input arrays)
  - Compile-and-fix loop to propagate const through the private APIs
  - Run autotests

Known issues:
- I could only compile for my system architecture, some SIMD implementations may have been missed
- I am not sure if cmake supports find-libfec yet, so may have missed the fun algorithms
- Breaking change: The user callback functions used in the framing module now need const qualifiers
- Not implemented for FFT run function as fft plan struct would need to be modified
- Not implemented for MRESAMP2 execute function as input array is used as ping pong buffer

Please let me know if you have any requests or concerns