### PR TITLE
dotprod: Optimise AVX code for out-of-order execution

### DIFF
--- a/src/dotprod/src/dotprod_cccf.avx.c
+++ b/src/dotprod/src/dotprod_cccf.avx.c
@@ -153,34 +153,37 @@ dotprod_cccf_execute_avx_4(dotprod_cccf    _q,
     __m256 ci0, ci1, ci2, ci3;  // output multiplications (v * hi)
     __m256 cq0, cq1, cq2, cq3;  // output multiplications (v * hq)
 
-    // load zeros into sum registers
-    __m256 sumi = _mm256_setzero_ps();
-    __m256 sumq = _mm256_setzero_ps();
+    // four independent accumulator pairs to break the dependency chain,
+    // allowing for more out-of-order execution
+    __m256 sumi0 = _mm256_setzero_ps(), sumq0 = _mm256_setzero_ps();
+    __m256 sumi1 = _mm256_setzero_ps(), sumq1 = _mm256_setzero_ps();
+    __m256 sumi2 = _mm256_setzero_ps(), sumq2 = _mm256_setzero_ps();
+    __m256 sumi3 = _mm256_setzero_ps(), sumq3 = _mm256_setzero_ps();
 
-    // r = 8*floor(n/32)
-    unsigned int r = (n >> 5) << 3;
+    // r = 32*floor(n/32)
+    unsigned int r = (n >> 5) << 5;
 
     //
     unsigned int i;
-    for (i=0; i<r; i+=8) {
+    for (i=0; i<r; i+=32) {
         // load inputs into register (unaligned)
-        v0 = _mm256_loadu_ps(&x[4*i+0]);
-        v1 = _mm256_loadu_ps(&x[4*i+8]);
-        v2 = _mm256_loadu_ps(&x[4*i+16]);
-        v3 = _mm256_loadu_ps(&x[4*i+24]);
+        v0 = _mm256_loadu_ps(&x[i+0]);
+        v1 = _mm256_loadu_ps(&x[i+8]);
+        v2 = _mm256_loadu_ps(&x[i+16]);
+        v3 = _mm256_loadu_ps(&x[i+24]);
 
         // load real coefficients into registers (aligned)
-        hi0 = _mm256_load_ps(&_q->hi[4*i+0]);
-        hi1 = _mm256_load_ps(&_q->hi[4*i+8]);
-        hi2 = _mm256_load_ps(&_q->hi[4*i+16]);
-        hi3 = _mm256_load_ps(&_q->hi[4*i+24]);
+        hi0 = _mm256_load_ps(&_q->hi[i+0]);
+        hi1 = _mm256_load_ps(&_q->hi[i+8]);
+        hi2 = _mm256_load_ps(&_q->hi[i+16]);
+        hi3 = _mm256_load_ps(&_q->hi[i+24]);
 
         // load real coefficients into registers (aligned)
-        hq0 = _mm256_load_ps(&_q->hq[4*i+0]);
-        hq1 = _mm256_load_ps(&_q->hq[4*i+8]);
-        hq2 = _mm256_load_ps(&_q->hq[4*i+16]);
-        hq3 = _mm256_load_ps(&_q->hq[4*i+24]);
-        
+        hq0 = _mm256_load_ps(&_q->hq[i+0]);
+        hq1 = _mm256_load_ps(&_q->hq[i+8]);
+        hq2 = _mm256_load_ps(&_q->hq[i+16]);
+        hq3 = _mm256_load_ps(&_q->hq[i+24]);
+
         // compute parallel multiplications (real)
         ci0 = _mm256_mul_ps(v0, hi0);
         ci1 = _mm256_mul_ps(v1, hi1);
@@ -194,11 +197,28 @@ dotprod_cccf_execute_avx_4(dotprod_cccf    _q,
         cq3 = _mm256_mul_ps(v3, hq3);
 
         // accumulate
-        sumi = _mm256_add_ps(sumi, ci0);   sumq = _mm256_add_ps(sumq, cq0);
-        sumi = _mm256_add_ps(sumi, ci1);   sumq = _mm256_add_ps(sumq, cq1);
-        sumi = _mm256_add_ps(sumi, ci2);   sumq = _mm256_add_ps(sumq, cq2);
-        sumi = _mm256_add_ps(sumi, ci3);   sumq = _mm256_add_ps(sumq, cq3);
+        sumi0 = _mm256_add_ps(sumi0, ci0);   sumq0 = _mm256_add_ps(sumq0, cq0);
+        sumi1 = _mm256_add_ps(sumi1, ci1);   sumq1 = _mm256_add_ps(sumq1, cq1);
+        sumi2 = _mm256_add_ps(sumi2, ci2);   sumq2 = _mm256_add_ps(sumq2, cq2);
+        sumi3 = _mm256_add_ps(sumi3, ci3);   sumq3 = _mm256_add_ps(sumq3, cq3);
     }
+
+    // process remaining blocks of 4 samples (8 floats) that can still utilise AVX
+    // before falling back to the cleanup loop below
+    // r = 8*floor(n/8)
+    r = (n >> 3) << 3;
+    // NOTE: No need to touch i here since r _was_ a multiple of 32, and now is a multiple of 8
+    for (; i<r; i+=8) {
+        __m256 v = _mm256_loadu_ps(&x[i]);
+        sumi0 = _mm256_add_ps(sumi0, _mm256_mul_ps(v, _mm256_load_ps(&_q->hi[i])));
+        sumq0 = _mm256_add_ps(sumq0, _mm256_mul_ps(v, _mm256_load_ps(&_q->hq[i])));
+    }
+
+    // combine the independent accumulator pairs
+    __m256 sumi = _mm256_add_ps(_mm256_add_ps(sumi0, sumi1),
+                                _mm256_add_ps(sumi2, sumi3));
+    __m256 sumq = _mm256_add_ps(_mm256_add_ps(sumq0, sumq1),
+                                _mm256_add_ps(sumq2, sumq3));
 
     // shuffle values
     sumq = _mm256_shuffle_ps( sumq, sumq, _MM_SHUFFLE(2,3,0,1) );
@@ -215,7 +235,7 @@ dotprod_cccf_execute_avx_4(dotprod_cccf    _q,
         ((wi[1] + wq[1]) + (wi[3] + wq[3]) + (wi[5] + wq[5]) + (wi[7] + wq[7])) * _Complex_I;
 
     // cleanup (note: n _must_ be even)
-    for (i=2*r; i<_q->n; i++) {
+    for (i=i/2; i<_q->n; i++) {
         total += _x[i] * ( _q->hi[2*i] + _q->hq[2*i]*_Complex_I );
     }
 

--- a/src/dotprod/src/dotprod_crcf.avx.c
+++ b/src/dotprod/src/dotprod_crcf.avx.c
@@ -109,41 +109,57 @@ dotprod_crcf_execute_avx_4(dotprod_crcf    _q,
     // first cut: ...
     __m256 v0, v1, v2, v3;  // input vectors
     __m256 h0, h1, h2, h3;  // coefficients vectors
-    __m256 s0, s1, s2, s3;  // dot products [re, im, re, im]
+    __m256 s0, s1, s2, s3; // dot products [re, im, re, im]
 
-    // load zeros into sum registers
-    __m256 sum = _mm256_setzero_ps();
+    // four independent accumulator pairs to break the dependency chain,
+    // allowing for more out-of-order execution
+    __m256 sum0 = _mm256_setzero_ps();
+    __m256 sum1 = _mm256_setzero_ps();
+    __m256 sum2 = _mm256_setzero_ps();
+    __m256 sum3 = _mm256_setzero_ps();
 
-    // r = 8*floor(n/32)
-    unsigned int r = (n >> 5) << 3;
+    // r = 32*floor(n/32)
+    unsigned int r = (n >> 5) << 5;
 
     //
     unsigned int i;
-    for (i=0; i<r; i+=8) {
+    for (i=0; i<r; i+=32) {
         // load inputs into register (unaligned)
-        v0 = _mm256_loadu_ps(&x[4*i+0]);
-        v1 = _mm256_loadu_ps(&x[4*i+8]);
-        v2 = _mm256_loadu_ps(&x[4*i+16]);
-        v3 = _mm256_loadu_ps(&x[4*i+24]);
+        v0 = _mm256_loadu_ps(&x[i+0]);
+        v1 = _mm256_loadu_ps(&x[i+8]);
+        v2 = _mm256_loadu_ps(&x[i+16]);
+        v3 = _mm256_loadu_ps(&x[i+24]);
 
         // load coefficients into register (aligned)
-        h0 = _mm256_load_ps(&_q->h[4*i+0]);
-        h1 = _mm256_load_ps(&_q->h[4*i+8]);
-        h2 = _mm256_load_ps(&_q->h[4*i+16]);
-        h3 = _mm256_load_ps(&_q->h[4*i+24]);
+        h0 = _mm256_load_ps(&_q->h[i+0]);
+        h1 = _mm256_load_ps(&_q->h[i+8]);
+        h2 = _mm256_load_ps(&_q->h[i+16]);
+        h3 = _mm256_load_ps(&_q->h[i+24]);
 
         // compute multiplication
         s0 = _mm256_mul_ps(v0, h0);
         s1 = _mm256_mul_ps(v1, h1);
         s2 = _mm256_mul_ps(v2, h2);
         s3 = _mm256_mul_ps(v3, h3);
-        
+
         // parallel addition
-        sum = _mm256_add_ps( sum, s0 );
-        sum = _mm256_add_ps( sum, s1 );
-        sum = _mm256_add_ps( sum, s2 );
-        sum = _mm256_add_ps( sum, s3 );
+        sum0 = _mm256_add_ps( sum0, s0 );
+        sum1 = _mm256_add_ps( sum1, s1 );
+        sum2 = _mm256_add_ps( sum2, s2 );
+        sum3 = _mm256_add_ps( sum3, s3 );
     }
+
+    // process remaining blocks of 4 samples (8 floats) that can still utilise AVX
+    // before falling back to the cleanup loop below
+    // r = 8*floor(n/8)
+    r = (n >> 3) << 3;
+    // NOTE: No need to touch i here since r _was_ a multiple of 32, and now is a multiple of 8
+    for (; i<r; i+=8)
+        sum0 = _mm256_add_ps(sum0, _mm256_mul_ps(_mm256_loadu_ps(&x[i]), _mm256_load_ps(&_q->h[i])));
+
+    // combine the independent accumulators
+    __m256 sum = _mm256_add_ps(_mm256_add_ps(sum0, sum1),
+                               _mm256_add_ps(sum2, sum3));
 
     // aligned output array
     float w[8] __attribute__((aligned(32)));
@@ -154,7 +170,7 @@ dotprod_crcf_execute_avx_4(dotprod_crcf    _q,
     w[1] += w[3] + w[5] + w[7];
 
     // cleanup (note: n _must_ be even)
-    for (i=4*r; i<n; i+=2) {
+    for (; i<n; i+=2) {
         w[0] += x[i  ] * _q->h[i  ];
         w[1] += x[i+1] * _q->h[i+1];
     }

--- a/src/dotprod/src/dotprod_rrrf.avx.c
+++ b/src/dotprod/src/dotprod_rrrf.avx.c
@@ -96,38 +96,56 @@ dotprod_rrrf_execute_avx_4(dotprod_rrrf _q,
     __m256 v0, v1, v2, v3;
     __m256 h0, h1, h2, h3;
     __m256 s0, s1, s2, s3;
-    __m256 sum = _mm256_setzero_ps(); // load zeros into sum register
 
-    // t = 8*(floor(_n/32))
-    unsigned int r = (_q->n >> 5) << 3;
+    // four independent accumulator pairs to break the dependency chain,
+    // allowing for more out-of-order execution
+    __m256 sum0 = _mm256_setzero_ps();
+    __m256 sum1 = _mm256_setzero_ps();
+    __m256 sum2 = _mm256_setzero_ps();
+    __m256 sum3 = _mm256_setzero_ps();
+
+    // r = 32*floor(n/32)
+    unsigned int r = (_q->n >> 5) << 5;
 
     //
     unsigned int i;
-    for (i=0; i<r; i+=8) {
+    for (i=0; i<r; i+=32) {
         // load inputs into register (unaligned)
-        v0 = _mm256_loadu_ps(&_x[4*i+ 0]);
-        v1 = _mm256_loadu_ps(&_x[4*i+ 8]);
-        v2 = _mm256_loadu_ps(&_x[4*i+16]);
-        v3 = _mm256_loadu_ps(&_x[4*i+24]);
+        v0 = _mm256_loadu_ps(&_x[i+ 0]);
+        v1 = _mm256_loadu_ps(&_x[i+ 8]);
+        v2 = _mm256_loadu_ps(&_x[i+16]);
+        v3 = _mm256_loadu_ps(&_x[i+24]);
 
         // load coefficients into register (aligned)
-        h0 = _mm256_load_ps(&_q->h[4*i+ 0]);
-        h1 = _mm256_load_ps(&_q->h[4*i+ 8]);
-        h2 = _mm256_load_ps(&_q->h[4*i+16]);
-        h3 = _mm256_load_ps(&_q->h[4*i+24]);
+        h0 = _mm256_load_ps(&_q->h[i+ 0]);
+        h1 = _mm256_load_ps(&_q->h[i+ 8]);
+        h2 = _mm256_load_ps(&_q->h[i+16]);
+        h3 = _mm256_load_ps(&_q->h[i+24]);
 
         // compute dot products
         s0 = _mm256_mul_ps(v0, h0);
         s1 = _mm256_mul_ps(v1, h1);
         s2 = _mm256_mul_ps(v2, h2);
         s3 = _mm256_mul_ps(v3, h3);
-        
+
         // parallel addition
-        sum = _mm256_add_ps( sum, s0 );
-        sum = _mm256_add_ps( sum, s1 );
-        sum = _mm256_add_ps( sum, s2 );
-        sum = _mm256_add_ps( sum, s3 );
+        sum0 = _mm256_add_ps( sum0, s0 );
+        sum1 = _mm256_add_ps( sum1, s1 );
+        sum2 = _mm256_add_ps( sum2, s2 );
+        sum3 = _mm256_add_ps( sum3, s3 );
     }
+
+    // process remaining blocks of 4 samples (8 floats) that can still utilise AVX
+    // before falling back to the cleanup loop below
+    // r = 8*floor(n/8)
+    r = (_q->n >> 3) << 3;
+    // NOTE: No need to touch i here since r _was_ a multiple of 32, and now is a multiple of 8
+    for (; i<r; i+=8)
+        sum0 = _mm256_add_ps(sum0, _mm256_mul_ps(_mm256_loadu_ps(&_x[i]), _mm256_load_ps(&_q->h[i])));
+
+    // combine the independent accumulators
+    __m256 sum = _mm256_add_ps(_mm256_add_ps(sum0, sum1),
+                               _mm256_add_ps(sum2, sum3));
 
     // fold down into single value
     __m256 z = _mm256_setzero_ps();
@@ -142,7 +160,7 @@ dotprod_rrrf_execute_avx_4(dotprod_rrrf _q,
     float total = w[0] + w[4];
 
     // cleanup
-    for (i=4*r; i<_q->n; i++)
+    for (; i<_q->n; i++)
         total += _x[i] * _q->h[i];
 
     // set return value


### PR DESCRIPTION
By breaking up the dependency between some of the steps, they can be executed in parallel out-of-order

This is inherently CPU dependant, but x86 CPUs are built with out-of-order execution, meaning CPU instructions can execute out-of-order if there are no dependencies between them. This can allow some instructions to be executed in parallel within the same CPU core. For example, if there are two AVX ADD units in a CPU, two AVX ADD instructions can be executed in parallel. 

This refactors the AVX code for dotprod to run four accumulators instead of one. This removes some instruction dependencies since these chains are only merged outside the loop. The effect of this will vary between CPU models and depend on what kind of AVX units are actually available. For my AMD Ryzen 9 5950X it seems to approach a 2x speed increase.  

As an FYI, this is also applicable for the Neon variant as well, but I've yet to try this out on ARM HW yet