### PR TITLE
Fix linker error for Windows mingw cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,8 +408,9 @@ if(COVERAGE)
     target_link_options(${LIBNAME} PRIVATE -coverage)
 endif(COVERAGE)
 
-
+if(NOT WIN32)
 target_link_libraries(${LIBNAME} c m)
+endif()
 if (fftw3f_FOUND)
     target_link_libraries(${LIBNAME} fftw3f)
 endif()


### PR DESCRIPTION
Currently, if you attempt to try and cross compile liquid-dsp for Windows from Linux using mingw-w64 it will fail with

```
/usr/bin/x86_64-w64-mingw32-ld: cannot find -lc: No such file or directory
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/liquid.dir/build.make:404: libliquid.dll] Error 1
make[1]: *** [CMakeFiles/Makefile2:1056: CMakeFiles/liquid.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

It appears some cleanup work has been done to make it much easier to cross compile but this remains an issue still. 

This resolves the issue as MinGW provides it's own C runtime and this makes linking towards it conditional. 