### PR TITLE
Fix the reproducibility with opt-in CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option(ENABLE_LOGGING    "Set to ON to enable full logging"          ON)
 set(LOGGING_LEVEL "trace" CACHE STRING "Set minimum logging level to compile")
 option(ENABLE_COLOR      "Set to ON to enable color terminal output" ON)
 option(ENABLE_STRICT     "Set to ON to enable strict compilation"    OFF)
+option(ENABLE_TIMESTAMPS "Compile the build timestamps into binary"  ON)
 
 if (NOT BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
     message(FATAL_ERROR "At least one of BUILD_SHARED_LIBS or BUILD_STATIC_LIBS must be ON")
@@ -282,6 +283,10 @@ endif()
 set(CMAKE_C_COMPILER_INFO "${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
 
 set(BUILD_ENV "cmake")
+
+if(ENABLE_TIMESTAMPS)
+    add_compile_definitions(ENABLE_TIMESTAMPS)
+endif()
 
 # this file can only use the @VARIABLE@ syntax
 #configure_file(cmake/version.c.in ${PROJECT_BINARY_DIR}/src/version.c @ONLY)

--- a/cmake/liquid.config.h.in
+++ b/cmake/liquid.config.h.in
@@ -16,14 +16,30 @@
 // unsigned int version_minor  = @PROJECT_VERSION_MINOR@+0;
 // unsigned int version_patch  = @PROJECT_VERSION_PATCH@+0;
 // unsigned int version_tweak  = @PROJECT_VERSION_TWEAK@+0;
-#define BUILD_GITHASH       "@BUILD_GITHASH@"
 
-// date/time of build
-#define BUILD_DATETIME      "@BUILD_DATETIME@"
-#define BUILD_HOSTNAME      "@BUILD_HOSTNAME@"
-#define BUILD_OS            "@CMAKE_HOST_SYSTEM_NAME@"
-#define BUILD_ARCH          "@CMAKE_HOST_SYSTEM_PROCESSOR@"
-#define BUILD_TOOLCHAIN     "@CMAKE_C_COMPILER_INFO@"
+#ifdef ENABLE_TIMESTAMPS
+
+    #define BUILD_GITHASH       "@BUILD_GITHASH@"
+
+    // date/time of build
+    #define BUILD_DATETIME      "@BUILD_DATETIME@"
+    #define BUILD_HOSTNAME      "@BUILD_HOSTNAME@"
+    #define BUILD_OS            "@CMAKE_HOST_SYSTEM_NAME@"
+    #define BUILD_ARCH          "@CMAKE_HOST_SYSTEM_PROCESSOR@"
+    #define BUILD_TOOLCHAIN     "@CMAKE_C_COMPILER_INFO@"
+
+#else
+
+    #define BUILD_GITHASH       "---"
+
+    #define BUILD_DATETIME      "---"
+    #define BUILD_HOSTNAME      "---"
+    #define BUILD_OS            "---"
+    #define BUILD_ARCH          "---"
+    #define BUILD_TOOLCHAIN     "---"
+
+#endif
+
 #define BUILD_TYPE          "@CMAKE_BUILD_TYPE@"
 #define BUILD_ENV           "@BUILD_ENV@"
 


### PR DESCRIPTION
Hello,

the newest release, which added compiled-in timestamp and host info can break the reproducibility, so I made a patch
(which I applied in Debian package too) to fix it.

It adds an option to disable those info with a preprocessor definition and just put blank values.

The new CMake option is ```ENABLE_TIMESTAMPS```, which is default ```ON``` to make the default settings same as before.

Thanks :smile: 
Dawid Kulas
SP9SKA