### PR TITLE
filter/firfilt: fix recreate() storing coefficients in reverse order

### DIFF
--- a/src/filter/src/firfilt.proto.c
+++ b/src/filter/src/firfilt.proto.c
@@ -249,8 +249,6 @@ FIRFILT() FIRFILT(_recreate)(FIRFILT() _q,
                              TC * _h,
                              unsigned int _n)
 {
-    unsigned int i;
-
     // reallocate memory array if filter length has changed
     if (_n != _q->h_len) {
         // reallocate memory
@@ -273,12 +271,11 @@ FIRFILT() FIRFILT(_recreate)(FIRFILT() _q,
 #endif
     }
 
-    // load filter in reverse order
-    for (i=_n; i>0; i--)
-        _q->h[i-1] = _h[_n-i];
+    // move coefficients
+    memmove(_q->h, _h, (_q->h_len)*sizeof(TC));
 
-    // re-create internal dot product object
-    _q->dp = DOTPROD(_recreate)(_q->dp, _q->h, _q->h_len);
+    // re-create dot product object with coefficients in reverse order
+    _q->dp = DOTPROD(_recreate_rev)(_q->dp, _q->h, _q->h_len);
 
     return _q;
 }

--- a/src/filter/tests/firfilt_autotest.c
+++ b/src/filter/tests/firfilt_autotest.c
@@ -162,10 +162,9 @@ LIQUID_AUTOTEST(firfilt_recreate,"description","",0.1)
     LIQUID_CHECK(scale ==  3.0f)
 
     // assert the coefficients are original scaled by 7.1
-    // NOTE: need to account for time-reversal here
     const float * h = firfilt_crcf_get_coefficients(q);
     for (i=0; i<n; i++)
-        LIQUID_CHECK(h[n-i-1] ==  h0[i]*7.1f);
+        LIQUID_CHECK(h[i] ==  h0[i]*7.1f);
 
     // re-create with longer coefficients array and test impulse response
     float h2[2*n+1]; // new random-ish coefficients


### PR DESCRIPTION
firfilt_create() stores coefficients in forward order and uses DOTPROD(_create_rev), but firfilt_recreate() was manually reversing coefficients and using DOTPROD(_recreate) without reversal. While the dot product computation was equivalent, the internal h[] array ended up reversed after recreate(), causing get_coefficients(), copy_coefficients(), freqresponse(), and groupdelay() to return incorrect results.

Align recreate() with create() by using memmove() for forward-order storage and DOTPROD(_recreate_rev) for the dot product, matching the pattern established in create(). Update the corresponding autotest to verify coefficients are stored in forward order after recreate().

Fixes #427