### PR TITLE
Make autoscripts building conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,7 +590,9 @@ endif(BUILD_SANDBOX)
 # ---------------------------------------- autotest ----------------------------------------
 
 # build autoscript executable for both autotests and benchmarks
-add_executable(autoscript scripts/autoscript.c scripts/main.c scripts/autoscript.h)
+if(BUILD_AUTOTESTS OR BUILD_BENCHMARKS)
+    add_executable(autoscript scripts/autoscript.c scripts/main.c scripts/autoscript.h)
+endif()
 
 set(AUTOTESTS
     ${PROJECT_SOURCE_DIR}/autotest/null_autotest.c


### PR DESCRIPTION
Hello,

I am pushing the patch from Debian.

It was reported as a bug that unconditional building of this target, breaks the cross-compilation,
so as it is used only by the tests and benchmark, it might be better to use it only when requested.

Thanks
Dawid Kulas