### PR TITLE
Bump cmake_minimum_required to reflect usage of newer features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # cmake build file for liquid-dsp
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 # parse version number from include/liquid.h
 include(cmake/version.cmake)


### PR DESCRIPTION
Among other things:

NAMELINK_COMPONENT argument to install() was added in 3.12

DESTINATION was only made optional in install() in 3.13