### PR TITLE
Remove outdated FIXME comment in dotprod SSE

### DIFF
--- a/src/dotprod/src/dotprod_cccf.sse.c
+++ b/src/dotprod/src/dotprod_cccf.sse.c
@@ -289,7 +289,6 @@ int dotprod_cccf_execute_sse(dotprod_cccf    _q,
         sum = _mm_add_ps(sum, s);
 #else
         // no SSE3: combine using slow method
-        // FIXME: implement slow method
         // unload values
         _mm_store_ps(wi, ci);
         _mm_store_ps(wq, cq);


### PR DESCRIPTION
Remove obsolete FIXME comment claiming slow method needs implementation. The non-SSE3 fallback has been implemented since 2012 (commit 538d1d66).