### PR TITLE
math/uppergamma: using continued fraction when alpha exceeds z+1

### DIFF
--- a/autotest/liquid_autotest_registry.h
+++ b/autotest/liquid_autotest_registry.h
@@ -915,6 +915,7 @@ extern struct liquid_autotest_s cargf_s;
 extern struct liquid_autotest_s gamma_s;
 extern struct liquid_autotest_s lngamma_s;
 extern struct liquid_autotest_s uppergamma_s;
+extern struct liquid_autotest_s uppergamma_large_alpha_s;
 extern struct liquid_autotest_s factorial_s;
 extern struct liquid_autotest_s nchoosek_s;
 // ./src/math/tests/math_window_autotest.c
@@ -2319,6 +2320,7 @@ liquid_autotest liquid_autotest_registry[] =
     &gamma_s,
     &lngamma_s,
     &uppergamma_s,
+    &uppergamma_large_alpha_s,
     &factorial_s,
     &nchoosek_s,
     &window_hamming_s,

--- a/src/math/src/math.gamma.c
+++ b/src/math/src/math.gamma.c
@@ -133,9 +133,46 @@ float liquid_lnlowergammaf(float _z, float _alpha)
 }
 
 // ln( Gamma(z,alpha) ) : upper incomplete gamma function
+#define UPPERGAMMA_MAX_ITERATIONS 1000  // maximum number of iterations
 float liquid_lnuppergammaf(float _z, float _alpha)
 {
-    return logf( liquid_gammaf(_z) - liquid_lowergammaf(_z,_alpha) );
+    // taking the complement is only well conditioned while alpha < z+1; past
+    // that point Gamma(z) and gamma(z,alpha) agree to within single precision,
+    // the difference cancels down to zero and then goes negative, and the
+    // logarithm of it is nan
+    if (_alpha < _z + 1.0f)
+        return logf( liquid_gammaf(_z) - liquid_lowergammaf(_z,_alpha) );
+
+    // evaluate the Legendre continued fraction for Gamma(z,alpha) directly
+    // with the modified Lentz method and return its logarithm
+    float b = _alpha + 1.0f - _z;
+    float c = 1e30f;
+    float d = 1.0f / b;
+    float h = d;
+    float a = 0.0f;
+    float del = 0.0f;
+
+    unsigned int i;
+    for (i=1; i<=UPPERGAMMA_MAX_ITERATIONS; i++) {
+        a = -(float)i * ((float)i - _z);
+        b += 2.0f;
+
+        d = a*d + b;
+        if (fabsf(d) < 1e-30f) d = 1e-30f;
+
+        c = b + a/c;
+        if (fabsf(c) < 1e-30f) c = 1e-30f;
+
+        d = 1.0f/d;
+        del = d*c;
+        h *= del;
+
+        if (fabsf(del - 1.0f) < 1e-6f)
+            break;
+    }
+
+    // Gamma(z,alpha) = exp(-alpha) * alpha^z * h
+    return -_alpha + _z*logf(_alpha) + logf(h);
 }
 
 

--- a/src/math/tests/math_gamma_autotest.c
+++ b/src/math/tests/math_gamma_autotest.c
@@ -149,6 +149,49 @@ LIQUID_AUTOTEST(uppergamma,"upper incomplete gamma function","",0.1)
     LIQUID_CHECK_DELTA(liquid_uppergammaf(2.1f, 10.0f),  0.000635002f, tol);
 }
 
