### PR TITLE
math/besseli: accumulating series in log domain to avoid overflow for large z

### DIFF
--- a/autotest/liquid_autotest_registry.h
+++ b/autotest/liquid_autotest_registry.h
@@ -899,6 +899,7 @@ extern struct liquid_autotest_s nextpow2_s;
 extern struct liquid_autotest_s math_config_s;
 // ./src/math/tests/math_bessel_autotest.c
 extern struct liquid_autotest_s lnbesselif_s;
+extern struct liquid_autotest_s lnbesselif_large_z_s;
 extern struct liquid_autotest_s besselif_s;
 extern struct liquid_autotest_s besseli0f_s;
 extern struct liquid_autotest_s besseljf_s;
@@ -2305,6 +2306,7 @@ liquid_autotest liquid_autotest_registry[] =
     &nextpow2_s,
     &math_config_s,
     &lnbesselif_s,
+    &lnbesselif_large_z_s,
     &besselif_s,
     &besseli0f_s,
     &besseljf_s,

--- a/src/math/src/math.bessel.c
+++ b/src/math/src/math.bessel.c
@@ -38,7 +38,8 @@
 #include "liquid.internal.h"
 
 // log(I_v(z)) : log Modified Bessel function of the first kind
-#define NUM_BESSELI_ITERATIONS 64
+// the terms peak near k = z/2, so the bound has to reach past the peak
+#define NUM_BESSELI_ITERATIONS 512
 float liquid_lnbesselif(float _nu,
                         float _z)
 {
@@ -51,7 +52,11 @@ float liquid_lnbesselif(float _nu,
 
     // special case: _nu = 1/2, besseli(z) = sqrt(2/pi*z)*sinh(z)
     if (_nu == 0.5f) {
-        return 0.5f*logf(2.0f/(M_PI*_z)) + logf(sinhf(_z));
+        // ln(sinh(z)) = z - ln(2) + ln(1 - exp(-2z)) keeps sinhf() from
+        // overflowing on its own, which it does above z of about 89
+        float lnsinh = _z < 1.0f ? logf(sinhf(_z))
+                                 : _z - logf(2.0f) + log1pf(-expf(-2.0f*_z));
+        return 0.5f*logf(2.0f/(M_PI*_z)) + lnsinh;
     }
 
     // low signal approximation
@@ -71,7 +76,8 @@ float liquid_lnbesselif(float _nu,
     float t1 = 0.0f;
     float t2 = 0.0f;
     float t3 = 0.0f;
-    float y = 0.0f;
+    float t  = 0.0f;
+    float y  = 0.0f;    // log of the partial sum
 
     unsigned int k;
     for (k=0; k<NUM_BESSELI_ITERATIONS; k++) {
@@ -82,12 +88,24 @@ float liquid_lnbesselif(float _nu,
         t2 = liquid_lngammaf((float)k + 1.0f);
         t3 = liquid_lngammaf(_nu + (float)k + 1.0f);
 
-        // accumulate y
-        y += expf( t1 - t2 - t3 );
-        //printf("%3u : t1: %12.3e, t2: %12.4e, t3: %12.4e, y: %12.4e\n", k, t1, t2, t3, y);
+        // accumulate in the log domain; exponentiating the term on its own
+        // overflows for large z and underflows to zero for large nu
+        t = t1 - t2 - t3;
+        if (k==0) {
+            y = t;
+        } else if (t > y) {
+            y = t + log1pf(expf(y - t));
+        } else {
+            y = y + log1pf(expf(t - y));
+
+            // the terms are unimodal in k, so once one falls 20 nats below the
+            // partial sum the rest of the tail is below single precision
+            if (t < y - 20.0f)
+                break;
+        }
     }
 
-    return t0 + logf(y);
+    return t0 + y;
 }
 
 // I_v(z) : Modified Bessel function of the first kind

--- a/src/math/tests/math_bessel_autotest.c
+++ b/src/math/tests/math_bessel_autotest.c
@@ -53,6 +53,33 @@ LIQUID_AUTOTEST(lnbesselif,"log Modified Bessel function of the first kind","",0
 #endif
 }
 
+// regression: the series is accumulated in the linear domain, so expf() overflows
+// for large z and underflows to zero for large nu; in both cases the function
+// returns a non-finite value although log(I_nu(z)) is perfectly representable.
+// Expected values computed with mpmath at 30 digits.
+LIQUID_AUTOTEST(lnbesselif_large_z,"log Modified Bessel function of the first kind (large z, large nu)","",0.1)
+{
+    float tol = 1e-2f;
+
+    // large z: the terms reach exp(z)/sqrt(2*pi*z) and expf() saturates near z=88
+    LIQUID_CHECK_DELTA( liquid_lnbesselif(   0.0f,  95.0f),   91.8054458129, tol );
+    LIQUID_CHECK_DELTA( liquid_lnbesselif(   0.0f, 200.0f),  196.432529354,  tol );
+    LIQUID_CHECK_DELTA( liquid_lnbesselif(   1.0f, 100.0f),   96.7747074576, tol );
+    LIQUID_CHECK_DELTA( liquid_lnbesselif(   5.5f, 120.0f),  116.561812609,  tol );
+
+    // the nu=1/2 special case goes through logf(sinhf(z)), which saturates near z=89
+    LIQUID_CHECK_DELTA( liquid_lnbesselif(   0.5f, 100.0f),   96.7784763738, tol );
+    LIQUID_CHECK_DELTA( liquid_lnbesselif(   0.5f, 200.0f),  196.431902784,  tol );
+
+    // large nu: the same terms underflow to zero and logf(0) is -inf
+    LIQUID_CHECK_DELTA( liquid_lnbesselif(  40.0f,   9.3f),  -48.3218301294, tol );
+    LIQUID_CHECK_DELTA( liquid_lnbesselif( 140.0f,   3.0f), -498.439222461,  tol );
+    LIQUID_CHECK_DELTA( liquid_lnbesselif( 140.0f, 200.0f),  149.090232742,  tol );
+
+    // the peak of the series sits near k=z/2 and was beyond the iteration bound
+    LIQUID_CHECK_DELTA( liquid_lnbesselif(  40.0f, 200.0f),  192.435848483,  tol );
+}
+
 LIQUID_AUTOTEST(besselif,"Modified Bessel function of the first kind","",0.1)
 {
     float tol = 1e-3f;


### PR DESCRIPTION
## What this fixes

`liquid_lnbesselif()` returns a non-finite value for arguments whose logarithm is well
inside float range. `liquid_lnbesselif(0, 95)` returns `inf` where the true value is
91.805, and `liquid_lnbesselif(140, 3)` returns `-inf` where the true value is -498.44.
The same values reach callers through `liquid_besselif()`, `liquid_besseli0f()` and
`randricek`, which evaluates `liquid_lnbesselif(0, x*s/sig2)`.

## Why

The series is summed in the linear domain:

```c
    // accumulate y
    y += expf( t1 - t2 - t3 );
    ...
    return t0 + logf(y);
```

`t1 - t2 - t3` stays finite, but `expf()` of it does not. The dominant term is about
`exp(z)/sqrt(2*pi*z)`, so the exponent crosses the float32 limit of 88.7 and `y` becomes
`inf`. On the tested grid `nu = 0` is still correct at z = 90 and returns `inf` at
z = 95, and `nu = 0.5` returns `inf` from z = 90 on. In the other direction, for large
nu the terms are around `exp(-lngamma(nu+1))`, which underflows to zero, so `y` is 0 and
`logf(0)` is `-inf`. `liquid_lnbesselif(140, z)` is `-inf` for every z tested from 0.1 to
200.

Two smaller points in the same function have the same character:

* the `nu = 1/2` branch computes `logf(sinhf(_z))`, and `sinhf()` saturates on its own
  above z of about 89;
* the terms peak near k = z/2, so the 64 term bound stops before the peak once z passes
  about 128. `liquid_lnbesselif(40, 200)` returns 186.81 against a true 192.44.

## How

Accumulate in the log domain with `log1pf()`, so no term is ever exponentiated on its
own. Use `ln(sinh z) = z - ln 2 + ln(1 - exp(-2z))` for z >= 1 in the `nu = 1/2` branch.
Raise the bound to 512 and stop as soon as a term falls 20 nats below the partial sum;
the terms are unimodal in k, so what is left of the tail is below single precision. The
early exit means the common small z case runs fewer iterations than before, not more.

The choice of 512 is pragmatic rather than derived: it covers the range the function is
plausibly called over and it moves the cliff rather than removing it. The large-signal
asymptotic already sitting commented out just above this loop could remove the large z
cliff entirely, and I am glad to rework the change that way if you prefer it.

## Testing

Built with the repository CMake on `f434da118`, gcc 13.3.0, x86_64 Linux, Release.

With only the new test added and the source untouched, `lnbesselif_large_z` fails 10 of
10 checks while the existing `lnbesselif` test passes 13 of 13 in the same binary. With
the source change, `lnbesselif_large_z` passes 10 of 10 and `lnbesselif` still passes 13
of 13.

Full suite: 1349 tests, 0 fail, 716535 checks, 0 fail, PASS. Baseline on the same
machine before the change: 1348 tests, 716525 checks, 0 fail.

The expected values in the new test are `log(besseli(nu, z))` from mpmath at 30 digits,
evaluated on the exact float32 arguments. Swept over 164 points (nu in
{0, 0.5, 1, 2, 5.5, 10, 40, 140}, z from 1e-3 to 200), the result is 34 non-finite values
before the change and none after, and the largest absolute error after the change is
7.5e-5.

Cost on the same machine: 800000 `liquid_besseli0f()` calls over the Kaiser window
regime (beta up to 20) take 1.86 s before and 0.69 s after; one million
`liquid_lnbesselif()` calls on the arguments of the existing autotest take 2.29 s before
and 0.79 s after. A single call at z = 200 is slower, 6.3 us against 2.0 us, because it
now runs past the peak of the series instead of returning `inf`.

## Not tested

* Only gcc 13.3.0 on x86_64 Linux with the CMake build. Not the autotools build, not
  clang, not macOS, not Windows, not 32 bit, not any SIMD configuration.
* Accuracy holds to about z = 900: the absolute error is 1.3e-4 at z = 900 and 9.1e-3 at
  z = 950. From z = 1000 the 512 term bound stops covering the peak and the result is an
  underestimate again. Every one of those arguments returned `inf` before the change.
* The `nu = 35` to `nu = 140` checks inside `#if 0` in `math_bessel_autotest.c` are left
  as they are. They do compute finite values now, but their 1e-5 absolute tolerance is
  below one ulp of a float at those magnitudes, so they cannot pass in single precision.
* `liquid_besseljf()` is untouched. It is inaccurate above z of about 12 for a different
  reason, which is a separate matter.
* No complex or double precision variant of these functions exists to check against.

## Notes

* Based on `f434da118fa6338ed19f44895e7bf292e497d2ec`.
* New dependencies: none. mpmath was used to produce the expected values and is not
  needed to build or run anything.
* `autotest/liquid_autotest_registry.h` was regenerated with
  `autotest/autotest_parse_headers.py`; the only difference is the two lines for the new
  test.
