### PR TITLE
build: fix pkg-config paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,6 +575,9 @@ if (fftw3f_FOUND)
     string(APPEND LIQUID_PC_LIBS_PRIVATE " -lfftw3f")
 endif()
 
+cmake_path(APPEND libdir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+cmake_path(APPEND includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+
 configure_file(
     cmake/liquid-dsp.pc.in
     ${CMAKE_CURRENT_BINARY_DIR}/liquid-dsp.pc

--- a/README.rst
+++ b/README.rst
@@ -300,7 +300,7 @@ Your ``CMakeLists.txt`` file might look something like this:
 .. code-block:: cmake
 
     # CMakeLists.txt - test finding package and linking against it
-    cmake_minimum_required(VERSION 3.10)
+    cmake_minimum_required(VERSION 3.20)
     project(liquid_test C)
 
     # option 1: check for local installation

--- a/cmake/liquid-dsp.pc.in
+++ b/cmake/liquid-dsp.pc.in
@@ -2,8 +2,8 @@
 
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
 
 Name: liquid-dsp
 Description: Software-defined radio digital signal processing library


### PR DESCRIPTION
`CMAKE_INSTALL_*` are not guaranteed to be relative. See also:
- https://github.com/NixOS/nixpkgs/issues/144170
- https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files