+// regression: once alpha passes z+1 the complement Gamma(z)-gamma(z,alpha)
+// cancels in single precision, reaches zero and then goes negative, so the
+// logarithm of it is nan for values that are perfectly representable.
+// Expected values computed with mpmath at 30 digits.
+LIQUID_AUTOTEST(uppergamma_large_alpha,"upper incomplete gamma function, alpha well above z","",0.1)
+{
+    // relative error tolerance
+    float tol = 1e-3f;
+
+    // test vectors: z, alpha, Gamma(z,alpha)
+    float v[10][3] = {
+        { 1.5f, 20.0f, 9.44282794735e-9f  },
+        { 2.1f, 20.0f, 5.86954197095e-8f  },
+        { 5.0f, 25.0f, 6.40580021977e-6f  },
+        { 8.0f, 30.0f, 2.63780202020e-3f  },
+        { 8.0f, 40.0f, 8.38660810393e-7f  },
+        { 1.5f, 60.0f, 6.83882739124e-26f },
+        { 2.0f, 15.0f, 4.89443712803e-6f  },
+        { 3.0f, 20.0f, 9.11029901118e-7f  },
+        {30.0f, 50.0f, 8.10638258199e+27f },
+        {30.0f, 60.0f, 6.07982982594e+25f }};
+
+    unsigned int i;
+    for (i=0; i<10; i++) {
+        // extract test vector
+        float z     = v[i][0];
+        float alpha = v[i][1];
+        float g     = v[i][2];
+
+        // compute upper incomplete gamma
+        float G = liquid_uppergammaf(z, alpha);
+
+        // compute relative error
+        float error = fabsf(G-g) / fabsf(g);
+
+        liquid_log_debug("uppergamma(%12.4e,%12.4e) = %12.4e (expected %12.4e) error=%12.4e",
+            z, alpha, G, g, error);
+
+        // run test
+        LIQUID_CHECK(error < tol);
+    }
+}
+
 LIQUID_AUTOTEST(factorial,"factorial","",0.1)
 {
     float tol = 1e-3f;


### PR DESCRIPTION
## What this fixes

`liquid_uppergammaf()` returns `nan` once alpha is well above z, for values that are
perfectly representable. `liquid_uppergammaf(8, 30)` returns `nan` where the true value
is 2.6378e-3. On a 208 point sweep, 31 points come back non-finite, and several more come
back with no correct digit at all: `liquid_uppergammaf(1.5, 60)` returns 1.61e-6 against
a true 6.84e-26. `liquid_lnuppergammaf()` behaves the same way, since that is where the
arithmetic happens.

## Why

`liquid_lnuppergammaf()` takes the complement:

```c
    return logf( liquid_gammaf(_z) - liquid_lowergammaf(_z,_alpha) );
```

Once alpha passes z, `Gamma(z,alpha)` is the small difference between two nearly equal
quantities. In single precision `liquid_gammaf(z)` and `liquid_lowergammaf(z,alpha)`
agree to within their own rounding long before `Gamma(z,alpha)` becomes negligible, so
the difference loses its digits, reaches zero, and then goes slightly negative, at which
point `logf()` returns `nan`.

The loss is gradual rather than sudden, which is what makes it easy to miss:

| z | alpha | returned | true value |
| --- | --- | --- | --- |
| 2 | 12 | 7.9155e-5 | 7.9875e-5 |
| 2 | 15 | 3.3379e-6 | 4.8944e-6 |
| 30 | 50 | 7.9565e+27 | 8.1064e+27 |
| 3 | 20 | 0 | 9.1103e-7 |
| 8 | 30 | nan | 2.6378e-3 |
| 1.5 | 60 | 1.6093e-6 | 6.8388e-26 |

## How

Keep the complement while `alpha < z + 1`, which is where it is well conditioned and
where the existing autotest lives. Past that point, evaluate the Legendre continued
fraction for `Gamma(z,alpha)` with the modified Lentz method and return its logarithm. It
is the standard companion to the series already used for the lower incomplete gamma, and
it converges quickly in exactly the region where the complement fails: over 165 points on
the continued fraction side of the branch it took at most 22 iterations, against a cap of
1000.

## Testing

Built with the repository CMake on `f434da118`, gcc 13.3.0, x86_64 Linux, Release.

With only the new test added and the source untouched, `uppergamma_large_alpha` fails 10
of 10 checks while the existing `uppergamma` test passes 21 of 21 in the same binary.
With the source change, `uppergamma_large_alpha` passes 10 of 10 and `uppergamma` still
passes 21 of 21. The existing test is not merely unaffected: its points from
`alpha = 3.1` to `alpha = 10` now go through the continued fraction, and their largest
relative error drops from 4.2e-4 to 6.4e-7.

Full suite: 1349 tests, 0 fail, 716535 checks, 0 fail, PASS. Baseline on the same machine
before the change: 1348 tests, 716525 checks, 0 fail.

The expected values in the new test are `gammainc(z, alpha, inf)` from mpmath at 30
digits, evaluated on the exact float32 arguments. Swept over 208 points (z from 1.5 to
30, alpha from below z+1 up to 60, including a dense scan across the branch point), the
result is 31 non-finite values before the change and none after, and the largest relative
error after the change is 1.0e-5.

Cost on the same machine, 200000 calls: `liquid_uppergammaf(2.1, 10)` takes 0.241 s
before and 0.007 s after; `liquid_uppergammaf(30, 31)`, the worst case at the branch
point, takes 0.217 s before and 0.020 s after. Arguments below the branch point are on
the unchanged path and are unchanged in cost, 0.254 s before and 0.249 s after.

## Not tested

* Only gcc 13.3.0 on x86_64 Linux with the CMake build. Not the autotools build, not
  clang, not macOS, not Windows, not 32 bit.
* Arguments with `z < 0` change behaviour. They previously produced `nan` together with
  an error from `liquid_lngammaf()`; they now take the continued fraction and return the
  analytic continuation, which agrees with the reference to about 1e-6 relative. That is
  outside the documented domain and there is no test for it.
* Where the true value falls below the smallest normal float, the function now returns 0
  rather than `nan`. `Gamma(1, 200)` is 1.4e-87, for instance.
* The continued fraction loop is capped at 1000 iterations. Every point tested converged
  in 22 or fewer, but no test forces the cap, and if it were ever reached the result
  would be a truncated fraction rather than an error.
* `liquid_lnlowergammaf()` and `liquid_gammaf()` are untouched.

## Notes

* Based on `f434da118fa6338ed19f44895e7bf292e497d2ec`.
* New dependencies: none. mpmath was used to produce the expected values and is not
  needed to build or run anything.
* `autotest/liquid_autotest_registry.h` was regenerated with
  `autotest/autotest_parse_headers.py`; the only difference is the two lines for the new
  test.
