### PR TITLE
Fix out-of-bounds read in firdespm_iext_search()

### DIFF
--- a/src/filter/src/firdespm.c
+++ b/src/filter/src/firdespm.c
@@ -837,7 +837,7 @@ int firdespm_iext_search(firdespm _q)
                  (num_found-imin)*sizeof(unsigned int));
 #else
         // equivalent code:
-        for (i=imin; i<num_found; i++)
+        for (i=imin; i<num_found-1; i++)
             found_iext[i] = found_iext[i+1];
 #endif
 


### PR DESCRIPTION
Fixes #385.

`firdespm_iext_search()` keeps a local array of extremal indices, `found_iext`, sized `nmax = 2*r + 2*num_bands`. When there are more extrema than needed it removes the weakest one by shifting everything above it down by one:

```c
for (i=imin; i<num_found; i++)
    found_iext[i] = found_iext[i+1];
```

The loop's last iteration (`i == num_found-1`) reads `found_iext[num_found]`. That's fine as long as `num_found < nmax`, but `num_found` can legitimately reach `nmax` (there's an `assert(num_found <= nmax)` right above this code confirming it), in which case the read lands one element past the end of the array.

I reproduced it by running `firdespm_run()` with ordinary multi-band specs through a build compiled with ASan/UBSan - the smallest combination that triggers it is `num_bands=3`, a 3-tap filter. UBSan reports it cleanly:

```
firdespm.c:841:39: runtime error: index 10 out of bounds for type 'unsigned int [*]'
    #0 firdespm_iext_search firdespm.c:841
    #1 firdespm_execute firdespm.c:516
    #2 firdespm_run firdespm.c:157
```

The fix is just changing the loop bound to `num_found-1`, which is what the shift is actually supposed to do (copy the `num_found-imin-1` remaining elements down, not `num_found-imin`). Note the `#if 0`'d `memmove` right above the loop has the same off-by-one in its length calculation, so it's not something you'd want to swap in as-is either.

After the fix, sweeping the same range of `num_bands`/filter-length combinations no longer trips any sanitizer, and the `firdespm` and `filter` autotest suites still pass in full.
