### PR TITLE
Fix qs1dsearch error code for non-convergence

### DIFF
--- a/src/optim/src/qs1dsearch.c
+++ b/src/optim/src/qs1dsearch.c
@@ -120,7 +120,7 @@ int qs1dsearch_init(qs1dsearch _q,
     }
 
     // TODO: be more persistent?
-    return LIQUID_EIVAL;// FIXME: return proper error here, e.g. LIQUID_ENOCONV
+    return LIQUID_ENOCONV;
 }
 
 // perform initial search along a particular direction
@@ -168,7 +168,7 @@ int qs1dsearch_init_direction(qs1dsearch _q,
     }
 
     // did not converge; return non-zero value
-    return LIQUID_EIVAL;// FIXME: return proper error here, e.g. LIQUID_ENOCONV
+    return LIQUID_ENOCONV;
 }
 
 int qs1dsearch_init_bounds(qs1dsearch _q,


### PR DESCRIPTION
## Summary

Fix incorrect error code in `qs1dsearch_init()` and `qs1dsearch_init_direction()`. These functions now return `LIQUID_ENOCONV` (algorithm did not converge) instead of `LIQUID_EIVAL` (invalid input value) when they fail to find a solution.

## Changes

- `src/optim/src/qs1dsearch.c:123`: Changed `LIQUID_EIVAL` to `LIQUID_ENOCONV`
- `src/optim/src/qs1dsearch.c:171`: Changed `LIQUID_EIVAL` to `LIQUID_ENOCONV`
- Removed outdated FIXME comments

## Rationale

**LIQUID_EIVAL** is defined as "input out of range" (e.g., taking log of -1).

**LIQUID_ENOCONV** is defined as "algorithm could not converge or no solution could be found" (e.g., polynomial root finding instability).

The code comments explicitly state "did not converge", making `LIQUID_ENOCONV` the semantically correct error code.

## Background

These FIXME comments were added by the maintainer in commit d0dc373a (2022-09-22) during a refactoring, suggesting this exact change.

## Testing

- Compiled successfully with `cmake --build build`
- All qs1dsearch tests pass: `./build/xautotest -t qs1dsearch`
- No existing code checks for the specific error code, so this change is backward compatible

## Related Issues

Addresses FIXME comments in the code suggesting this change.